### PR TITLE
fix: add reviewer routing for autonomous PRs

### DIFF
--- a/docs/autonomy/ACTIVATION.md
+++ b/docs/autonomy/ACTIVATION.md
@@ -39,6 +39,7 @@ This repo is now set up with the team definitions and a GitHub-native control-to
 - `AUTONOMY_MODEL`: optional, defaults to `gpt-4.1-mini`
 - `AUTONOMY_MAX_PATCH_BYTES`: optional, defaults to `50000`
 - `AUTONOMY_MAX_CHANGED_FILES`: optional, defaults to `6`
+- `AUTONOMY_REVIEWER_MAP`: optional JSON object mapping reviewer-agent ids to GitHub logins
 
 ## Required Secret
 
@@ -63,6 +64,8 @@ python scripts/autonomy/hosted_llm_executor.py --agent {agent} --brief {brief} -
 ```
 
 If a generated patch exceeds the configured size or file-count guardrails, the executor stops and writes `.autonomy/guardrail-failure.json` for debugging.
+
+If `AUTONOMY_REVIEWER_MAP` is set, the executor also assigns the mapped GitHub login to the PR and leaves a reviewer-routing comment.
 
 ## Dispatch Logic
 

--- a/docs/autonomy/OPERATING_MODEL.md
+++ b/docs/autonomy/OPERATING_MODEL.md
@@ -53,7 +53,7 @@ Requirements:
 2. Orchestrator scans open issues labeled `autonomy:ready`.
 3. Work is assigned to a single owning agent based on area labels.
 4. Authoring agent creates a branch and PR.
-5. Reviewer agent checks scope, ownership, validation, and drift.
+5. Reviewer agent checks scope, ownership, validation, and drift. If reviewer login mapping is configured, PR assignment follows the work order.
 6. CI gates run.
 7. Safe PRs auto-merge; risky PRs stop for human approval.
 

--- a/scripts/autonomy/execute_work_order.py
+++ b/scripts/autonomy/execute_work_order.py
@@ -19,6 +19,20 @@ def git_output(args: list[str]) -> str:
     return run(["git", *args]).stdout.strip()
 
 
+def resolve_reviewer_login(reviewer_agent: str) -> str | None:
+    raw_map = os.environ.get("AUTONOMY_REVIEWER_MAP", "").strip()
+    if not raw_map:
+        return None
+    try:
+        reviewer_map = json.loads(raw_map)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(reviewer_map, dict):
+        return None
+    login = reviewer_map.get(reviewer_agent)
+    return login if isinstance(login, str) and login.strip() else None
+
+
 def count_changed_files() -> int:
     status = git_output(["status", "--short"])
     return len([line for line in status.splitlines() if line.strip()])
@@ -164,6 +178,30 @@ def maybe_open_pr(work_order: dict, base_branch: str) -> None:
         ],
         check=False,
     )
+    reviewer_login = resolve_reviewer_login(work_order["reviewer"])
+    if reviewer_login and os.environ.get("GH_TOKEN"):
+        run(
+            [
+                "gh",
+                "pr",
+                "edit",
+                work_order["branch"],
+                "--add-assignee",
+                reviewer_login,
+            ],
+            check=False,
+        )
+        run(
+            [
+                "gh",
+                "pr",
+                "comment",
+                work_order["branch"],
+                "--body",
+                f"Reviewer routing: `{work_order['reviewer']}` -> @{reviewer_login}",
+            ],
+            check=False,
+        )
 
 
 def main() -> int:


### PR DESCRIPTION
## What changed?

- added optional reviewer-agent to GitHub-login mapping in `scripts/autonomy/execute_work_order.py`
- autonomous PR creation now assigns the mapped login and leaves a routing comment when configured
- documented the new `AUTONOMY_REVIEWER_MAP` variable in the autonomy docs

## Why?

- issue #15 tracks making reviewer routing from work orders visible in GitHub instead of keeping it only in local metadata
- this lets the dispatch system degrade safely when no mapping is configured, but become more useful when one is

## Validation

- `python3 -m compileall scripts/autonomy/execute_work_order.py`
- `.venv/bin/ruff check scripts/autonomy`
