### PR TITLE
ci: run app-level frontend tests in validation script

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,6 +38,10 @@ echo "Generating frontend API types..."
 npm run generate-types
 
 echo ""
+echo "Running app-level frontend unit tests..."
+npm run test:app
+
+echo ""
 echo "Checking generated frontend API types are committed..."
 git diff --exit-code -- app/types/api.ts
 


### PR DESCRIPTION
## Summary
- add `npm run test:app` to the shared validation script so app-level auth/cookie helper tests are part of the trusted baseline

## Validation
- `npm run test:app`

## Scope
- `scripts/test.sh`
