### PR TITLE
fix: stop rewriting OpenAPI on API startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ uvicorn src.api.main:app --reload --port 8000
 npm run dev
 ```
 
+Regenerate the API contract explicitly when backend routes change:
+
+```bash
+python3 scripts/generate_openapi.py
+npm run generate-types
+```
+
 ---
 
 *MUTX: Building the backbone of the agentic economy.*

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,9 +1,23 @@
+from pathlib import Path
+import sys
+
 import json
 from fastapi.openapi.utils import get_openapi
-from src.api.main import app
-from pathlib import Path
 
-Path('docs/api').mkdir(parents=True, exist_ok=True)
-with open('docs/api/openapi.json', 'w') as f:
-    json.dump(get_openapi(title=app.title, version=app.version, routes=app.routes), f, indent=2)
-print("OpenAPI spec generated.")
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.api.main import app
+
+
+def main() -> None:
+    output_path = Path('docs/api/openapi.json')
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open('w') as file_handle:
+        json.dump(get_openapi(title=app.title, version=app.version, routes=app.routes), file_handle, indent=2)
+    print(f'OpenAPI spec generated at {output_path}.')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -2,12 +2,9 @@ import asyncio
 from contextlib import asynccontextmanager
 from datetime import datetime
 import logging
-import json
-from pathlib import Path
 
 from fastapi import FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.openapi.utils import get_openapi
 
 from src.api.config import get_settings
 from src.api.database import dispose_engine, init_db
@@ -78,12 +75,6 @@ async def lifespan(app: FastAPI):
         monitor_task = asyncio.create_task(start_background_monitor())
     else:
         monitor_task = asyncio.create_task(_start_monitor_when_database_ready(app))
-
-    # Generate OpenAPI spec on startup
-    Path("docs/api").mkdir(parents=True, exist_ok=True)
-    with open("docs/api/openapi.json", "w") as f:
-        json.dump(get_openapi(title=app.title, version=app.version, routes=app.routes), f, indent=2)
-        logger.info("OpenAPI spec generated at docs/api/openapi.json")
 
     try:
         yield


### PR DESCRIPTION
## What changed?

- removed the startup-time OpenAPI file write from `src/api/main.py`
- kept OpenAPI generation explicit via `scripts/generate_openapi.py`
- made the generator runnable from the repo root by inserting the project root on `sys.path`
- documented the explicit regenerate flow in `README.md`

## Why?

- issue #6 tracks the repo-mutation side effect on API startup
- backend boot should not rewrite tracked artifacts just because the app started

## Validation

- `/Users/fortune/MUTX/.venv/bin/python -m compileall src/api scripts/generate_openapi.py`
- `/Users/fortune/MUTX/.venv/bin/python scripts/generate_openapi.py`
