### PR TITLE
Fix autonomous dispatch stale claim comment interpolation

### DIFF
--- a/.github/workflows/autonomous-dispatch.yml
+++ b/.github/workflows/autonomous-dispatch.yml
@@ -116,7 +116,7 @@ jobs:
                 body: [
                   'Autonomous dispatch released this stale claim.',
                   '',
-                  `- no open PR was found for the claimed branch${branchName ? ` \\`${branchName}\\`` : ''}`,
+                  '- no open PR was found for the claimed branch' + (branchName ? ` - \`${branchName}\`` : ''),
                   `- stale threshold: ${staleMinutes} minutes`,
                   '- the issue is eligible for re-dispatch',
                 ].join('\n'),


### PR DESCRIPTION
## Summary\n- Fix a JavaScript syntax error in the github-script stale-claim release block that prevented the dispatch workflow from running.\n- Keep scope unchanged to a one-line interpolation fix.\n\n@codex please review