### PR TITLE
fix: remove stale user_id assumptions from agent creation

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -5,9 +5,9 @@ The agents routes manage agent records, deployments, logs, and metrics.
 ## Current Implementation Notes
 
 - Routes are mounted at `/agents`, not `/v1/agents`.
-- `POST /agents` currently requires an explicit `user_id` in the request body.
+- `POST /agents` derives ownership from the authenticated user instead of accepting `user_id` in the request body.
 - `config` is currently modeled as a string field, so JSON config should be sent as a string payload.
-- Auth dependencies are not currently attached to these route handlers, even though the broader product direction assumes authenticated control-plane access.
+- Auth dependencies are attached to these route handlers, so agent operations require authenticated control-plane access.
 
 ## Routes
 
@@ -24,18 +24,18 @@ The agents routes manage agent records, deployments, logs, and metrics.
 
 ## Create an Agent
 
-Use `/auth/me` first if you need a `user_id`.
+Authenticate first, then create the agent without sending a `user_id`.
 
 ```bash
 BASE_URL=http://localhost:8000
 
 curl -X POST "$BASE_URL/agents" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Support Bot",
     "description": "Handles inbound support tasks",
-    "config": "{\"model\":\"gpt-4\"}",
-    "user_id": "YOUR_USER_ID"
+    "config": "{\"model\":\"gpt-4\"}"
   }'
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,10 +77,9 @@ mutx status
 
 | Command | Current issue |
 |--------|---------------|
-| `mutx agents create` | does not supply the `user_id` that `POST /agents` currently requires |
 | `mutx deploy create` | still points at an older `/api/v1/...` route shape |
 
-For those flows, use the API directly for now.
+For those flows, prefer the live route behavior in code over older docs. `mutx agents create` now relies on authenticated ownership instead of a client-supplied `user_id`.
 
 ## Example Session
 

--- a/sdk/mutx/agents.py
+++ b/sdk/mutx/agents.py
@@ -70,7 +70,6 @@ class Agents:
         name: str,
         description: Optional[str] = None,
         config: Optional[str] = None,
-        user_id: Optional[str] = None,
     ) -> Agent:
         response = self._client.post(
             "/agents",
@@ -78,7 +77,6 @@ class Agents:
                 "name": name,
                 "description": description,
                 "config": config,
-                "user_id": user_id,
             },
         )
         response.raise_for_status()


### PR DESCRIPTION
## What changed?

- removed the stale `user_id` parameter from `sdk/mutx/agents.py` create calls
- updated `docs/cli.md` to stop claiming `mutx agents create` is blocked on client-supplied ownership
- updated `docs/api/agents.md` so the create-agent example uses authenticated ownership and no longer sends `user_id`

## Why?

- the live backend derives agent ownership from the authenticated user
- the SDK and docs were still teaching an older contract and creating drift around issue #2

## Validation

- `.venv/bin/ruff check cli sdk`
- `.venv/bin/black --check cli sdk`
- `python3 -m compileall cli sdk/mutx`
