### PR TITLE
docs: align API overview with live deployment and webhook routes

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -18,9 +18,9 @@ Routes are mounted directly at top-level prefixes. There is no global `/v1` back
 | Auth | `POST /auth/register`, `POST /auth/login`, `POST /auth/refresh`, `POST /auth/logout`, `GET /auth/me` |
 | Agents | `POST /agents`, `GET /agents`, `GET /agents/{agent_id}`, `DELETE /agents/{agent_id}`, `POST /agents/{agent_id}/deploy`, `POST /agents/{agent_id}/stop`, `GET /agents/{agent_id}/logs`, `GET /agents/{agent_id}/metrics` |
 | Agent Runtime | `POST /agents/register`, `POST /agents/heartbeat`, `POST /agents/metrics`, `GET /agents/commands`, `POST /agents/commands/acknowledge`, `POST /agents/logs`, `GET /agents/{agent_id}/status` |
-| Deployments | `GET /deployments`, `POST /deployments`, `GET /deployments/{deployment_id}`, `POST /deployments/{deployment_id}/scale`, `POST /deployments/{deployment_id}/restart`, `DELETE /deployments/{deployment_id}` |
+| Deployments | `GET /deployments`, `GET /deployments/{deployment_id}`, `GET /deployments/{deployment_id}/events`, `POST /deployments/{deployment_id}/scale`, `POST /deployments/{deployment_id}/restart`, `DELETE /deployments/{deployment_id}` |
 | API Keys | `GET /api-keys`, `POST /api-keys`, `DELETE /api-keys/{key_id}`, `POST /api-keys/{key_id}/rotate` |
-| Webhooks | `POST /webhooks/agent-status`, `POST /webhooks/deployment`, `POST /webhooks/metrics` |
+| Webhooks | `GET /webhooks/`, `GET /webhooks/{id}`, `GET /webhooks/{id}/deliveries`, `PATCH /webhooks/{id}`, `DELETE /webhooks/{id}`, `POST /webhooks/{id}/test`, `POST /webhooks/agent-status`, `POST /webhooks/deployment`, `POST /webhooks/metrics` |
 | Newsletter | `GET /newsletter`, `POST /newsletter` |
 | Leads | `POST /leads`, `GET /leads`, `GET /leads/{lead_id}` |
 
@@ -33,6 +33,8 @@ The Next.js app also exposes same-origin route handlers under `app/api/` for bro
 - `/api/dashboard/agents`
 - `/api/dashboard/deployments`
 - `/api/api-keys`
+- `/api/api-keys/[id]`
+- `/api/api-keys/[id]/rotate`
 - `/api/newsletter`
 
 Use the FastAPI routes for direct control-plane integrations and the Next.js route handlers for browser or app-surface flows.


### PR DESCRIPTION
## Summary
- update the API overview route table to match live deployment event and webhook delivery routes
- add the API key delete/rotate Next.js proxy routes to the website proxy section

## Validation
- docs-only slice; verified route references against `src/api/routes/deployments.py`, `src/api/routes/webhooks.py`, `app/api/api-keys/[id]/route.ts`, and `app/api/api-keys/[id]/rotate/route.ts`

## Scope
- `docs/api/index.md`
