### PR TITLE
Remove external links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,6 @@
   <strong>Deploy, run, observe, and govern AI agents like you deploy services.</strong>
 </p>
 
-<p align="center">
-  <a href="./MANIFESTO.md"><strong>Our Manifesto</strong></a> ·
-  <a href="./WHITEPAPER.md"><strong>Technical Whitepaper</strong></a> ·
-  <a href="https://mutx.dev"><strong>Live Preview</strong></a> ·
-  <a href="./docs/README.md"><strong>Read Docs</strong></a> ·
-  <a href="https://github.com/fortunexbt/mutx-dev"><strong>GitHub</strong></a>
-</p>
-
 ---
 
 ## Start Here


### PR DESCRIPTION
Removed links to manifesto, whitepaper, live preview, and documentation from the README.

## What changed?

-

## Why?

-

## Validation

- [ ] `npm run build`
- [ ] `ruff check src/api cli sdk`
- [ ] `black --check src/api cli sdk`
- [ ] `python -m compileall src/api cli sdk/mutx`
- [ ] targeted manual or automated verification

## Agent Ownership

- authoring agent:
- reviewer agent:
- primary area:
- risk: low / medium / high
- lane: safe auto-merge / staging-first / human-gated

## Docs

- [ ] no docs update needed
- [ ] updated the closest docs

## Notes

- breaking changes:
- follow-up work:
