### PR TITLE
feat(cli,sdk): add API key management (list, create, revoke, rotate)

### DIFF
--- a/cli/commands/api_keys.py
+++ b/cli/commands/api_keys.py
@@ -1,0 +1,137 @@
+import click
+from typing import Optional
+
+from cli.config import CLIConfig, get_client
+
+
+@click.group(name="api-keys")
+def api_keys_group():
+    """Manage API keys"""
+    pass
+
+
+@api_keys_group.command(name="list")
+def list_api_keys():
+    """List all API keys"""
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        return
+
+    client = get_client(config)
+    response = client.get("/api-keys")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    keys = response.json()
+    if not keys:
+        click.echo("No API keys found.")
+        return
+
+    for key in keys:
+        active = "active" if key.get("is_active") else "revoked"
+        expires = key.get("expires_at") or "never"
+        click.echo(f"{key['id']} | {key['name']} | {active} | expires: {expires}")
+
+
+@api_keys_group.command(name="create")
+@click.option("--name", "-n", required=True, help="Name for the API key")
+@click.option("--expires-in-days", "-e", default=None, type=int, help="Expiration in days (1-365)")
+def create_api_key(name: str, expires_in_days: Optional[int]):
+    """Create a new API key"""
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        return
+
+    payload = {"name": name}
+    if expires_in_days is not None:
+        payload["expires_in_days"] = expires_in_days
+
+    client = get_client(config)
+    response = client.post("/api-keys", json=payload)
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 201:
+        data = response.json()
+        click.echo(f"Created API key: {data['name']}")
+        click.echo(f"Key ID:  {data['id']}")
+        click.echo(f"Secret:  {data['key']}")
+        click.echo("")
+        click.echo("⚠  Save this secret now — it will not be shown again.")
+    else:
+        click.echo(f"Error: {response.text}", err=True)
+
+
+@api_keys_group.command(name="revoke")
+@click.argument("key_id")
+@click.option("--force", "-f", is_flag=True, help="Skip confirmation prompt")
+def revoke_api_key(key_id: str, force: bool):
+    """Revoke (delete) an API key"""
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        return
+
+    if not force:
+        if not click.confirm(f"Are you sure you want to revoke API key {key_id}?"):
+            return
+
+    client = get_client(config)
+    response = client.delete(f"/api-keys/{key_id}")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 204:
+        click.echo(f"Revoked API key: {key_id}")
+    elif response.status_code == 404:
+        click.echo("Error: API key not found", err=True)
+    else:
+        click.echo(f"Error: {response.text}", err=True)
+
+
+@api_keys_group.command(name="rotate")
+@click.argument("key_id")
+@click.option("--force", "-f", is_flag=True, help="Skip confirmation prompt")
+def rotate_api_key(key_id: str, force: bool):
+    """Rotate an API key (revoke old, create new)"""
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        return
+
+    if not force:
+        if not click.confirm(
+            f"Rotating will revoke the old key immediately. Continue for {key_id}?"
+        ):
+            return
+
+    client = get_client(config)
+    response = client.post(f"/api-keys/{key_id}/rotate")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 200:
+        data = response.json()
+        click.echo(f"Rotated API key: {data['name']}")
+        click.echo(f"New Key ID:  {data['id']}")
+        click.echo(f"New Secret:  {data['key']}")
+        click.echo("")
+        click.echo("⚠  Save this secret now — it will not be shown again.")
+    elif response.status_code == 404:
+        click.echo("Error: API key not found", err=True)
+    else:
+        click.echo(f"Error: {response.text}", err=True)

--- a/cli/main.py
+++ b/cli/main.py
@@ -2,6 +2,7 @@ import click
 
 from cli.config import CLIConfig, get_client
 from cli.commands.agents import agents_group
+from cli.commands.api_keys import api_keys_group
 from cli.commands.deploy import deploy_group
 
 
@@ -95,6 +96,7 @@ def status():
 
 
 cli.add_command(agents_group)
+cli.add_command(api_keys_group)
 cli.add_command(deploy_group)
 
 

--- a/sdk/mutx/__init__.py
+++ b/sdk/mutx/__init__.py
@@ -9,6 +9,7 @@ from mutx.agent_runtime import (
     create_agent_client,
 )
 from mutx.agents import Agents
+from mutx.api_keys import APIKeys
 from mutx.deployments import Deployments
 from mutx.webhooks import Webhooks
 
@@ -34,6 +35,7 @@ class MutxClient:
         )
 
         self.agents = Agents(self._client)
+        self.api_keys = APIKeys(self._client)
         self.deployments = Deployments(self._client)
         self.webhooks = Webhooks(self._client)
 
@@ -53,6 +55,14 @@ class MutxClient:
     @agents.setter
     def agents(self, value: Agents):
         self._agents = value
+
+    @property
+    def api_keys(self) -> APIKeys:
+        return self._api_keys
+
+    @api_keys.setter
+    def api_keys(self, value: APIKeys):
+        self._api_keys = value
 
     @property
     def deployments(self) -> Deployments:
@@ -92,6 +102,7 @@ class MutxAsyncClient:
         )
 
         self.agents = Agents(self._client)
+        self.api_keys = APIKeys(self._client)
         self.deployments = Deployments(self._client)
         self.webhooks = Webhooks(self._client)
 
@@ -111,6 +122,14 @@ class MutxAsyncClient:
     @agents.setter
     def agents(self, value: Agents):
         self._agents = value
+
+    @property
+    def api_keys(self) -> APIKeys:
+        return self._api_keys
+
+    @api_keys.setter
+    def api_keys(self, value: APIKeys):
+        self._api_keys = value
 
     @property
     def deployments(self) -> Deployments:
@@ -137,5 +156,6 @@ __all__ = [
     "AgentInfo",
     "Command",
     "AgentMetrics",
+    "APIKeys",
     "create_agent_client",
 ]

--- a/sdk/mutx/agents.py
+++ b/sdk/mutx/agents.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any, Callable, Generator, Optional
 from uuid import UUID

--- a/sdk/mutx/api_keys.py
+++ b/sdk/mutx/api_keys.py
@@ -1,0 +1,75 @@
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID
+
+import httpx
+
+
+class APIKey:
+    """Represents an API key (without the raw secret)."""
+
+    def __init__(self, data: dict[str, Any]):
+        self.id = UUID(data["id"])
+        self.name = data["name"]
+        self.is_active = data.get("is_active", True)
+        self.last_used = (
+            datetime.fromisoformat(data["last_used"]) if data.get("last_used") else None
+        )
+        self.created_at = datetime.fromisoformat(data["created_at"])
+        self.expires_at = (
+            datetime.fromisoformat(data["expires_at"]) if data.get("expires_at") else None
+        )
+        self._data = data
+
+    def __repr__(self) -> str:
+        return f"APIKey(id={self.id}, name={self.name}, active={self.is_active})"
+
+
+class APIKeyWithSecret(APIKey):
+    """Returned on create/rotate — includes the plain key (shown once)."""
+
+    def __init__(self, data: dict[str, Any]):
+        super().__init__(data)
+        self.key: str = data["key"]
+
+    def __repr__(self) -> str:
+        prefix = self.key[:16] + "…" if len(self.key) > 16 else self.key
+        return f"APIKeyWithSecret(id={self.id}, name={self.name}, key={prefix})"
+
+
+class APIKeys:
+    """SDK resource for /api-keys endpoints."""
+
+    def __init__(self, client: httpx.Client | httpx.AsyncClient):
+        self._client = client
+
+    def list(self) -> list[APIKey]:
+        """List all API keys for the authenticated user."""
+        response = self._client.get("/api-keys")
+        response.raise_for_status()
+        return [APIKey(data) for data in response.json()]
+
+    def create(
+        self,
+        name: str,
+        expires_in_days: Optional[int] = None,
+    ) -> APIKeyWithSecret:
+        """Create a new API key.  The plain key is only returned once."""
+        payload: dict[str, Any] = {"name": name}
+        if expires_in_days is not None:
+            payload["expires_in_days"] = expires_in_days
+
+        response = self._client.post("/api-keys", json=payload)
+        response.raise_for_status()
+        return APIKeyWithSecret(response.json())
+
+    def revoke(self, key_id: UUID | str) -> None:
+        """Revoke (delete) an API key."""
+        response = self._client.delete(f"/api-keys/{key_id}")
+        response.raise_for_status()
+
+    def rotate(self, key_id: UUID | str) -> APIKeyWithSecret:
+        """Rotate an API key — revokes the old one and returns a new one."""
+        response = self._client.post(f"/api-keys/{key_id}/rotate")
+        response.raise_for_status()
+        return APIKeyWithSecret(response.json())

--- a/sdk/mutx/deployments.py
+++ b/sdk/mutx/deployments.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any, Optional
 from uuid import UUID

--- a/sdk/mutx/webhooks.py
+++ b/sdk/mutx/webhooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any, Optional
 from uuid import UUID


### PR DESCRIPTION
## What

Closes the contract parity gap between the backend `/api-keys` routes and the CLI/SDK surfaces.

### CLI — `mutx api-keys`

| Command | Backend route |
|---------|-------------|
| `mutx api-keys list` | `GET /api-keys` |
| `mutx api-keys create -n <name> [-e days]` | `POST /api-keys` |
| `mutx api-keys revoke <id> [-f]` | `DELETE /api-keys/{id}` |
| `mutx api-keys rotate <id> [-f]` | `POST /api-keys/{id}/rotate` |

### SDK — `client.api_keys.*`

| Method | Backend route |
|--------|-------------|
| `list()` | `GET /api-keys` |
| `create(name, expires_in_days)` | `POST /api-keys` |
| `revoke(key_id)` | `DELETE /api-keys/{id}` |
| `rotate(key_id)` | `POST /api-keys/{id}/rotate` |

### Bug fix (bonus)

The SDK was **completely broken on import** — `agents.py`, `deployments.py`, and `webhooks.py` each had a `list` method that shadowed the builtin, causing `TypeError: 'function' object is not subscriptable` at module load time. Fixed with `from __future__ import annotations`.

## Checks

- [x] `ruff check cli/ sdk/` — all passed
- [x] `ruff format --check cli/ sdk/` — all formatted
- [x] `pytest tests/ -x -q` — 48/48 passed
- [x] CLI import test — `mutx api-keys --help` works
- [x] SDK import test — `MutxClient` exposes `.api_keys`

@codex review