### PR TITLE
fix(api): typed agent config instead of string blobs

### DIFF
--- a/src/api/models/schemas.py
+++ b/src/api/models/schemas.py
@@ -44,7 +44,7 @@ class AgentCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
     description: Optional[str] = Field(None, max_length=1000)
     type: AgentType = Field(default=AgentType.OPENAI)
-    config: Optional[dict[str, Any] | str] = None
+    config: Optional[dict[str, Any]] = None
     # user_id is set from current_user in the route, not from request body
 
 
@@ -117,7 +117,7 @@ class AgentResponse(BaseModel):
     name: str
     description: Optional[str]
     status: str
-    config: Optional[str]
+    config: Optional[dict[str, Any]]
     created_at: datetime
     updated_at: datetime
     user_id: uuid.UUID

--- a/src/api/routes/agents.py
+++ b/src/api/routes/agents.py
@@ -95,12 +95,21 @@ def _serialize_deployment(deployment: Deployment):
 
 
 def _serialize_agent(agent: Agent, include_deployments: bool = False):
+    config_dict = None
+    if agent.config:
+        try:
+            config_dict = (
+                json.loads(agent.config) if isinstance(agent.config, str) else agent.config
+            )
+        except json.JSONDecodeError:
+            config_dict = {"raw_config": agent.config}
+
     payload = {
         "id": agent.id,
         "name": agent.name,
         "description": agent.description,
         "status": agent.status,
-        "config": agent.config,
+        "config": config_dict,
         "created_at": agent.created_at,
         "updated_at": agent.updated_at,
         "user_id": agent.user_id,

--- a/tests/api/test_agents.py
+++ b/tests/api/test_agents.py
@@ -1,9 +1,8 @@
 """
 Tests for /agents endpoints.
 """
-import json
+
 import pytest
-import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,7 +11,7 @@ from src.api.models.models import Agent, AgentStatus
 
 class TestCreateAgent:
     """Tests for POST /agents endpoint."""
-    
+
     @pytest.mark.asyncio
     async def test_create_agent_success(self, client: AsyncClient, test_user):
         """Test creating an agent successfully."""
@@ -30,9 +29,9 @@ class TestCreateAgent:
         assert data["name"] == "new-agent"
         assert data["description"] == "A new test agent"
         assert data["status"] == "creating"
-        
+
         # Verify validated config
-        config = json.loads(data["config"])
+        config = data["config"]
         assert config["model"] == "gpt-4o"
         assert config["temperature"] == 0.7
         assert "id" in data
@@ -50,7 +49,7 @@ class TestCreateAgent:
         )
         assert response.status_code == 400
         assert "Configuration validation failed" in response.json()["detail"]
-    
+
     @pytest.mark.asyncio
     async def test_create_agent_with_minimal_data(self, client: AsyncClient):
         """Test creating an agent with minimal data."""
@@ -67,25 +66,23 @@ class TestCreateAgent:
 
 class TestListAgents:
     """Tests for GET /agents endpoint."""
-    
+
     @pytest.mark.asyncio
     async def test_list_agents_empty(self, client: AsyncClient):
         """Test listing agents when none exist."""
         response = await client.get("/agents")
         assert response.status_code == 200
         assert response.json() == []
-    
+
     @pytest.mark.asyncio
-    async def test_list_agents_with_data(
-        self, client: AsyncClient, test_agent
-    ):
+    async def test_list_agents_with_data(self, client: AsyncClient, test_agent):
         """Test listing agents returns user's agents."""
         response = await client.get("/agents")
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 1
         assert data[0]["id"] == str(test_agent.id)
-    
+
     @pytest.mark.asyncio
     async def test_list_agents_pagination(
         self, client: AsyncClient, db_session: AsyncSession, test_user
@@ -102,12 +99,12 @@ class TestListAgents:
             )
             db_session.add(agent)
         await db_session.commit()
-        
+
         response = await client.get("/agents?limit=2")
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 2
-    
+
     @pytest.mark.asyncio
     async def test_list_agents_by_user_id(
         self, client: AsyncClient, test_agent, other_user_client: AsyncClient
@@ -116,7 +113,7 @@ class TestListAgents:
         # Test user can see their own agents
         response = await client.get("/agents")
         assert len(response.json()) == 1
-        
+
         # Other user sees empty list
         response = await other_user_client.get("/agents")
         assert len(response.json()) == 0
@@ -124,26 +121,22 @@ class TestListAgents:
 
 class TestGetAgent:
     """Tests for GET /agents/{agent_id} endpoint."""
-    
+
     @pytest.mark.asyncio
-    async def test_get_agent_success(
-        self, client: AsyncClient, test_agent
-    ):
+    async def test_get_agent_success(self, client: AsyncClient, test_agent):
         """Test getting a specific agent."""
         response = await client.get(f"/agents/{test_agent.id}")
         assert response.status_code == 200
         data = response.json()
         assert data["id"] == str(test_agent.id)
         assert data["name"] == test_agent.name
-    
+
     @pytest.mark.asyncio
     async def test_get_agent_not_found(self, client: AsyncClient):
         """Test getting non-existent agent returns 404."""
-        response = await client.get(
-            "/agents/00000000-0000-0000-0000-999999999999"
-        )
+        response = await client.get("/agents/00000000-0000-0000-0000-999999999999")
         assert response.status_code == 404
-    
+
     @pytest.mark.asyncio
     async def test_get_agent_other_user_forbidden(
         self, client: AsyncClient, test_agent, other_user_client: AsyncClient
@@ -155,7 +148,7 @@ class TestGetAgent:
 
 class TestDeleteAgent:
     """Tests for DELETE /agents/{agent_id} endpoint."""
-    
+
     @pytest.mark.asyncio
     async def test_delete_agent_success(
         self, client: AsyncClient, db_session: AsyncSession, test_user
@@ -172,18 +165,16 @@ class TestDeleteAgent:
         db_session.add(agent)
         await db_session.commit()
         await db_session.refresh(agent)
-        
+
         response = await client.delete(f"/agents/{agent.id}")
         assert response.status_code == 204
-    
+
     @pytest.mark.asyncio
     async def test_delete_agent_not_found(self, client: AsyncClient):
         """Test deleting non-existent agent returns 404."""
-        response = await client.delete(
-            "/agents/00000000-0000-0000-0000-999999999999"
-        )
+        response = await client.delete("/agents/00000000-0000-0000-0000-999999999999")
         assert response.status_code == 404
-    
+
     @pytest.mark.asyncio
     async def test_delete_agent_other_user_forbidden(
         self, client: AsyncClient, test_agent, other_user_client: AsyncClient
@@ -195,7 +186,7 @@ class TestDeleteAgent:
 
 class TestDeployAgent:
     """Tests for POST /agents/{agent_id}/deploy endpoint."""
-    
+
     @pytest.mark.asyncio
     async def test_deploy_agent_success(
         self, client: AsyncClient, test_agent, db_session: AsyncSession
@@ -206,33 +197,29 @@ class TestDeployAgent:
         data = response.json()
         assert "deployment_id" in data
         assert data["status"] == "deploying"
-        
+
         # Verify agent status changed
         await db_session.refresh(test_agent)
         assert test_agent.status == AgentStatus.RUNNING
-    
+
     @pytest.mark.asyncio
     async def test_deploy_agent_not_found(self, client: AsyncClient):
         """Test deploying non-existent agent returns 404."""
-        response = await client.post(
-            "/agents/00000000-0000-0000-0000-999999999999/deploy"
-        )
+        response = await client.post("/agents/00000000-0000-0000-0000-999999999999/deploy")
         assert response.status_code == 404
-    
+
     @pytest.mark.asyncio
     async def test_deploy_agent_other_user_forbidden(
         self, client: AsyncClient, test_agent, other_user_client: AsyncClient
     ):
         """Test that users cannot deploy other users' agents."""
-        response = await other_user_client.post(
-            f"/agents/{test_agent.id}/deploy"
-        )
+        response = await other_user_client.post(f"/agents/{test_agent.id}/deploy")
         assert response.status_code == 403
 
 
 class TestStopAgent:
     """Tests for POST /agents/{agent_id}/stop endpoint."""
-    
+
     @pytest.mark.asyncio
     async def test_stop_agent_success(
         self, client: AsyncClient, test_agent, test_deployment, db_session: AsyncSession
@@ -242,41 +229,35 @@ class TestStopAgent:
         test_agent.status = AgentStatus.RUNNING
         test_deployment.status = "running"
         await db_session.commit()
-        
+
         response = await client.post(f"/agents/{test_agent.id}/stop")
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "stopped"
-    
+
     @pytest.mark.asyncio
     async def test_stop_agent_not_found(self, client: AsyncClient):
         """Test stopping non-existent agent returns 404."""
-        response = await client.post(
-            "/agents/00000000-0000-0000-0000-999999999999/stop"
-        )
+        response = await client.post("/agents/00000000-0000-0000-0000-999999999999/stop")
         assert response.status_code == 404
 
 
 class TestAgentLogs:
     """Tests for GET /agents/{agent_id}/logs endpoint."""
-    
+
     @pytest.mark.asyncio
-    async def test_get_agent_logs_success(
-        self, client: AsyncClient, test_agent
-    ):
+    async def test_get_agent_logs_success(self, client: AsyncClient, test_agent):
         """Test getting agent logs."""
         response = await client.get(f"/agents/{test_agent.id}/logs")
         assert response.status_code == 200
         assert isinstance(response.json(), list)
-    
+
     @pytest.mark.asyncio
     async def test_get_agent_logs_not_found(self, client: AsyncClient):
         """Test getting logs for non-existent agent returns 404."""
-        response = await client.get(
-            "/agents/00000000-0000-0000-0000-999999999999/logs"
-        )
+        response = await client.get("/agents/00000000-0000-0000-0000-999999999999/logs")
         assert response.status_code == 404
-    
+
     @pytest.mark.asyncio
     async def test_get_agent_logs_other_user_forbidden(
         self, client: AsyncClient, test_agent, other_user_client: AsyncClient
@@ -288,11 +269,9 @@ class TestAgentLogs:
 
 class TestAgentMetrics:
     """Tests for GET /agents/{agent_id}/metrics endpoint."""
-    
+
     @pytest.mark.asyncio
-    async def test_get_agent_metrics_success(
-        self, client: AsyncClient, test_agent
-    ):
+    async def test_get_agent_metrics_success(self, client: AsyncClient, test_agent):
         """Test getting agent metrics."""
         response = await client.get(f"/agents/{test_agent.id}/metrics")
         assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Changed `AgentCreate` and `AgentResponse` in `schemas.py` to use `dict[str, Any]` instead of a string blob for config.
- Updated `_serialize_agent` in `agents.py` to deserialize `agent.config` before embedding in API responses.
- Updated `test_agents.py` to expect a JSON object instead of a string for `config`.

Resolves #67

@codex please review.