### PR TITLE
fix: align cli and sdk agent config contract

### DIFF
--- a/cli/commands/agents.py
+++ b/cli/commands/agents.py
@@ -43,7 +43,7 @@ def list_agents(limit: int, skip: int):
 @agents_group.command(name="create")
 @click.option("--name", "-n", required=True, help="Agent name")
 @click.option("--description", "-d", default="", help="Agent description")
-@click.option("--config", "-c", default="{}", help="Agent config as JSON string")
+@click.option("--config", "-c", default="{}", help="Agent config as JSON object string")
 def create_agent(name: str, description: str, config: str):
     """Create a new agent"""
     cli_config = CLIConfig()
@@ -54,9 +54,8 @@ def create_agent(name: str, description: str, config: str):
     import json
 
     try:
-        # Validate JSON but send as string to match API schema
+        # Validate JSON locally; backend accepts dict or string and normalizes it.
         config_json = json.loads(config)
-        config_str = json.dumps(config_json)
     except json.JSONDecodeError:
         click.echo("Error: Invalid JSON in config", err=True)
         return
@@ -67,7 +66,7 @@ def create_agent(name: str, description: str, config: str):
         json={
             "name": name,
             "description": description,
-            "config": config_str,
+            "config": config_json,
         },
     )
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,19 @@
+# mutx Python SDK
+
+Python SDK for mutx.dev.
+
+## Install
+
+```bash
+pip install mutx
+```
+
+## Usage
+
+```python
+from mutx import MutxClient
+
+with MutxClient(api_key="your-api-key") as client:
+    agents = client.agents.list()
+    print(agents)
+```

--- a/sdk/mutx/__init__.py
+++ b/sdk/mutx/__init__.py
@@ -177,5 +177,7 @@ __all__ = [
     "AgentMetrics",
     "APIKeys",
     "ClawHub",
+    "Deployments",
+    "Webhooks",
     "create_agent_client",
 ]

--- a/sdk/mutx/agents.py
+++ b/sdk/mutx/agents.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import Any, Callable, Generator, Optional
 from uuid import UUID
@@ -13,11 +14,22 @@ class Agent:
         self.name = data["name"]
         self.description = data.get("description")
         self.status = data["status"]
-        self.config = data.get("config")
+        self.config_json = data.get("config")
+        self.config = self._parse_config(self.config_json)
         self.created_at = datetime.fromisoformat(data["created_at"])
         self.updated_at = datetime.fromisoformat(data["updated_at"])
         self.user_id = data.get("user_id")
         self._data = data
+
+    @staticmethod
+    def _parse_config(raw_config: Any) -> Any:
+        if not isinstance(raw_config, str):
+            return raw_config
+
+        try:
+            return json.loads(raw_config)
+        except json.JSONDecodeError:
+            return raw_config
 
     def __repr__(self) -> str:
         return f"Agent(id={self.id}, name={self.name}, status={self.status})"
@@ -71,7 +83,7 @@ class Agents:
         self,
         name: str,
         description: Optional[str] = None,
-        config: Optional[str] = None,
+        config: Optional[dict[str, Any] | str] = None,
     ) -> Agent:
         response = self._client.post(
             "/agents",

--- a/tests/test_sdk_agent_config_contract.py
+++ b/tests/test_sdk_agent_config_contract.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sdk"))
+
+from mutx import Deployments, Webhooks
+from mutx.agents import Agent, Agents
+
+
+def _agent_payload(config: Any = None, **overrides: Any) -> dict[str, Any]:
+    payload = {
+        "id": str(uuid.uuid4()),
+        "name": "test-agent",
+        "description": "sdk contract test",
+        "status": "creating",
+        "config": json.dumps(config if config is not None else {"model": "gpt-4o"}),
+        "created_at": "2026-03-12T09:00:00",
+        "updated_at": "2026-03-12T09:00:00",
+        "user_id": str(uuid.uuid4()),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_agent_parses_stringified_config_into_config_json_and_dict_alias() -> None:
+    raw_config = {"model": "gpt-4o-mini", "temperature": 0.2}
+
+    agent = Agent(_agent_payload(config=raw_config))
+
+    assert agent.config == raw_config
+    assert agent.config_json == json.dumps(raw_config)
+    assert agent._data["config"] == agent.config_json
+
+
+def test_agents_create_accepts_dict_config_and_sends_backend_json_string_contract() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["json"] = json.loads(request.content.decode())
+        return httpx.Response(201, json=_agent_payload(config={"model": "gpt-4o"}))
+
+    client = httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler))
+    agents = Agents(client)
+
+    agents.create(
+        name="demo",
+        description="test",
+        config={"model": "gpt-4o", "temperature": 0.1},
+    )
+
+    assert captured["path"] == "/agents"
+    assert isinstance(captured["json"]["config"], dict)
+    assert captured["json"]["config"]["model"] == "gpt-4o"
+
+
+def test_agents_create_accepts_json_string_config_and_preserves_it() -> None:
+    captured: dict[str, Any] = {}
+    raw_json = json.dumps({"model": "gpt-4o-mini", "temperature": 0.3})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["json"] = json.loads(request.content.decode())
+        return httpx.Response(201, json=_agent_payload(config=json.loads(raw_json)))
+
+    client = httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler))
+    agents = Agents(client)
+
+    agents.create(name="demo", config=raw_json)
+
+    assert captured["json"]["config"] == raw_json
+
+
+def test_top_level_sdk_exports_include_deployments_and_webhooks() -> None:
+    assert Deployments is not None
+    assert Webhooks is not None


### PR DESCRIPTION
## Summary\n- align CLI agent create payloads with the live backend contract by sending parsed JSON objects instead of re-stringifying config\n- make SDK Agent normalize stringified backend config into  (dict when JSON) while preserving raw \n- export  and  from the top-level SDK and add the missing  so editable SDK installs work\n- add focused SDK contract tests for agent config parsing/creation and top-level exports\n\n## Validation\n- .......                                                                  [100%]
7 passed in 0.01s\n- All checks passed!\n