### PR TITLE
docs: align webhook delivery and deploy events docs

### DIFF
--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -66,9 +66,46 @@ curl -X POST "https://api.mutx.dev/webhooks/" \
 |--------|-------|---------|
 | `GET` | `/webhooks/` | List all registered webhooks |
 | `GET` | `/webhooks/{id}` | Get a specific webhook |
+| `GET` | `/webhooks/{id}/deliveries` | List delivery attempts for one webhook |
 | `PATCH` | `/webhooks/{id}` | Update a webhook (URL, events, active status) |
 | `DELETE` | `/webhooks/{id}` | Remove a webhook |
 | `POST` | `/webhooks/{id}/test` | Send a test event to verify delivery |
+
+### Delivery History
+
+Delivery attempts are persisted and can be queried directly:
+
+```bash
+curl "https://api.mutx.dev/webhooks/YOUR_WEBHOOK_ID/deliveries?limit=20" \
+  -H "Authorization: Bearer YOUR_TOKEN"
+
+curl "https://api.mutx.dev/webhooks/YOUR_WEBHOOK_ID/deliveries?event=agent.status&success=false" \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+Supported query parameters:
+
+- `skip`
+- `limit`
+- `event`
+- `success`
+
+Example response item:
+
+```json
+{
+  "id": "uuid",
+  "webhook_id": "uuid",
+  "event": "agent.status",
+  "payload": "{\"new_status\":\"failed\"}",
+  "status_code": 502,
+  "success": false,
+  "error_message": "upstream timeout",
+  "attempts": 2,
+  "created_at": "2026-03-12T09:15:00Z",
+  "delivered_at": null
+}
+```
 
 ## Delivery and Security
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -70,6 +70,7 @@ mutx status
 | `mutx agents deploy` | reliable | uses `POST /agents/{id}/deploy` |
 | `mutx agents delete` | reliable | uses `DELETE /agents/{id}` |
 | `mutx deploy list` | reliable | uses `GET /deployments` |
+| `mutx deploy events` | reliable | uses `GET /deployments/{id}/events` |
 | `mutx deploy scale` | reliable | uses `POST /deployments/{id}/scale` |
 | `mutx deploy delete` | reliable | uses `DELETE /deployments/{id}` |
 


### PR DESCRIPTION
## Summary
- document the live webhook delivery history route under `/webhooks/{id}/deliveries`
- mark `mutx deploy events` as a reliable CLI command that maps to the live deployment events route

## Validation
- docs-only slice; route and command references verified against:
  - `src/api/routes/webhooks.py`
  - `src/api/routes/deployments.py`
  - `sdk/mutx/webhooks.py`
  - `cli/commands/deploy.py`

## Scope
- `docs/api/webhooks.md`
- `docs/cli.md`
