### PR TITLE
feat: add deployment event history endpoint

### DIFF
--- a/src/api/routes/deployments.py
+++ b/src/api/routes/deployments.py
@@ -22,6 +22,7 @@ from src.api.models.schemas import (
     DeploymentResponse,
     DeploymentScale,
     DeploymentCreate,
+    DeploymentEventResponse,
     DeploymentLogsResponse,
     DeploymentMetricsResponse,
 )
@@ -142,6 +143,32 @@ async def get_deployment(
 ):
     deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
     return _serialize_deployment(deployment)
+
+
+@router.get("/{deployment_id}/events", response_model=list[DeploymentEventResponse])
+async def get_deployment_events(
+    deployment_id: uuid.UUID,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=500),
+    event_type: Optional[str] = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get lifecycle events for a specific deployment."""
+    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+
+    query = (
+        select(DeploymentEventModel)
+        .where(DeploymentEventModel.deployment_id == deployment.id)
+        .order_by(DeploymentEventModel.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+    )
+    if event_type:
+        query = query.where(DeploymentEventModel.event_type == event_type)
+
+    result = await db.execute(query)
+    return result.scalars().all()
 
 
 @router.post("/{deployment_id}/scale", response_model=DeploymentResponse)

--- a/tests/api/test_deployments.py
+++ b/tests/api/test_deployments.py
@@ -5,7 +5,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.models.models import Agent, Deployment, AgentStatus
+from src.api.models.models import Agent, Deployment, AgentStatus, DeploymentEvent
 
 
 class TestListDeployments:
@@ -191,6 +191,62 @@ class TestScaleDeployment:
             f"/deployments/{test_deployment.id}/scale",
             json={"replicas": 5},
         )
+        assert response.status_code == 403
+
+
+class TestDeploymentEvents:
+    """Tests for GET /deployments/{deployment_id}/events endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_deployment_events_success(
+        self, client: AsyncClient, test_deployment, db_session: AsyncSession
+    ):
+        event = DeploymentEvent(
+            deployment_id=test_deployment.id,
+            event_type="scale",
+            status=test_deployment.status,
+            node_id="node-123",
+        )
+        db_session.add(event)
+        await db_session.commit()
+
+        response = await client.get(f"/deployments/{test_deployment.id}/events")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["event_type"] == "scale"
+
+    @pytest.mark.asyncio
+    async def test_get_deployment_events_filter_by_type(
+        self, client: AsyncClient, test_deployment, db_session: AsyncSession
+    ):
+        db_session.add_all(
+            [
+                DeploymentEvent(
+                    deployment_id=test_deployment.id,
+                    event_type="scale",
+                    status=test_deployment.status,
+                ),
+                DeploymentEvent(
+                    deployment_id=test_deployment.id,
+                    event_type="restart",
+                    status="pending",
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/deployments/{test_deployment.id}/events?event_type=restart")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["event_type"] == "restart"
+
+    @pytest.mark.asyncio
+    async def test_get_deployment_events_other_user_forbidden(
+        self, other_user_client: AsyncClient, test_deployment
+    ):
+        response = await other_user_client.get(f"/deployments/{test_deployment.id}/events")
         assert response.status_code == 403
 
 


### PR DESCRIPTION
## What changed?

- added `GET /deployments/{deployment_id}/events` to expose deployment lifecycle history as a first-class API surface
- added optional `event_type`, `skip`, and `limit` query support for deployment event retrieval
- added focused deployment API tests for event listing, type filtering, and cross-user denial

## Why?

- issue #66 calls for real deployment lifecycle and event history instead of only embedding events opportunistically in larger payloads
- this is the smallest reviewable slice that gives operators a direct history endpoint today

## Validation

- `/Users/fortune/MUTX/.venv/bin/ruff check src/api/routes/deployments.py tests/api/test_deployments.py`
- `/Users/fortune/MUTX/.venv/bin/python -m pytest tests/api/test_deployments.py -q`
- `python3 -m compileall src/api/routes/deployments.py`
