### PR TITLE
fix: clarify deploy replicas behavior in the CLI

### DIFF
--- a/cli/commands/deploy.py
+++ b/cli/commands/deploy.py
@@ -52,7 +52,12 @@ def list_deployments(limit: int, skip: int, agent_id: Optional[str], status: Opt
 
 @deploy_group.command(name="create")
 @click.option("--agent-id", "-a", required=True, help="Agent ID to deploy")
-@click.option("--replicas", "-r", default=1, help="Number of replicas")
+@click.option(
+    "--replicas",
+    "-r",
+    default=1,
+    help="Requested replica count. Current backend deploy route always starts with 1 replica.",
+)
 def create_deployment(agent_id: str, replicas: int):
     """Create a new deployment"""
     config = CLIConfig()
@@ -71,6 +76,11 @@ def create_deployment(agent_id: str, replicas: int):
         result = response.json()
         click.echo(f"Created deployment: {result.get('deployment_id')}")
         click.echo(f"Status: {result.get('status')}")
+        if replicas != 1:
+            click.echo(
+                "Note: the current backend deploy route ignores --replicas and starts with 1 replica.",
+                err=True,
+            )
     elif response.status_code == 404:
         click.echo("Error: Agent not found", err=True)
     else:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,7 +77,7 @@ mutx status
 
 | Command | Current issue |
 |--------|---------------|
-| `mutx deploy create` | still points at an older `/api/v1/...` route shape |
+| `mutx deploy create` | uses the live deploy route, but the backend currently ignores `--replicas` and starts with 1 replica |
 
 For those flows, prefer the live route behavior in code over older docs. `mutx agents create` now relies on authenticated ownership instead of a client-supplied `user_id`.
 


### PR DESCRIPTION
## What changed?

- clarified the `--replicas` help text on `mutx deploy create`
- added an explicit runtime note when a non-default replica count is requested
- updated `docs/cli.md` so the support matrix matches the current backend behavior

## Why?

- issue #13 tracks the mismatch between the CLI flag surface and the backend deploy route
- the backend currently starts deployments with 1 replica, so the CLI should stop pretending otherwise

## Validation

- `.venv/bin/ruff check cli sdk`
- `.venv/bin/black --check cli sdk`
- `python3 -m compileall cli sdk/mutx`
