### PR TITLE
fix: correct monitoring stack bind mounts cleanly

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -71,7 +71,7 @@ make monitor-up
 
 The monitoring compose file binds UI and exporter ports to localhost by default.
 Stop it with `cd infrastructure && make monitor-down`.
-Prometheus now loads alerting rules from `infrastructure/monitoring/prometheus/alerts.yml` and scrapes the API via `host.docker.internal:8000` (works for local Docker Desktop + Linux host-gateway mapping).
+Prometheus now loads alerting rules from `infrastructure/monitoring/prometheus/alerts.yml` and scrapes the API via `host.docker.internal:8000` (works for local Docker Desktop + Linux host-gateway mapping). Grafana provisioning and dashboard mounts are resolved relative to `infrastructure/docker/docker-compose.monitoring.yml`, so the stack reads from `../monitoring/grafana/...` when launched from `infrastructure/`.
 
 ## CI Drift Detection
 

--- a/infrastructure/docker/docker-compose.monitoring.yml
+++ b/infrastructure/docker/docker-compose.monitoring.yml
@@ -35,7 +35,7 @@ services:
     ports:
       - "127.0.0.1:${ALERTMANAGER_PORT:-9093}:9093"
     volumes:
-      - ./infrastructure/monitoring/prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - ../monitoring/prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - alertmanager_data:/alertmanager
     restart: unless-stopped
     networks:
@@ -53,8 +53,8 @@ services:
     ports:
       - "127.0.0.1:${GRAFANA_PORT:-3001}:3000"
     volumes:
-      - ./infrastructure/monitoring/grafana/dashboards:/etc/grafana/dashboards:ro
-      - ./infrastructure/monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../monitoring/grafana/dashboards:/etc/grafana/dashboards:ro
+      - ../monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
       - grafana_data:/var/lib/grafana
     depends_on:
       prometheus:


### PR DESCRIPTION
## Summary
- fix Alertmanager and Grafana bind mounts relative to `infrastructure/docker/docker-compose.monitoring.yml`
- document the relative mount behavior in `infrastructure/README.md`
- keep this PR strictly scoped to the monitoring compose issue, without dashboard or Playwright fallout

## Validation
- `docker compose --env-file /tmp/mutx-monitoring.env -f infrastructure/docker/docker-compose.monitoring.yml config`

## Notes
- this clean PR supersedes the mixed-scope blocker in #110
