### PR TITLE
feat: connect monitor lifecycle to deployment events

### DIFF
--- a/src/api/services/monitoring.py
+++ b/src/api/services/monitoring.py
@@ -19,6 +19,37 @@ STALE_THRESHOLD_SECONDS = 120  # Agent is failed after 120s
 HEAL_THRESHOLD_SECONDS = 30  # Heal failed agents after 30s
 
 
+async def _get_latest_deployment(session: AsyncSession, agent_id: uuid.UUID) -> Deployment | None:
+    result = await session.execute(
+        select(Deployment)
+        .where(Deployment.agent_id == agent_id)
+        .order_by(Deployment.created_at.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+def _record_deployment_event(
+    session: AsyncSession,
+    deployment: Deployment,
+    *,
+    event_type: str,
+    status: str,
+    error_message: str | None = None,
+) -> None:
+    from src.api.models import DeploymentEvent
+
+    session.add(
+        DeploymentEvent(
+            deployment_id=deployment.id,
+            event_type=event_type,
+            status=status,
+            node_id=deployment.node_id,
+            error_message=error_message,
+        )
+    )
+
+
 async def monitor_agent_health(session: AsyncSession):
     """
     Main monitoring and self-healing lifecycle:
@@ -50,6 +81,13 @@ async def monitor_agent_health(session: AsyncSession):
                     node_id=f"node-{uuid.uuid4().hex[:6]}",
                 )
                 session.add(deployment)
+                await session.flush()
+                _record_deployment_event(
+                    session,
+                    deployment,
+                    event_type="monitor_started",
+                    status="running",
+                )
 
             logger.info(f"Monitor: Agent {agent.name} ({agent.id}) promoted to RUNNING")
 
@@ -80,6 +118,19 @@ async def monitor_agent_health(session: AsyncSession):
             )
             session.add(log)
 
+            deployment = await _get_latest_deployment(session, agent.id)
+            if deployment is not None:
+                deployment.status = "failed"
+                deployment.ended_at = now
+                deployment.error_message = log.message
+                _record_deployment_event(
+                    session,
+                    deployment,
+                    event_type="monitor_failed",
+                    status="failed",
+                    error_message=log.message,
+                )
+
     # 3. Auto-Heal Failed Agents
     result = await session.execute(select(Agent).where(Agent.status == "failed"))
     failed_agents = result.scalars().all()
@@ -96,7 +147,7 @@ async def monitor_agent_health(session: AsyncSession):
                 .where(
                     Alert.agent_id == agent.id,
                     Alert.type == AlertType.AGENT_DOWN,
-                    not Alert.resolved,
+                    Alert.resolved.is_(False),
                 )
                 .values(resolved=True, resolved_at=now)
             )
@@ -109,5 +160,18 @@ async def monitor_agent_health(session: AsyncSession):
                 timestamp=now,
             )
             session.add(heal_log)
+
+            deployment = await _get_latest_deployment(session, agent.id)
+            if deployment is not None:
+                deployment.status = "running"
+                deployment.started_at = now
+                deployment.ended_at = None
+                deployment.error_message = None
+                _record_deployment_event(
+                    session,
+                    deployment,
+                    event_type="monitor_restarted",
+                    status="running",
+                )
 
     await session.commit()

--- a/tests/api/test_monitoring.py
+++ b/tests/api/test_monitoring.py
@@ -1,0 +1,82 @@
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from src.api.models import AlertType, DeploymentEvent
+from src.api.models.models import AgentStatus
+from src.api.services.monitoring import monitor_agent_health
+
+
+@pytest.mark.asyncio
+async def test_monitor_marks_latest_deployment_failed_on_stale_heartbeat(
+    db_session, test_agent, test_deployment
+):
+    test_agent.status = AgentStatus.RUNNING.value
+    test_agent.last_heartbeat = datetime.utcnow() - timedelta(seconds=121)
+    test_deployment.status = 'running'
+    await db_session.commit()
+
+    await monitor_agent_health(db_session)
+    await db_session.refresh(test_agent)
+    await db_session.refresh(test_deployment)
+
+    assert test_agent.status == AgentStatus.FAILED.value
+    assert test_deployment.status == 'failed'
+    assert test_deployment.error_message is not None
+
+    events = (
+        await db_session.execute(
+            select(DeploymentEvent).where(DeploymentEvent.deployment_id == test_deployment.id)
+        )
+    ).scalars().all()
+    assert any(event.event_type == 'monitor_failed' for event in events)
+
+
+@pytest.mark.asyncio
+async def test_monitor_auto_heal_restores_latest_deployment(db_session, test_agent, test_deployment):
+    test_agent.status = AgentStatus.FAILED.value
+    test_agent.updated_at = datetime.utcnow() - timedelta(seconds=31)
+    test_deployment.status = 'failed'
+    test_deployment.error_message = 'System: Agent marked as FAILED due to heartbeat timeout (120s).'
+    test_deployment.ended_at = datetime.utcnow()
+    await db_session.commit()
+
+    await monitor_agent_health(db_session)
+    await db_session.refresh(test_agent)
+    await db_session.refresh(test_deployment)
+
+    assert test_agent.status == AgentStatus.RUNNING.value
+    assert test_deployment.status == 'running'
+    assert test_deployment.error_message is None
+    assert test_deployment.ended_at is None
+
+    events = (
+        await db_session.execute(
+            select(DeploymentEvent).where(DeploymentEvent.deployment_id == test_deployment.id)
+        )
+    ).scalars().all()
+    assert any(event.event_type == 'monitor_restarted' for event in events)
+
+
+@pytest.mark.asyncio
+async def test_monitor_resolves_agent_down_alerts_on_recovery(db_session, test_agent, test_deployment):
+    from src.api.models.models import Alert
+
+    test_agent.status = AgentStatus.FAILED.value
+    test_agent.updated_at = datetime.utcnow() - timedelta(seconds=31)
+    test_deployment.status = 'failed'
+    alert = Alert(
+        agent_id=test_agent.id,
+        type=AlertType.AGENT_DOWN,
+        message='Agent is down',
+        resolved=False,
+    )
+    db_session.add(alert)
+    await db_session.commit()
+
+    await monitor_agent_health(db_session)
+    await db_session.refresh(alert)
+
+    assert alert.resolved is True
+    assert alert.resolved_at is not None


### PR DESCRIPTION
## What changed?

- updated `src/api/services/monitoring.py` so the monitor now updates the latest deployment record when an agent is marked failed or auto-healed
- recorded `monitor_started`, `monitor_failed`, and `monitor_restarted` deployment events from the monitor loop
- added focused tests proving stale heartbeat failure updates deployments, recovery restores deployments, and AGENT_DOWN alerts resolve on recovery

## Why?

- issue #39 calls for monitoring and self-healing paths to connect to actual runtime records instead of only mutating in-memory or agent-only status
- this lands a small truthful slice that makes monitor actions visible in deployment history

## Validation

- `/Users/fortune/MUTX/.venv/bin/ruff check src/api/services/monitoring.py tests/api/test_monitoring.py`
- `/Users/fortune/MUTX/.venv/bin/python -m pytest tests/api/test_monitoring.py -q`
- `python3 -m compileall src/api/services/monitoring.py`
