### PR TITLE
fix(runtime): require agent auth for status lookup

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -2,6 +2,8 @@
 
 The agents routes manage agent records, deployments, logs, and metrics.
 
+Runtime-facing agent endpoints such as heartbeat, command polling, log submission, and `GET /agents/{agent_id}/status` use the agent API key as a bearer token. Control-plane users should use the standard `GET /agents/{agent_id}` route instead.
+
 ## Current Implementation Notes
 
 - Routes are mounted at `/agents`, not `/v1/agents`.
@@ -16,6 +18,7 @@ The agents routes manage agent records, deployments, logs, and metrics.
 | `POST /agents` | Create an agent record |
 | `GET /agents` | List agents |
 | `GET /agents/{agent_id}` | Get one agent with deployments |
+| `GET /agents/{agent_id}/status` | Get runtime status for the authenticated agent |
 | `DELETE /agents/{agent_id}` | Delete an agent |
 | `POST /agents/{agent_id}/deploy` | Create a deployment record and mark the agent running |
 | `POST /agents/{agent_id}/stop` | Stop active deployments for an agent |
@@ -73,6 +76,17 @@ curl "$BASE_URL/agents/YOUR_AGENT_ID"
 ```
 
 The detail response includes a `deployments` array.
+
+## Get Runtime Status
+
+This runtime endpoint is only for the authenticated agent itself.
+
+```bash
+curl "$BASE_URL/agents/YOUR_AGENT_ID/status" \
+  -H "Authorization: Bearer YOUR_AGENT_API_KEY"
+```
+
+If the bearer token belongs to a different agent, the API returns `403 Agent ID mismatch`.
 
 ## Deploy an Agent
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -17,6 +17,7 @@ Routes are mounted directly at top-level prefixes. There is no global `/v1` back
 | Root | `GET /`, `GET /health`, `GET /ready` |
 | Auth | `POST /auth/register`, `POST /auth/login`, `POST /auth/refresh`, `POST /auth/logout`, `GET /auth/me` |
 | Agents | `POST /agents`, `GET /agents`, `GET /agents/{agent_id}`, `DELETE /agents/{agent_id}`, `POST /agents/{agent_id}/deploy`, `POST /agents/{agent_id}/stop`, `GET /agents/{agent_id}/logs`, `GET /agents/{agent_id}/metrics` |
+| Agent Runtime | `POST /agents/register`, `POST /agents/heartbeat`, `POST /agents/metrics`, `GET /agents/commands`, `POST /agents/commands/acknowledge`, `POST /agents/logs`, `GET /agents/{agent_id}/status` |
 | Deployments | `GET /deployments`, `POST /deployments`, `GET /deployments/{deployment_id}`, `POST /deployments/{deployment_id}/scale`, `POST /deployments/{deployment_id}/restart`, `DELETE /deployments/{deployment_id}` |
 | API Keys | `GET /api-keys`, `POST /api-keys`, `DELETE /api-keys/{key_id}`, `POST /api-keys/{key_id}/rotate` |
 | Webhooks | `POST /webhooks/agent-status`, `POST /webhooks/deployment`, `POST /webhooks/metrics` |
@@ -56,6 +57,8 @@ Authenticated requests require a bearer token:
 curl "$BASE_URL/auth/me" \
   -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
 ```
+
+Agent runtime routes use the agent API key as the bearer token rather than a user access token.
 
 ## Health And Readiness
 

--- a/src/api/routes/agent_runtime.py
+++ b/src/api/routes/agent_runtime.py
@@ -359,21 +359,27 @@ async def submit_log(
 async def get_agent_status(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
+    agent: Agent = Depends(get_current_agent),
 ):
-    """Get agent status."""
-    result = await db.execute(select(Agent).where(Agent.id == uuid.UUID(agent_id)))
-    agent = result.scalar_one_or_none()
+    """Get status for the authenticated agent."""
+    if str(agent.id) != agent_id:
+        raise HTTPException(status_code=403, detail="Agent ID mismatch")
 
-    if not agent:
+    result = await db.execute(select(Agent).where(Agent.id == agent.id))
+    current_agent = result.scalar_one_or_none()
+
+    if not current_agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
     uptime = 0.0
-    if agent.created_at:
-        uptime = (datetime.utcnow() - agent.created_at).total_seconds()
+    if current_agent.created_at:
+        uptime = (datetime.utcnow() - current_agent.created_at).total_seconds()
 
     return AgentStatusResponse(
-        agent_id=str(agent.id),
-        status=agent.status,
-        last_heartbeat=agent.last_heartbeat.isoformat() if agent.last_heartbeat else None,
+        agent_id=str(current_agent.id),
+        status=current_agent.status,
+        last_heartbeat=(
+            current_agent.last_heartbeat.isoformat() if current_agent.last_heartbeat else None
+        ),
         uptime_seconds=uptime,
     )

--- a/tests/api/test_agent_runtime.py
+++ b/tests/api/test_agent_runtime.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+import uuid
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_agent_status_requires_agent_auth(client, test_agent):
+    response = await client.get(f'/agents/{test_agent.id}/status')
+
+    assert response.status_code == 401
+    assert response.json()['detail'] == 'Missing authorization header'
+
+
+@pytest.mark.asyncio
+async def test_agent_status_returns_authenticated_agent_status(client, db_session, test_agent):
+    test_agent.api_key = 'mutx_agent_status_test_key'
+    test_agent.status = 'running'
+    test_agent.last_heartbeat = datetime.utcnow()
+    await db_session.commit()
+
+    response = await client.get(
+        f'/agents/{test_agent.id}/status',
+        headers={'Authorization': f'Bearer {test_agent.api_key}'},
+    )
+
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload['agent_id'] == str(test_agent.id)
+    assert payload['status'] == 'running'
+    assert payload['last_heartbeat'] is not None
+    assert payload['uptime_seconds'] >= 0
+
+
+@pytest.mark.asyncio
+async def test_agent_status_rejects_requests_for_other_agents(
+    client, db_session, other_user, test_agent
+):
+    from src.api.models.models import Agent, AgentStatus
+
+    other_agent = Agent(
+        id=uuid.UUID('55555555-5555-4555-a555-555555555555'),
+        name='other-agent',
+        description='Another test agent',
+        config='{"model": "gpt-4"}',
+        user_id=other_user.id,
+        status=AgentStatus.RUNNING,
+        api_key='mutx_agent_other_status_key',
+    )
+    db_session.add(other_agent)
+    await db_session.commit()
+
+    response = await client.get(
+        f'/agents/{test_agent.id}/status',
+        headers={'Authorization': f'Bearer {other_agent.api_key}'},
+    )
+
+    assert response.status_code == 403
+    assert response.json()['detail'] == 'Agent ID mismatch'


### PR DESCRIPTION
## Summary
- require agent authentication for `GET /agents/{agent_id}/status` and reject cross-agent lookups
- add focused API coverage for unauthenticated, happy-path, and mismatched-agent requests
- document the runtime status endpoint and clarify that control-plane users should use `GET /agents/{agent_id}` instead

## Validation
- `/Users/fortune/MUTX/.venv/bin/ruff check src/api/routes/agent_runtime.py tests/api/test_agent_runtime.py`
- `/Users/fortune/MUTX/.venv/bin/python -m pytest tests/api/test_agent_runtime.py -q`
- `/Users/fortune/MUTX/.venv/bin/python -m compileall src/api/routes/agent_runtime.py tests/api/test_agent_runtime.py`

Closes #118.
