### PR TITLE
feat(infra): integrate Alertmanager and replace static Ansible inventory

### DIFF
--- a/infrastructure/Makefile
+++ b/infrastructure/Makefile
@@ -49,6 +49,12 @@ ansible-lint:
 ansible-inventory:
 	./scripts/generate-inventory.sh
 
+ansible-provision: ansible-inventory
+	cd $(ANSIBLE_DIR) && ansible-playbook -i inventory.generated.ini playbooks/provision.yml
+
+ansible-deploy-agent: ansible-inventory
+	cd $(ANSIBLE_DIR) && ansible-playbook -i inventory.generated.ini playbooks/deploy-agent.yml
+
 monitor-up:
 	cd .. && ./start-monitoring.sh
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -37,9 +37,9 @@ terraform apply -var-file=environments/production/terraform.tfvars
 ## Ansible Provisioning
 
 ```bash
-cd infrastructure/ansible
-ansible-playbook -i inventory.ini playbooks/provision.yml
-ansible-playbook -i inventory.ini playbooks/deploy-agent.yml
+cd infrastructure
+make ansible-provision
+make ansible-deploy-agent
 ```
 
 Install Ansible collections and lint before applying:

--- a/infrastructure/docker/docker-compose.monitoring.yml
+++ b/infrastructure/docker/docker-compose.monitoring.yml
@@ -26,6 +26,21 @@ services:
       timeout: 10s
       retries: 5
 
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: mutx-alertmanager
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+    ports:
+      - "127.0.0.1:${ALERTMANAGER_PORT:-9093}:9093"
+    volumes:
+      - ./infrastructure/monitoring/prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager_data:/alertmanager
+    restart: unless-stopped
+    networks:
+      - monitoring
+
   grafana:
     image: grafana/grafana:11.2.2
     container_name: mutx-grafana
@@ -122,6 +137,7 @@ services:
 volumes:
   prometheus_data:
   grafana_data:
+  alertmanager_data:
   redis_data:
   postgres_data:
 

--- a/infrastructure/monitoring/prometheus/alertmanager.yml
+++ b/infrastructure/monitoring/prometheus/alertmanager.yml
@@ -1,0 +1,16 @@
+route:
+  group_by: ['alertname']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 1h
+  receiver: 'web.hook'
+receivers:
+  - name: 'web.hook'
+    webhook_configs:
+      - url: 'http://127.0.0.1:5001/'
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['alertname', 'dev', 'instance']

--- a/infrastructure/monitoring/prometheus/prometheus.yml
+++ b/infrastructure/monitoring/prometheus/prometheus.yml
@@ -8,6 +8,11 @@ global:
 rule_files:
   - /etc/prometheus/alerts.yml
 
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
 scrape_configs:
   - job_name: 'prometheus'
     static_configs:


### PR DESCRIPTION
## Summary
- Wires Alertmanager into Prometheus configuration for monitoring self-healing alerts
- Replaces static inventory with Terraform-generated inventory by default in Ansible playbook wrappers (via Makefile updates)
- Updates `docker-compose.monitoring.yml` to run the Alertmanager service
- Resolves hardened README.md next items

@codex please review