### PR TITLE
feat(api): add typed agent configuration schemas and validation

### DIFF
--- a/src/api/models/schemas.py
+++ b/src/api/models/schemas.py
@@ -3,16 +3,48 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic import EmailStr
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Any
 import uuid
 
-from src.api.models.models import AgentStatus
+from src.api.models.models import AgentStatus, AgentType
+
+
+class AgentConfigBase(BaseModel):
+    """Base schema for specialized agent configurations"""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class OpenAIAgentConfig(AgentConfigBase):
+    model: str = Field(default="gpt-4o")
+    temperature: float = Field(default=0.7, ge=0.0, le=2.0)
+    system_prompt: Optional[str] = None
+    max_tokens: Optional[int] = Field(default=None, gt=0)
+
+
+class AnthropicAgentConfig(AgentConfigBase):
+    model: str = Field(default="claude-3-5-sonnet-20240620")
+    temperature: float = Field(default=0.7, ge=0.0, le=1.0)
+    system_prompt: Optional[str] = None
+    max_tokens: int = Field(default=4096, gt=0)
+
+
+class LangChainAgentConfig(AgentConfigBase):
+    chain_id: str
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class CustomAgentConfig(AgentConfigBase):
+    image: str
+    command: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
 
 
 class AgentCreate(BaseModel):
-    name: str
-    description: Optional[str] = None
-    config: Optional[str] = None
+    name: str = Field(..., min_length=1, max_length=255)
+    description: Optional[str] = Field(None, max_length=1000)
+    type: AgentType = Field(default=AgentType.OPENAI)
+    config: Optional[dict[str, Any] | str] = None
     # user_id is set from current_user in the route, not from request body
 
 

--- a/src/api/routes/agents.py
+++ b/src/api/routes/agents.py
@@ -2,25 +2,62 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 import logging
-from typing import Optional
+from typing import Optional, Any
 import uuid
+import json
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from src.api.database import get_db
-from src.api.models import Agent, Deployment, AgentLog, AgentMetric, AgentStatus, User
+from src.api.models import Agent, Deployment, AgentLog, AgentMetric, AgentStatus, User, AgentType
 from src.api.models.schemas import (
     AgentCreate,
     AgentResponse,
     AgentDetailResponse,
     AgentLogResponse,
     AgentMetricResponse,
+    OpenAIAgentConfig,
+    AnthropicAgentConfig,
+    LangChainAgentConfig,
+    CustomAgentConfig,
 )
 from src.api.middleware.auth import get_current_user
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 logger = logging.getLogger(__name__)
+
+
+def _validate_agent_config(agent_type: AgentType, config: Any) -> str:
+    """Validate and normalize agent configuration based on its type."""
+    if config is None:
+        return "{}"
+
+    # If it's already a string, try to parse it first to ensure it's valid JSON
+    if isinstance(config, str):
+        try:
+            config_dict = json.loads(config)
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=400, detail="Invalid JSON in agent configuration")
+    else:
+        config_dict = config
+
+    try:
+        if agent_type == AgentType.OPENAI:
+            validated = OpenAIAgentConfig(**config_dict)
+        elif agent_type == AgentType.ANTHROPIC:
+            validated = AnthropicAgentConfig(**config_dict)
+        elif agent_type == AgentType.LANGCHAIN:
+            validated = LangChainAgentConfig(**config_dict)
+        elif agent_type == AgentType.CUSTOM:
+            validated = CustomAgentConfig(**config_dict)
+        else:
+            # Fallback for future types not yet fully schema-guarded
+            return json.dumps(config_dict)
+
+        return validated.model_dump_json()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Configuration validation failed: {str(e)}")
 
 
 def _serialize_deployment(deployment: Deployment):
@@ -62,11 +99,15 @@ async def create_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    # Validate and normalize config based on agent type
+    config_json = _validate_agent_config(agent_data.type, agent_data.config)
+
     # Use current_user.id for ownership, not from request body
     agent = Agent(
         name=agent_data.name,
         description=agent_data.description,
-        config=agent_data.config,
+        type=agent_data.type,
+        config=config_json,
         user_id=current_user.id,
         status=AgentStatus.CREATING.value,
     )

--- a/tests/api/test_agents.py
+++ b/tests/api/test_agents.py
@@ -21,7 +21,8 @@ class TestCreateAgent:
             json={
                 "name": "new-agent",
                 "description": "A new test agent",
-                "config": json.dumps({"model": "gpt-4", "temperature": 0.7}),
+                "type": "openai",
+                "config": {"model": "gpt-4o", "temperature": 0.7},
             },
         )
         assert response.status_code == 201
@@ -29,7 +30,26 @@ class TestCreateAgent:
         assert data["name"] == "new-agent"
         assert data["description"] == "A new test agent"
         assert data["status"] == "creating"
+        
+        # Verify validated config
+        config = json.loads(data["config"])
+        assert config["model"] == "gpt-4o"
+        assert config["temperature"] == 0.7
         assert "id" in data
+
+    @pytest.mark.asyncio
+    async def test_create_agent_invalid_config(self, client: AsyncClient):
+        """Test creating an agent with invalid config schema."""
+        response = await client.post(
+            "/agents",
+            json={
+                "name": "invalid-config-agent",
+                "type": "openai",
+                "config": {"model": "gpt-4o", "temperature": 5.0},  # Invalid temperature > 2.0
+            },
+        )
+        assert response.status_code == 400
+        assert "Configuration validation failed" in response.json()["detail"]
     
     @pytest.mark.asyncio
     async def test_create_agent_with_minimal_data(self, client: AsyncClient):


### PR DESCRIPTION
Introduce specialized Pydantic models for OpenAI, Anthropic, LangChain, and Custom agent types to replace loose JSON strings.

### Changes
- Added , , , and  schemas.
- Implemented  helper in  routes to enforce type-specific validation.
- Updated  to use the new validation logic.
- Added test cases for successful creation and validation failures.

Tagging @codex for review.