### PR TITLE
feat: make contact leads a documented tested API surface

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -21,6 +21,7 @@ Routes are mounted directly at top-level prefixes. There is no global `/v1` back
 | API Keys | `GET /api-keys`, `POST /api-keys`, `DELETE /api-keys/{key_id}`, `POST /api-keys/{key_id}/rotate` |
 | Webhooks | `POST /webhooks/agent-status`, `POST /webhooks/deployment`, `POST /webhooks/metrics` |
 | Newsletter | `GET /newsletter`, `POST /newsletter` |
+| Leads | `POST /leads`, `GET /leads`, `GET /leads/{lead_id}` |
 
 ## Website Proxies
 
@@ -92,3 +93,4 @@ curl "$BASE_URL/agents?skip=0&limit=50"
 - [Agents](./agents.md)
 - [Deployments](./deployments.md)
 - [Webhook Ingestion](./webhooks.md)
+- [Leads](./leads.md)

--- a/docs/api/leads.md
+++ b/docs/api/leads.md
@@ -1,0 +1,62 @@
+# Leads API
+
+The leads routes capture contact and onboarding interest from the public surface, then expose authenticated read access for internal follow-up.
+
+## Current Implementation Notes
+
+- Routes are mounted at `/leads`.
+- `POST /leads` is public so marketing or onboarding surfaces can capture interest without prior auth.
+- `GET /leads` and `GET /leads/{lead_id}` require authenticated control-plane access.
+- Leads are stored in the `leads` table with optional `name`, `company`, `message`, and `source` metadata.
+
+## Routes
+
+| Route | Purpose |
+| --- | --- |
+| `POST /leads` | Capture a new contact lead |
+| `GET /leads` | List captured leads |
+| `GET /leads/{lead_id}` | Fetch one captured lead |
+
+## Capture A Lead
+
+```bash
+BASE_URL=http://localhost:8000
+
+curl -X POST "$BASE_URL/leads" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "founder@example.com",
+    "name": "Founder",
+    "company": "Example Co",
+    "message": "Interested in early access and migration help.",
+    "source": "homepage"
+  }'
+```
+
+Example response:
+
+```json
+{
+  "id": "uuid",
+  "email": "founder@example.com",
+  "name": "Founder",
+  "company": "Example Co",
+  "message": "Interested in early access and migration help.",
+  "source": "homepage",
+  "created_at": "2026-03-12T00:00:00Z"
+}
+```
+
+## List Leads
+
+```bash
+curl "$BASE_URL/leads?skip=0&limit=50" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+## Get One Lead
+
+```bash
+curl "$BASE_URL/leads/YOUR_LEAD_ID" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -19,6 +19,7 @@ from src.api.routes import (
     newsletter,
     agent_runtime,
     ingest,
+    leads,
 )
 from src.api.metrics import router as metrics_router, track_request
 from src.api.services.monitor import start_background_monitor
@@ -136,6 +137,7 @@ app.include_router(auth.router)
 app.include_router(clawhub.router)
 app.include_router(api_keys.router)
 app.include_router(newsletter.router)
+app.include_router(leads.router)
 app.include_router(agent_runtime.router)
 app.include_router(ingest.router)
 

--- a/src/api/models/models.py
+++ b/src/api/models/models.py
@@ -326,3 +326,15 @@ class WaitlistSignup(Base):
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     source: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, index=True)
+
+
+class Lead(Base):
+    __tablename__ = "leads"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    email: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    company: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    source: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, index=True)

--- a/src/api/models/schemas.py
+++ b/src/api/models/schemas.py
@@ -257,3 +257,24 @@ class WaitlistSignupResponse(BaseModel):
 
 class WaitlistCountResponse(BaseModel):
     count: int
+
+
+# Lead Schemas
+class LeadCreate(BaseModel):
+    email: EmailStr
+    name: Optional[str] = Field(None, max_length=255)
+    company: Optional[str] = Field(None, max_length=255)
+    message: Optional[str] = Field(None, max_length=5000)
+    source: Optional[str] = Field(None, max_length=120)
+
+
+class LeadResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    email: str
+    name: Optional[str]
+    company: Optional[str]
+    message: Optional[str]
+    source: Optional[str]
+    created_at: datetime

--- a/src/api/routes/leads.py
+++ b/src/api/routes/leads.py
@@ -1,0 +1,67 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import List
+import uuid
+
+from src.api.database import get_db
+from src.api.models.models import Lead, User
+from src.api.models.schemas import LeadCreate, LeadResponse
+from src.api.middleware.auth import get_current_user
+
+router = APIRouter(prefix="/leads", tags=["leads"])
+
+
+@router.post("", response_model=LeadResponse, status_code=status.HTTP_201_CREATED)
+async def capture_lead(
+    payload: LeadCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Capture a new contact lead.
+    Public endpoint for landing pages and onboarding.
+    """
+    lead = Lead(
+        email=payload.email.lower().strip(),
+        name=payload.name.strip() if payload.name else None,
+        company=payload.company.strip() if payload.company else None,
+        message=payload.message.strip() if payload.message else None,
+        source=payload.source.strip() if payload.source else "direct",
+    )
+    db.add(lead)
+    await db.commit()
+    await db.refresh(lead)
+    return lead
+
+
+@router.get("", response_model=List[LeadResponse])
+async def list_leads(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    List captured leads.
+    Restricted to authenticated users (internal/admin use).
+    """
+    # In a real app, we might check if user is admin
+    result = await db.execute(
+        select(Lead).order_by(Lead.created_at.desc()).offset(skip).limit(limit)
+    )
+    leads = result.scalars().all()
+    return leads
+
+
+@router.get("/{lead_id}", response_model=LeadResponse)
+async def get_lead(
+    lead_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get a specific lead by ID."""
+    result = await db.execute(select(Lead).where(Lead.id == lead_id))
+    lead = result.scalar_one_or_none()
+    if not lead:
+        raise HTTPException(status_code=404, detail="Lead not found")
+    return lead

--- a/tests/api/test_leads.py
+++ b/tests/api/test_leads.py
@@ -1,0 +1,99 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.models.models import Lead
+
+
+@pytest.mark.asyncio
+async def test_capture_lead_success(client: AsyncClient, db_session: AsyncSession):
+    """Test capturing a lead successfully."""
+    response = await client.post(
+        "/leads",
+        json={
+            "email": "lead@example.com",
+            "name": "Lead Name",
+            "company": "Lead Co",
+            "message": "Hello, I am interested.",
+            "source": "onboarding",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["email"] == "lead@example.com"
+    assert data["name"] == "Lead Name"
+    assert data["company"] == "Lead Co"
+    assert data["message"] == "Hello, I am interested."
+    assert data["source"] == "onboarding"
+    assert "id" in data
+
+
+@pytest.mark.asyncio
+async def test_capture_lead_minimal(client: AsyncClient):
+    """Test capturing a lead with minimal data."""
+    response = await client.post(
+        "/leads",
+        json={
+            "email": "minimal@example.com",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["email"] == "minimal@example.com"
+    assert data["source"] == "direct"  # Default value
+
+
+@pytest.mark.asyncio
+async def test_list_leads_authenticated(client: AsyncClient, test_user):
+    """Test listing leads requires authentication."""
+    # This should succeed because 'client' is authenticated (via conftest fixtures usually)
+    response = await client.get("/leads")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+@pytest.mark.asyncio
+async def test_list_leads_unauthorized(client_no_auth: AsyncClient):
+    """Test listing leads without auth fails."""
+    response = await client_no_auth.get("/leads")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_lead_authenticated(client: AsyncClient, db_session: AsyncSession):
+    """Test fetching a single lead when authenticated."""
+    lead = Lead(
+        email="reader@example.com",
+        name="Reader",
+        company="Read Co",
+        message="Tell me more.",
+        source="docs",
+    )
+    db_session.add(lead)
+    await db_session.commit()
+    await db_session.refresh(lead)
+
+    response = await client.get(f"/leads/{lead.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == str(lead.id)
+    assert data["email"] == "reader@example.com"
+
+
+@pytest.mark.asyncio
+async def test_get_lead_unauthorized(client_no_auth: AsyncClient, db_session: AsyncSession):
+    """Test fetching a single lead without auth fails."""
+    lead = Lead(email="private@example.com", source="homepage")
+    db_session.add(lead)
+    await db_session.commit()
+    await db_session.refresh(lead)
+
+    response = await client_no_auth.get(f"/leads/{lead.id}")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_lead_not_found(client: AsyncClient):
+    """Test fetching an unknown lead returns 404."""
+    response = await client.get("/leads/00000000-0000-0000-0000-999999999999")
+    assert response.status_code == 404

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import asyncio
 from collections.abc import AsyncGenerator
 import os
 import uuid
-from datetime import datetime
 
 import pytest
 import pytest_asyncio
@@ -35,7 +34,7 @@ def compile_uuid_sqlite(_type, _compiler, **_kw):
 
 def create_test_app() -> FastAPI:
     """Create a test FastAPI application."""
-    from src.api.routes import agents, deployments, api_keys, auth, webhooks, clawhub, agent_runtime, newsletter, ingest
+    from src.api.routes import agents, deployments, api_keys, auth, webhooks, clawhub, agent_runtime, newsletter, ingest, leads
     
     app = FastAPI(title="MUTX Test API")
     
@@ -48,6 +47,7 @@ def create_test_app() -> FastAPI:
     app.include_router(clawhub.router)
     app.include_router(agent_runtime.router)
     app.include_router(newsletter.router)
+    app.include_router(leads.router)
     app.include_router(ingest.router)
     
     # Health check endpoint


### PR DESCRIPTION
## Summary\n- add a documented  API surface for contact capture and authenticated lead review\n- mount the leads router and add lead schemas/model wiring\n- add focused API coverage for lead capture, list, single-lead fetch, auth, and not-found cases\n\n## Validation\n- All checks passed!\n- .......                                                                  [100%]
=============================== warnings summary ===============================
tests/api/test_leads.py::test_capture_lead_success
  /Users/fortune/MUTX/.venv/lib/python3.11/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    from crypt import crypt as _crypt

tests/api/test_leads.py::test_capture_lead_success
  /Users/fortune/MUTX/.venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:271: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.5/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
7 passed, 2 warnings in 0.65s\n- \n\nCloses #44\n