### PR TITLE
test: add clean deployment ownership regression coverage

### DIFF
--- a/tests/api/test_deployments.py
+++ b/tests/api/test_deployments.py
@@ -80,6 +80,14 @@ class TestListDeployments:
         data = response.json()
         assert len(data) == 1
         assert data[0]["agent_id"] == str(test_agent.id)
+
+    @pytest.mark.asyncio
+    async def test_list_deployments_other_user_agent_forbidden(
+        self, other_user_client: AsyncClient, test_agent
+    ):
+        """Test filtering by another user's agent is forbidden."""
+        response = await other_user_client.get(f"/deployments?agent_id={test_agent.id}")
+        assert response.status_code == 403
     
     @pytest.mark.asyncio
     async def test_list_deployments_by_status(
@@ -252,4 +260,19 @@ class TestCreateDeployment:
             "/deployments",
             json={"agent_id": str(test_agent.id), "replicas": 1},
         )
+        assert response.status_code == 403
+
+
+class TestRestartDeployment:
+    """Tests for POST /deployments/{deployment_id}/restart endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_restart_deployment_other_user_forbidden(
+        self, other_user_client: AsyncClient, test_deployment, db_session: AsyncSession
+    ):
+        """Test other users cannot restart deployments they do not own."""
+        test_deployment.status = "stopped"
+        await db_session.commit()
+
+        response = await other_user_client.post(f"/deployments/{test_deployment.id}/restart")
         assert response.status_code == 403


### PR DESCRIPTION
## What changed?

- rebuilt issue #36 cleanly from current `main` instead of trying to untangle conflicted PR #41
- added focused regression coverage for deployment ownership on:
  - filtering deployments by another user's agent id
  - restarting another user's deployment

## Why?

- current `main` already contains the deployment ownership helper path, but PR #41 is conflicted and noisy
- this replacement PR keeps the issue alive with a small reviewable slice that proves deployment access stays derived from the authenticated user

## Validation

- `/Users/fortune/MUTX/.venv/bin/ruff check tests/api/test_deployments.py`
- `/Users/fortune/MUTX/.venv/bin/python -m pytest tests/api/test_deployments.py -q`
- `python3 -m compileall src/api/routes/deployments.py`
