### PR TITLE
docs(sdk): deprecate incomplete async client surface

### DIFF
--- a/sdk/mutx/__init__.py
+++ b/sdk/mutx/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 import httpx
 
 from mutx.agent_runtime import (
@@ -98,6 +100,12 @@ class MutxAsyncClient:
         base_url: str = "https://api.mutx.dev",
         timeout: float = 30.0,
     ):
+        warnings.warn(
+            "MutxAsyncClient is deprecated until async resource methods are fully implemented; "
+            "prefer MutxClient or raw httpx.AsyncClient integrations for now.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.api_key = api_key
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout

--- a/tests/test_sdk_async_client_contract.py
+++ b/tests/test_sdk_async_client_contract.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sdk"))
+
+from mutx import MutxAsyncClient
+
+
+def test_mutx_async_client_emits_deprecation_warning() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        client = MutxAsyncClient(api_key="test-key", base_url="https://api.test")
+        try:
+            assert any("MutxAsyncClient is deprecated" in str(item.message) for item in caught)
+        finally:
+            import asyncio
+
+            asyncio.run(client.aclose())


### PR DESCRIPTION
## Summary
- emit a `DeprecationWarning` from `MutxAsyncClient` until the async resource surface is fully implemented
- add focused contract coverage proving the deprecation warning is emitted

## Validation
- `.venv/bin/ruff check sdk/mutx/__init__.py tests/test_sdk_async_client_contract.py`
- `.venv/bin/python -m pytest tests/test_sdk_async_client_contract.py -q`
- `python3 -m compileall sdk/mutx/__init__.py`

## Scope
- `sdk/mutx/__init__.py`
- `tests/test_sdk_async_client_contract.py`
