### PR TITLE
ci: make frontend validation truthful in test suite

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,11 +38,16 @@ echo "Generating frontend API types..."
 npm run generate-types
 
 echo ""
-echo "Running frontend build check..."
-npm run build
+echo "Checking generated frontend API types are committed..."
+git diff --exit-code -- app/types/api.ts
 
 echo ""
-echo "Skipping frontend lint: current ESLint setup is known broken in this repo."
+echo "Running frontend lint..."
+npm run lint
+
+echo ""
+echo "Running frontend build check..."
+npm run build
 
 echo ""
 echo "Validation complete!"


### PR DESCRIPTION
## Summary
- stop silently skipping frontend lint in Running Python lint and format checks...
All checks passed!

Running Python compile check...
Listing 'src/api'...
Listing 'src/api/auth'...
Listing 'src/api/integrations'...
Listing 'src/api/integrations/openclaw'...
Listing 'src/api/middleware'...
Listing 'src/api/models'...
Listing 'src/api/models/migrations'...
Listing 'src/api/models/migrations/versions'...
Listing 'src/api/routes'...
Listing 'src/api/services'...
Listing 'src/api/services/email'...
Listing 'cli'...
Listing 'cli/commands'...
Listing 'sdk/mutx'...

Running Python API test suite...
.....................................................................    [100%]
=============================== warnings summary ===============================
tests/api/test_agents.py::TestCreateAgent::test_create_agent_success
  /Users/fortune/MUTX/.venv/lib/python3.11/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    from crypt import crypt as _crypt

tests/api/test_agents.py::TestCreateAgent::test_create_agent_success
  /Users/fortune/MUTX/.venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:271: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.5/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
69 passed, 2 warnings in 3.59s

Generating frontend API types...

> mutx@1.0.0 generate-types
> openapi-typescript docs/api/openapi.json -o app/types/api.ts

✨ openapi-typescript 7.13.0
🚀 docs/api/openapi.json → app/types/api.ts [63.9ms]

Checking generated frontend API types are committed...

Running frontend lint...

> mutx@1.0.0 lint
> next lint

✔ No ESLint warnings or errors

Running frontend build check...

> mutx@1.0.0 build
> next build --no-lint

   ▲ Next.js 14.1.0

   Creating an optimized production build ...
 ✓ Compiled successfully
   Checking validity of types ...
   Collecting page data ...
   Generating static pages (0/6) ...
   Generating static pages (1/6) 
   Generating static pages (2/6) 
   Generating static pages (4/6) 
 ✓ Generating static pages (6/6) 
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                              Size     First Load JS
┌ ○ /                                    12.9 kB         151 kB
├ ○ /_not-found                          885 B          85.1 kB
├ λ /api/api-keys                        0 B                0 B
├ λ /api/api-keys/[id]                   0 B                0 B
├ λ /api/auth/login                      0 B                0 B
├ λ /api/auth/logout                     0 B                0 B
├ λ /api/auth/me                         0 B                0 B
├ λ /api/auth/register                   0 B                0 B
├ λ /api/dashboard/agents                0 B                0 B
├ λ /api/dashboard/deployments           0 B                0 B
├ λ /api/dashboard/health                0 B                0 B
├ λ /api/newsletter                      0 B                0 B
├ λ /api/turnstile/site-key              0 B                0 B
├ λ /app/[[...slug]]                     5.51 kB         144 kB
├ ○ /robots.txt                          0 B                0 B
└ ○ /sitemap.xml                         0 B                0 B
+ First Load JS shared by all            84.3 kB
  ├ chunks/69-937ff30f6529f43f.js        28.9 kB
  ├ chunks/fd9d1056-6110ffd77e8dcc12.js  53.4 kB
  └ other shared chunks (total)          1.96 kB


ƒ Middleware                             40.3 kB

○  (Static)   prerendered as static content
λ  (Dynamic)  server-rendered on demand using Node.js


Validation complete!
- run 
> mutx@1.0.0 lint
> next lint

✔ No ESLint warnings or errors as part of validation
- after generating API types, fail if  changed but was not committed ()

## Why
This tightens CI signal quality by removing a fake-green path and ensuring generated types stay in sync with source OpenAPI changes.

## Validation
- Running Python lint and format checks...
All checks passed!

Running Python compile check...
Listing 'src/api'...
Listing 'src/api/auth'...
Listing 'src/api/integrations'...
Listing 'src/api/integrations/openclaw'...
Listing 'src/api/middleware'...
Listing 'src/api/models'...
Listing 'src/api/models/migrations'...
Listing 'src/api/models/migrations/versions'...
Listing 'src/api/routes'...
Listing 'src/api/services'...
Listing 'src/api/services/email'...
Listing 'cli'...
Listing 'cli/commands'...
Listing 'sdk/mutx'...

Running Python API test suite...
.....................................................................    [100%]
=============================== warnings summary ===============================
tests/api/test_agents.py::TestCreateAgent::test_create_agent_success
  /Users/fortune/MUTX/.venv/lib/python3.11/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    from crypt import crypt as _crypt

tests/api/test_agents.py::TestCreateAgent::test_create_agent_success
  /Users/fortune/MUTX/.venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:271: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.5/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
69 passed, 2 warnings in 4.00s

Generating frontend API types...

> mutx@1.0.0 generate-types
> openapi-typescript docs/api/openapi.json -o app/types/api.ts

✨ openapi-typescript 7.13.0
🚀 docs/api/openapi.json → app/types/api.ts [74.1ms]

Checking generated frontend API types are committed...

Running frontend lint...

> mutx@1.0.0 lint
> next lint

✔ No ESLint warnings or errors

Running frontend build check...

> mutx@1.0.0 build
> next build --no-lint

   ▲ Next.js 14.1.0

   Creating an optimized production build ...
 ✓ Compiled successfully
   Checking validity of types ...
   Collecting page data ...
   Generating static pages (0/6) ...
   Generating static pages (1/6) 
   Generating static pages (2/6) 
   Generating static pages (4/6) 
 ✓ Generating static pages (6/6) 
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                              Size     First Load JS
┌ ○ /                                    12.9 kB         151 kB
├ ○ /_not-found                          885 B          85.1 kB
├ λ /api/api-keys                        0 B                0 B
├ λ /api/api-keys/[id]                   0 B                0 B
├ λ /api/auth/login                      0 B                0 B
├ λ /api/auth/logout                     0 B                0 B
├ λ /api/auth/me                         0 B                0 B
├ λ /api/auth/register                   0 B                0 B
├ λ /api/dashboard/agents                0 B                0 B
├ λ /api/dashboard/deployments           0 B                0 B
├ λ /api/dashboard/health                0 B                0 B
├ λ /api/newsletter                      0 B                0 B
├ λ /api/turnstile/site-key              0 B                0 B
├ λ /app/[[...slug]]                     5.51 kB         144 kB
├ ○ /robots.txt                          0 B                0 B
└ ○ /sitemap.xml                         0 B                0 B
+ First Load JS shared by all            84.3 kB
  ├ chunks/69-937ff30f6529f43f.js        28.9 kB
  ├ chunks/fd9d1056-6110ffd77e8dcc12.js  53.4 kB
  └ other shared chunks (total)          1.96 kB


ƒ Middleware                             40.3 kB

○  (Static)   prerendered as static content
λ  (Dynamic)  server-rendered on demand using Node.js


Validation complete! (passes locally)
