### PR TITLE
fix: harden webhook ownership responses

### DIFF
--- a/src/api/routes/webhooks.py
+++ b/src/api/routes/webhooks.py
@@ -19,6 +19,25 @@ router = APIRouter(prefix="/webhooks", tags=["webhooks"])
 logger = logging.getLogger(__name__)
 
 
+async def _get_owned_webhook(
+    webhook_id: uuid.UUID,
+    db: AsyncSession,
+    current_user: User,
+    *,
+    not_found_detail: str = "Webhook not found",
+    forbidden_detail: str = "Not authorized to access this webhook",
+) -> Webhook:
+    result = await db.execute(select(Webhook).where(Webhook.id == webhook_id))
+    webhook = result.scalar_one_or_none()
+
+    if not webhook:
+        raise HTTPException(status_code=404, detail=not_found_detail)
+    if webhook.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail=forbidden_detail)
+
+    return webhook
+
+
 async def get_webhook_auth(
     authorization: Optional[str] = Header(None, description="Bearer token for JWT auth"),
     x_api_key: Optional[str] = Header(
@@ -96,14 +115,7 @@ async def get_webhook(
     current_user: User = Depends(get_webhook_auth),
 ):
     """Get a specific webhook by ID."""
-    result = await db.execute(
-        select(Webhook).where(Webhook.id == webhook_id, Webhook.user_id == current_user.id)
-    )
-    webhook = result.scalar_one_or_none()
-
-    if not webhook:
-        raise HTTPException(status_code=404, detail="Webhook not found")
-
+    webhook = await _get_owned_webhook(webhook_id, db, current_user)
     return webhook
 
 
@@ -115,13 +127,7 @@ async def update_webhook(
     current_user: User = Depends(get_webhook_auth),
 ):
     """Update an existing webhook."""
-    result = await db.execute(
-        select(Webhook).where(Webhook.id == webhook_id, Webhook.user_id == current_user.id)
-    )
-    webhook = result.scalar_one_or_none()
-
-    if not webhook:
-        raise HTTPException(status_code=404, detail="Webhook not found")
+    webhook = await _get_owned_webhook(webhook_id, db, current_user)
 
     # Update fields if provided
     if webhook_data.url is not None:
@@ -163,13 +169,7 @@ async def delete_webhook(
     current_user: User = Depends(get_webhook_auth),
 ):
     """Delete a webhook."""
-    result = await db.execute(
-        select(Webhook).where(Webhook.id == webhook_id, Webhook.user_id == current_user.id)
-    )
-    webhook = result.scalar_one_or_none()
-
-    if not webhook:
-        raise HTTPException(status_code=404, detail="Webhook not found")
+    webhook = await _get_owned_webhook(webhook_id, db, current_user)
 
     await db.delete(webhook)
     await db.commit()
@@ -185,13 +185,7 @@ async def test_webhook(
     current_user: User = Depends(get_webhook_auth),
 ):
     """Send a test event to a webhook to verify it's working."""
-    result = await db.execute(
-        select(Webhook).where(Webhook.id == webhook_id, Webhook.user_id == current_user.id)
-    )
-    webhook = result.scalar_one_or_none()
-
-    if not webhook:
-        raise HTTPException(status_code=404, detail="Webhook not found")
+    webhook = await _get_owned_webhook(webhook_id, db, current_user)
 
     # Import the delivery function
     from src.api.services.webhook_service import deliver_webhook_with_retry

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -1,6 +1,5 @@
 import pytest
 from httpx import AsyncClient
-import uuid
 
 @pytest.mark.asyncio
 async def test_webhook_lifecycle(client: AsyncClient, test_user):
@@ -49,11 +48,40 @@ async def test_webhook_lifecycle(client: AsyncClient, test_user):
     assert response.status_code == 404
 
 @pytest.mark.asyncio
-async def test_webhook_unauthorized(client: AsyncClient):
-    # Logout or use unauthenticated client
-    # Note: client is likely pre-authenticated in these tests based on test_agents.py
-    # But usually there's a way to test unauth.
-    pass
+async def test_webhook_unauthorized(client_no_auth: AsyncClient):
+    response = await client_no_auth.get("/webhooks/")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_webhook_other_user_forbidden(
+    client: AsyncClient, other_user_client: AsyncClient, test_user
+):
+    response = await client.post(
+        "/webhooks/",
+        json={
+            "url": "https://example.com/webhook",
+            "events": ["agent.*"],
+            "secret": "test-secret",
+        },
+    )
+    assert response.status_code == 201
+    webhook_id = response.json()["id"]
+
+    get_response = await other_user_client.get(f"/webhooks/{webhook_id}")
+    assert get_response.status_code == 403
+
+    patch_response = await other_user_client.patch(
+        f"/webhooks/{webhook_id}",
+        json={"url": "https://example.com/hijacked"},
+    )
+    assert patch_response.status_code == 403
+
+    delete_response = await other_user_client.delete(f"/webhooks/{webhook_id}")
+    assert delete_response.status_code == 403
+
+    test_response = await other_user_client.post(f"/webhooks/{webhook_id}/test")
+    assert test_response.status_code == 403
 
 @pytest.mark.asyncio
 async def test_webhook_test_trigger(client: AsyncClient, test_user, monkeypatch):


### PR DESCRIPTION
## What changed?

- added a shared `_get_owned_webhook()` helper so webhook management routes distinguish not-found from cross-user access
- updated get, patch, delete, and test-webhook routes to enforce ownership consistently
- replaced the placeholder unauthorized webhook test with real auth coverage and added cross-user ownership checks

## Why?

- this tightens auth/ownership behavior on `/webhooks` without changing the broader contract surface
- it closes a small but real drift where other routes return explicit 403s for чужой resources while webhooks were silently 404ing on ownership failures

## Validation

- `.venv/bin/ruff check src/api/routes/webhooks.py tests/api/test_webhooks.py`
- `.venv/bin/python -m pytest tests/api/test_webhooks.py::test_webhook_unauthorized tests/api/test_webhooks.py::test_webhook_other_user_forbidden -q`
- `python3 -m compileall src/api/routes/webhooks.py`

## Notes

- full `tests/api/test_webhooks.py -q` still hits the existing in-memory SQLite fixture issue (`no such table: users`) during `test_webhook_lifecycle`; that is pre-existing and not introduced by this PR.
