### PR TITLE
docs: remove stale agent creation payload guidance

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -21,7 +21,7 @@ Used by the landing page for capturing early access intent.
 ## 2. Agent Management (`/agents`)
 
 - **Endpoints**:
-  - `POST /agents`: Create new agent. Requires `name`, `description`, `config` (as a JSON string), `user_id`.
+  - `POST /agents`: Create new agent. Requires `name`, `description`, and `config` (as a JSON string). Ownership comes from the authenticated user.
   - `GET /agents`: List agents for current user.
   - `GET /agents/{agent_id}`: Detail view.
 - **Critical Caveat**: The `config` field MUST be passed as a serialized **JSON string**, not a raw JSON object. Agents: do not attempt to send a raw object; stringify it first.

--- a/docs/deployment/quickstart.md
+++ b/docs/deployment/quickstart.md
@@ -79,7 +79,7 @@ curl -X POST http://localhost:8000/auth/login \
 
 ## 7. Create and deploy an agent record
 
-Get your user id:
+Log in first so you have an access token:
 
 ```bash
 curl http://localhost:8000/auth/me \
@@ -90,12 +90,12 @@ Create the agent:
 
 ```bash
 curl -X POST http://localhost:8000/agents \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "name":"My First Agent",
     "description":"Local test agent",
-    "config":"{\"model\":\"gpt-4\"}",
-    "user_id":"YOUR_USER_ID"
+    "config":"{\"model\":\"gpt-4\"}"
   }'
 ```
 
@@ -124,7 +124,7 @@ mutx login --email you@example.com
 mutx whoami
 ```
 
-Note: some CLI commands still reflect older API assumptions. See `docs/cli.md` for the current support matrix.
+Note: `mutx deploy create` still reflects older API assumptions. See `docs/cli.md` for the current support matrix.
 
 ## Optional: frontend verification
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -21,17 +21,17 @@ docker-compose exec postgres pg_isready -U mutx
 
 ## CLI login works, but agent creation fails
 
-Current cause: `mutx agents create` does not supply the `user_id` that `POST /agents` currently requires.
+Current cause: older docs and examples may still suggest a client-supplied `user_id`, but the backend now derives ownership from auth.
 
-Use the API directly for creation:
+Use the CLI or the authenticated API shape instead:
 
 ```bash
 curl -X POST http://localhost:8000/agents \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "name":"Support Bot",
-    "config":"{\"model\":\"gpt-4\"}",
-    "user_id":"YOUR_USER_ID"
+    "config":"{\"model\":\"gpt-4\"}"
   }'
 ```
 
@@ -82,7 +82,6 @@ That is expected with the current images.
 Prefer host-side verification:
 
 ```bash
-npm run lint
 npm run build
 python3 -m pytest --collect-only -q
 ```

--- a/docs/troubleshooting/faq.md
+++ b/docs/troubleshooting/faq.md
@@ -18,8 +18,9 @@ Not yet. Core auth and listing flows work well, but some commands still reflect 
 
 The two biggest gaps right now are:
 
-- `mutx agents create` does not send the required `user_id`
 - `mutx deploy create` still points at an older `/api/v1/...` route
+
+`mutx agents create` now relies on authenticated ownership instead of a client-supplied `user_id`.
 
 ## Is the SDK fully aligned with the API?
 


### PR DESCRIPTION
## What changed?

- updated `docs/CONTRACTS.md` so `POST /agents` no longer claims a client-supplied `user_id`
- updated troubleshooting docs to show the authenticated create-agent shape
- updated deployment quickstart and FAQ so they stop teaching stale ownership behavior

## Why?

- issue #10 tracks lingering doc drift after the backend moved agent ownership to authenticated user context
- these docs were still telling users to send `user_id` directly

## Validation

- doc updates only; verified the touched examples against the current route behavior in `src/api/routes/agents.py`
