### PR TITLE
feat: add webhook delivery history endpoint

### DIFF
--- a/src/api/models/schemas.py
+++ b/src/api/models/schemas.py
@@ -247,14 +247,18 @@ class WebhookResponse(BaseModel):
 class WebhookDelivery(BaseModel):
     """Schema for webhook delivery attempts"""
 
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
     webhook_id: uuid.UUID
     event: str
-    payload: dict
+    payload: str
     status_code: Optional[int]
     success: bool
     error_message: Optional[str]
     attempts: int
     created_at: datetime
+    delivered_at: Optional[datetime]
 
 
 class WaitlistSignupCreate(BaseModel):

--- a/src/api/routes/webhooks.py
+++ b/src/api/routes/webhooks.py
@@ -6,12 +6,13 @@ import logging
 from typing import Optional
 
 from src.api.database import get_db
-from src.api.models import User, Webhook
+from src.api.models import User, Webhook, WebhookDeliveryLog
 from src.api.services.webhook_handler import WebhookEventType as WebhookEvent
 from src.api.models.schemas import (
     WebhookCreate,
     WebhookUpdate,
     WebhookResponse,
+    WebhookDelivery,
 )
 from src.api.middleware.auth import get_current_user_or_api_key
 
@@ -206,3 +207,30 @@ async def test_webhook(
             status_code=502,
             detail="Test event delivery failed. Check webhook URL and ensure it's reachable.",
         )
+
+
+@router.get("/{webhook_id}/deliveries", response_model=list[WebhookDelivery])
+async def list_webhook_deliveries(
+    webhook_id: uuid.UUID,
+    event: Optional[str] = None,
+    success: Optional[bool] = None,
+    limit: int = 50,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_webhook_auth),
+):
+    """List delivery attempts for a webhook owned by the authenticated user."""
+    webhook = await _get_owned_webhook(webhook_id, db, current_user)
+
+    query = (
+        select(WebhookDeliveryLog)
+        .where(WebhookDeliveryLog.webhook_id == webhook.id)
+        .order_by(WebhookDeliveryLog.created_at.desc())
+        .limit(limit)
+    )
+    if event is not None:
+        query = query.where(WebhookDeliveryLog.event == event)
+    if success is not None:
+        query = query.where(WebhookDeliveryLog.success == success)
+
+    result = await db.execute(query)
+    return result.scalars().all()

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -1,5 +1,8 @@
 import pytest
 from httpx import AsyncClient
+import uuid
+
+from src.api.models.models import WebhookDeliveryLog
 
 @pytest.mark.asyncio
 async def test_webhook_lifecycle(client: AsyncClient, test_user):
@@ -103,3 +106,67 @@ async def test_webhook_test_trigger(client: AsyncClient, test_user, monkeypatch)
     response = await client.post(f"/webhooks/{webhook_id}/test")
     assert response.status_code == 200
     assert response.json()["status"] == "test_delivered"
+
+
+@pytest.mark.asyncio
+async def test_webhook_delivery_history_filters(client: AsyncClient, db_session, test_user):
+    create_response = await client.post(
+        "/webhooks/",
+        json={"url": "https://example.com/webhook", "events": ["*"]},
+    )
+    assert create_response.status_code == 201
+    webhook_id = uuid.UUID(create_response.json()["id"])
+
+    db_session.add_all(
+        [
+            WebhookDeliveryLog(
+                webhook_id=webhook_id,
+                event="deployment.event",
+                payload='{"status":"running"}',
+                success=True,
+                attempts=1,
+            ),
+            WebhookDeliveryLog(
+                webhook_id=webhook_id,
+                event="agent.status",
+                payload='{"new_status":"failed"}',
+                success=False,
+                error_message="boom",
+                attempts=2,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    response = await client.get(f"/webhooks/{webhook_id}/deliveries?event=agent.status&success=false")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["event"] == "agent.status"
+    assert data[0]["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_webhook_delivery_history_other_user_forbidden(
+    client: AsyncClient, other_user_client: AsyncClient, db_session, test_user
+):
+    create_response = await client.post(
+        "/webhooks/",
+        json={"url": "https://example.com/webhook", "events": ["*"]},
+    )
+    assert create_response.status_code == 201
+    webhook_id = uuid.UUID(create_response.json()["id"])
+
+    db_session.add(
+        WebhookDeliveryLog(
+            webhook_id=webhook_id,
+            event="agent.status",
+            payload='{"new_status":"running"}',
+            success=True,
+            attempts=1,
+        )
+    )
+    await db_session.commit()
+
+    response = await other_user_client.get(f"/webhooks/{webhook_id}/deliveries")
+    assert response.status_code == 403


### PR DESCRIPTION
## What changed?

- added `GET /webhooks/{webhook_id}/deliveries` for authenticated webhook delivery history
- supports `event`, `success`, and `limit` filters on delivery history retrieval
- added focused API tests for delivery history filtering and cross-user denial
- aligned the `WebhookDelivery` schema with the persisted log model

## Why?

- issue #93 is about webhook delivery history contract alignment
- this is a small truthful first slice that exposes the delivery logs the backend already stores, instead of leaving history implicit or SDK-only

## Validation

- `/Users/fortune/MUTX/.venv/bin/ruff check src/api/routes/webhooks.py src/api/models/schemas.py tests/api/test_webhooks.py`
- `/Users/fortune/MUTX/.venv/bin/python -m pytest tests/api/test_webhooks.py::test_webhook_delivery_history_filters tests/api/test_webhooks.py::test_webhook_delivery_history_other_user_forbidden -q`
- `python3 -m compileall src/api/routes/webhooks.py`
