### PR TITLE
fix(runtime): emit heartbeat webhooks from live agent path

### DIFF
--- a/docs/architecture/agent-runtime.md
+++ b/docs/architecture/agent-runtime.md
@@ -2,6 +2,15 @@
 
 This document describes how agents run in mutx.dev, including their lifecycle, monitoring, and self-healing capabilities.
 
+## What is active today
+
+- `POST /agents/heartbeat` is the live runtime path for connected agents. It updates `agents.status` and `last_heartbeat` in the control plane.
+- Each runtime heartbeat now emits an `agent.heartbeat` outgoing webhook event for subscribers.
+- When a heartbeat changes the persisted agent status, MUTX also emits an `agent.status` outgoing webhook event.
+- The background monitor in `src/api/services/monitoring.py` still owns stale-agent detection, failure marking, alert resolution, and automatic recovery.
+- More advanced self-healing components remain partially aspirational until they are connected to real schedulers/executors.
+
+
 ---
 
 ## Overview

--- a/src/api/routes/agent_runtime.py
+++ b/src/api/routes/agent_runtime.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.api.database import get_db
 from src.api.middleware.auth import get_current_agent, get_current_user
 from src.api.models import Agent, AgentLog, AgentMetric, AgentStatus, Command, User
+from src.api.services.webhook_service import trigger_webhook_event
 
 logger = logging.getLogger(__name__)
 
@@ -175,10 +176,43 @@ async def heartbeat(
         raise HTTPException(status_code=403, detail="Agent ID mismatch")
 
     # Update agent status and last heartbeat
+    previous_status = agent.status
+    now = datetime.utcnow()
     agent.status = request.status
-    agent.last_heartbeat = datetime.utcnow()
+    agent.last_heartbeat = now
 
     await db.commit()
+
+    await trigger_webhook_event(
+        db,
+        "agent.heartbeat",
+        {
+            "agent_id": str(agent.id),
+            "agent_name": agent.name,
+            "status": agent.status,
+            "previous_status": previous_status,
+            "message": request.message,
+            "platform": request.platform,
+            "hostname": request.hostname,
+            "timestamp": now.isoformat(),
+        },
+    )
+
+    if previous_status != agent.status:
+        await trigger_webhook_event(
+            db,
+            "agent.status",
+            {
+                "agent_id": str(agent.id),
+                "agent_name": agent.name,
+                "old_status": previous_status,
+                "new_status": agent.status,
+                "message": request.message,
+                "platform": request.platform,
+                "hostname": request.hostname,
+                "timestamp": now.isoformat(),
+            },
+        )
 
     return {
         "status": "ok",

--- a/tests/api/test_ingest.py
+++ b/tests/api/test_ingest.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from httpx import AsyncClient
 from src.api.models.models import AgentStatus
@@ -56,3 +58,85 @@ async def test_ingest_unauthorized_agent(client: AsyncClient, test_user):
     )
     # Since agent_id doesn't exist in DB, it should be 404
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_heartbeat_triggers_heartbeat_webhook_without_status_change(
+    client: AsyncClient, db_session, test_agent, monkeypatch
+):
+    from src.api.models.models import AgentStatus
+    from src.api.routes.agent_runtime import get_current_agent
+    import src.api.routes.agent_runtime as agent_runtime_routes
+
+    test_agent.status = AgentStatus.RUNNING.value
+    await db_session.commit()
+
+    delivered: list[tuple[str, dict]] = []
+
+    async def mock_trigger_webhook_event(db, event, payload):
+        delivered.append((event, payload))
+        return 1
+
+    monkeypatch.setattr(agent_runtime_routes, "trigger_webhook_event", mock_trigger_webhook_event)
+    client.app.dependency_overrides[get_current_agent] = lambda: test_agent
+
+    response = await client.post(
+        "/agents/heartbeat",
+        json={
+            "agent_id": str(test_agent.id),
+            "status": "running",
+            "message": "still alive",
+            "platform": "linux",
+            "hostname": "agent-01",
+            "timestamp": datetime.utcnow().isoformat(),
+        },
+    )
+
+    assert response.status_code == 200
+    assert [event for event, _ in delivered] == ["agent.heartbeat"]
+    assert delivered[0][1]["agent_id"] == str(test_agent.id)
+    assert delivered[0][1]["status"] == "running"
+    assert delivered[0][1]["message"] == "still alive"
+
+    client.app.dependency_overrides.pop(get_current_agent, None)
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_heartbeat_emits_status_webhook_on_status_change(
+    client: AsyncClient, db_session, test_agent, monkeypatch
+):
+    from src.api.models.models import AgentStatus
+    from src.api.models.models import AgentStatus
+    from src.api.routes.agent_runtime import get_current_agent
+    import src.api.routes.agent_runtime as agent_runtime_routes
+
+    test_agent.status = AgentStatus.RUNNING.value
+    await db_session.commit()
+
+    test_agent.status = AgentStatus.CREATING.value
+    await db_session.commit()
+
+    delivered: list[tuple[str, dict]] = []
+
+    async def mock_trigger_webhook_event(db, event, payload):
+        delivered.append((event, payload))
+        return 1
+
+    monkeypatch.setattr(agent_runtime_routes, "trigger_webhook_event", mock_trigger_webhook_event)
+    client.app.dependency_overrides[get_current_agent] = lambda: test_agent
+
+    response = await client.post(
+        "/agents/heartbeat",
+        json={
+            "agent_id": str(test_agent.id),
+            "status": "running",
+            "timestamp": datetime.utcnow().isoformat(),
+        },
+    )
+
+    assert response.status_code == 200
+    assert [event for event, _ in delivered] == ["agent.heartbeat", "agent.status"]
+    assert delivered[1][1]["old_status"] == "creating"
+    assert delivered[1][1]["new_status"] == "running"
+
+    client.app.dependency_overrides.pop(get_current_agent, None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,7 @@ async def client(db_session: AsyncSession, test_user):
         transport=ASGITransport(app=test_app),
         base_url="http://test"
     ) as client:
+        client.app = test_app
         yield client
     
     test_app.dependency_overrides.clear()
@@ -160,6 +161,7 @@ async def client_no_auth(db_session: AsyncSession):
         transport=ASGITransport(app=test_app),
         base_url="http://test"
     ) as client:
+        client.app = test_app
         yield client
     
     test_app.dependency_overrides.clear()
@@ -200,6 +202,7 @@ async def other_user_client(db_session: AsyncSession, other_user):
         transport=ASGITransport(app=test_app),
         base_url="http://test"
     ) as client:
+        client.app = test_app
         yield client
     
     test_app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary\n- emit  events from the real  runtime endpoint\n- emit  when a heartbeat changes persisted agent status\n- document what monitoring/self-healing behavior is active today\n- extend API test fixtures so route-level dependency overrides can be exercised in tests\n\n## Validation\n- .........                                                                [100%]
=============================== warnings summary ===============================
tests/api/test_ingest.py::test_ingest_agent_status
  /Users/fortune/MUTX/.venv-ci311/lib/python3.11/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    from crypt import crypt as _crypt

tests/api/test_ingest.py::test_ingest_agent_status
  /Users/fortune/MUTX/.venv-ci311/lib/python3.11/site-packages/pydantic/_internal/_config.py:271: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.5/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
9 passed, 2 warnings in 1.50s\n- 
> mutx@1.0.0 build
> next build --no-lint

   ▲ Next.js 14.1.0

   Creating an optimized production build ...
 ✓ Compiled successfully
   Checking validity of types ...
   Collecting page data ...
   Generating static pages (0/6) ...
   Generating static pages (1/6) 
   Generating static pages (2/6) 
   Generating static pages (4/6) 
 ✓ Generating static pages (6/6) 
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                              Size     First Load JS
┌ ○ /                                    12.9 kB         151 kB
├ ○ /_not-found                          885 B          85.1 kB
├ λ /api/api-keys                        0 B                0 B
├ λ /api/api-keys/[id]                   0 B                0 B
├ λ /api/auth/login                      0 B                0 B
├ λ /api/auth/logout                     0 B                0 B
├ λ /api/auth/me                         0 B                0 B
├ λ /api/auth/register                   0 B                0 B
├ λ /api/dashboard/agents                0 B                0 B
├ λ /api/dashboard/deployments           0 B                0 B
├ λ /api/dashboard/health                0 B                0 B
├ λ /api/newsletter                      0 B                0 B
├ λ /api/turnstile/site-key              0 B                0 B
├ λ /app/[[...slug]]                     5.51 kB         144 kB
├ ○ /robots.txt                          0 B                0 B
└ ○ /sitemap.xml                         0 B                0 B
+ First Load JS shared by all            84.3 kB
  ├ chunks/69-937ff30f6529f43f.js        28.9 kB
  ├ chunks/fd9d1056-6110ffd77e8dcc12.js  53.4 kB
  └ other shared chunks (total)          1.96 kB


ƒ Middleware                             40.3 kB

○  (Static)   prerendered as static content
λ  (Dynamic)  server-rendered on demand using Node.js\n\n## Notes\n- Clean-room install via  +  is currently blocked by an  pin conflict (0.20.0 vs 0.19.0).\n- Python 3.14 also fails on older compiled deps in this repo (, ), so validation was run with Python 3.11.\n