### PR TITLE
fix: release stale autonomous claims automatically

### DIFF
--- a/.github/workflows/autonomous-dispatch.yml
+++ b/.github/workflows/autonomous-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
   dispatch:
     name: Claim and Dispatch Work Order
     runs-on: ubuntu-latest
+    env:
+      AUTONOMY_STALE_CLAIM_MINUTES: ${{ vars.AUTONOMY_STALE_CLAIM_MINUTES || '120' }}
 
     steps:
       - name: Check out repository
@@ -44,6 +46,82 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Release stale claimed issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const staleMinutes = parseInt(process.env.AUTONOMY_STALE_CLAIM_MINUTES || '120', 10);
+            const cutoff = Date.now() - staleMinutes * 60 * 1000;
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: 'autonomy:claimed',
+              per_page: 100,
+            });
+
+            for (const issue of issues) {
+              const updatedAt = new Date(issue.updated_at).getTime();
+              if (Number.isNaN(updatedAt) || updatedAt >= cutoff) {
+                continue;
+              }
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+
+              const claimComment = [...comments].reverse().find(comment =>
+                comment.body.includes('Autonomous dispatch claimed this task.') &&
+                comment.body.includes('- branch: `')
+              );
+
+              let branchName = null;
+              if (claimComment) {
+                const match = claimComment.body.match(/- branch: `([^`]+)`/);
+                branchName = match ? match[1] : null;
+              }
+
+              let hasOpenPr = false;
+              if (branchName) {
+                const prs = await github.paginate(github.rest.pulls.list, {
+                  owner,
+                  repo,
+                  state: 'open',
+                  head: `${owner}:${branchName}`,
+                  per_page: 100,
+                });
+                hasOpenPr = prs.length > 0;
+              }
+
+              if (hasOpenPr) {
+                continue;
+              }
+
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: issue.number,
+                name: 'autonomy:claimed',
+              }).catch(() => null);
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: [
+                  'Autonomous dispatch released this stale claim.',
+                  '',
+                  `- no open PR was found for the claimed branch${branchName ? ` \\`${branchName}\\`` : ''}`,
+                  `- stale threshold: ${staleMinutes} minutes`,
+                  '- the issue is eligible for re-dispatch',
+                ].join('\n'),
+              });
+            }
 
       - name: Capture autonomy-ready issues
         uses: actions/github-script@v7

--- a/docs/autonomy/ACTIVATION.md
+++ b/docs/autonomy/ACTIVATION.md
@@ -40,6 +40,7 @@ This repo is now set up with the team definitions and a GitHub-native control-to
 - `AUTONOMY_MAX_PATCH_BYTES`: optional, defaults to `50000`
 - `AUTONOMY_MAX_CHANGED_FILES`: optional, defaults to `6`
 - `AUTONOMY_REVIEWER_MAP`: optional JSON object mapping reviewer-agent ids to GitHub logins
+- `AUTONOMY_STALE_CLAIM_MINUTES`: optional, defaults to `120`
 
 ## Required Secret
 
@@ -66,6 +67,8 @@ python scripts/autonomy/hosted_llm_executor.py --agent {agent} --brief {brief} -
 If a generated patch exceeds the configured size or file-count guardrails, the executor stops and writes `.autonomy/guardrail-failure.json` for debugging.
 
 If `AUTONOMY_REVIEWER_MAP` is set, the executor also assigns the mapped GitHub login to the PR and leaves a reviewer-routing comment.
+
+If an issue stays labeled `autonomy:claimed` past `AUTONOMY_STALE_CLAIM_MINUTES` and no open PR exists for the claimed branch, the dispatch workflow automatically releases the claim and comments on the issue.
 
 ## Dispatch Logic
 

--- a/docs/autonomy/OPERATING_MODEL.md
+++ b/docs/autonomy/OPERATING_MODEL.md
@@ -56,6 +56,7 @@ Requirements:
 5. Reviewer agent checks scope, ownership, validation, and drift. If reviewer login mapping is configured, PR assignment follows the work order.
 6. CI gates run.
 7. Safe PRs auto-merge; risky PRs stop for human approval.
+8. Stale claimed issues with no open PR are automatically released back into the queue after the configured timeout.
 
 ## Required Labels
 


### PR DESCRIPTION
## What changed?

- added a stale-claim release step to `.github/workflows/autonomous-dispatch.yml`
- claimed issues older than the configured timeout are automatically unclaimed when no open PR exists for the claimed branch
- documented the new `AUTONOMY_STALE_CLAIM_MINUTES` control and recovery behavior in autonomy docs

## Why?

- issue #14 tracks keeping the queue moving when automation claims an issue but never opens a PR
- this gives claimed issues an automatic retry path instead of leaving them stuck forever

## Validation

- `python3 -m compileall scripts/autonomy/build_work_order.py scripts/autonomy/execute_work_order.py`
- workflow logic reviewed against the current claim comment format in `.github/workflows/autonomous-dispatch.yml`
