### PR TITLE
fix(web): allow localhost auth cookies over HTTP

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -9,6 +9,8 @@ export const dynamic = 'force-dynamic'
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
+    const secureCookies =
+      request.nextUrl.protocol === 'https:' || request.headers.get('x-forwarded-proto') === 'https'
 
     const response = await fetch(`${API_BASE_URL}/auth/login`, {
       method: 'POST',
@@ -27,14 +29,14 @@ export async function POST(request: NextRequest) {
     nextResponse.cookies.set('access_token', payload.access_token, {
       httpOnly: false,
       sameSite: 'lax',
-      secure: true,
+      secure: secureCookies,
       path: '/',
       maxAge: payload.expires_in || 1800,
     })
     nextResponse.cookies.set('refresh_token', payload.refresh_token, {
       httpOnly: false,
       sameSite: 'lax',
-      secure: true,
+      secure: secureCookies,
       path: '/',
       maxAge: 60 * 60 * 24 * 7,
     })

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -9,6 +9,8 @@ export const dynamic = 'force-dynamic'
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
+    const secureCookies =
+      request.nextUrl.protocol === 'https:' || request.headers.get('x-forwarded-proto') === 'https'
 
     const response = await fetch(`${API_BASE_URL}/auth/register`, {
       method: 'POST',
@@ -27,14 +29,14 @@ export async function POST(request: NextRequest) {
     nextResponse.cookies.set('access_token', payload.access_token, {
       httpOnly: false,
       sameSite: 'lax',
-      secure: true,
+      secure: secureCookies,
       path: '/',
       maxAge: payload.expires_in || 1800,
     })
     nextResponse.cookies.set('refresh_token', payload.refresh_token, {
       httpOnly: false,
       sameSite: 'lax',
-      secure: true,
+      secure: secureCookies,
       path: '/',
       maxAge: 60 * 60 * 24 * 7,
     })


### PR DESCRIPTION
## Summary
- set auth proxy cookies as `secure` only when the incoming request is HTTPS
- keep localhost HTTP login/register flows sticky without changing production HTTPS behavior

## Validation
- `npm run build`

## Scope
- `app/api/auth/login/route.ts`
- `app/api/auth/register/route.ts`
