### PR TITLE
feat(cli/sdk): align deployment create with canonical and live routes

### DIFF
--- a/cli/commands/deploy.py
+++ b/cli/commands/deploy.py
@@ -56,9 +56,16 @@ def list_deployments(limit: int, skip: int, agent_id: Optional[str], status: Opt
     "--replicas",
     "-r",
     default=1,
-    help="Requested replica count. Current backend deploy route always starts with 1 replica.",
+    help="Requested replica count. Supported via /deployments create route.",
 )
-def create_deployment(agent_id: str, replicas: int):
+@click.option(
+    "--route",
+    type=click.Choice(["deployments", "agent"], case_sensitive=False),
+    default="deployments",
+    show_default=True,
+    help="Backend route to use: canonical /deployments or legacy/live /agents/{agent_id}/deploy.",
+)
+def create_deployment(agent_id: str, replicas: int, route: str):
     """Create a new deployment"""
     config = CLIConfig()
     if not config.is_authenticated():
@@ -66,19 +73,24 @@ def create_deployment(agent_id: str, replicas: int):
         return
 
     client = get_client(config)
-    response = client.post(f"/agents/{agent_id}/deploy")
+
+    if route == "deployments":
+        response = client.post("/deployments", json={"agent_id": agent_id, "replicas": replicas})
+    else:
+        response = client.post(f"/agents/{agent_id}/deploy")
 
     if response.status_code == 401:
         click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
         return
 
-    if response.status_code == 200:
+    if response.status_code in (200, 201):
         result = response.json()
-        click.echo(f"Created deployment: {result.get('deployment_id')}")
+        deployment_id = result.get("deployment_id") or result.get("id")
+        click.echo(f"Created deployment: {deployment_id}")
         click.echo(f"Status: {result.get('status')}")
-        if replicas != 1:
+        if route == "agent" and replicas != 1:
             click.echo(
-                "Note: the current backend deploy route ignores --replicas and starts with 1 replica.",
+                "Note: /agents/{agent_id}/deploy currently ignores --replicas and starts with 1 replica.",
                 err=True,
             )
     elif response.status_code == 404:

--- a/sdk/mutx/deployments.py
+++ b/sdk/mutx/deployments.py
@@ -28,12 +28,23 @@ class Deployments:
         self._client = client
 
     def create(self, agent_id: UUID | str, replicas: int = 1) -> Deployment:
+        """Create a deployment via /deployments (canonical backend route)."""
         response = self._client.post(
             "/deployments",
             json={"agent_id": str(agent_id), "replicas": replicas},
         )
         response.raise_for_status()
         return Deployment(response.json())
+
+    def create_for_agent(self, agent_id: UUID | str) -> dict[str, Any]:
+        """Create deployment via legacy/live route /agents/{agent_id}/deploy.
+
+        This endpoint currently returns a lightweight payload:
+        {"deployment_id": ..., "status": ...}
+        """
+        response = self._client.post(f"/agents/{agent_id}/deploy")
+        response.raise_for_status()
+        return response.json()
 
     def list(
         self,


### PR DESCRIPTION
## Summary
- add CLI route selection for `mutx deploy create` to support both backend create paths
- default to canonical `/deployments` route so `--replicas` is honored
- keep compatibility with live legacy route `/agents/{agent_id}/deploy`
- add SDK helper `Deployments.create_for_agent()` for legacy/live route parity

## Why
Backend currently exposes both deployment create routes with different payload shapes. This keeps CLI/SDK aligned with live backend behavior while preserving backwards compatibility.

## Changes
- `cli/commands/deploy.py`
  - `mutx deploy create` now accepts `--route [deployments|agent]`
  - default route is `deployments`
  - handles both response schemas: `{id,...}` and `{deployment_id,...}`
- `sdk/mutx/deployments.py`
  - add `create_for_agent(agent_id)` for `/agents/{agent_id}/deploy`

## Validation
- `python -m pytest tests/api/test_agents.py -q` ✅
- `python -m pytest tests/api/test_deployments.py -q` ✅
- `python -m ruff check cli sdk/mutx` ✅

## Notes
- Existing `agents.deploy()` and `deploy create --route agent` remain compatible with current live behavior.
