### PR TITLE
fix: point setup script at relocated compose file

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,9 +1,26 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 echo "Setting up mutx.dev..."
 
-cd "$(dirname "$0")/.."
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+COMPOSE_FILE="$ROOT_DIR/infrastructure/docker/docker-compose.yml"
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker-compose)
+else
+    echo "Docker Compose is required (docker compose or docker-compose)."
+    exit 1
+fi
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+    echo "Compose file not found at $COMPOSE_FILE"
+    exit 1
+fi
 
 if [ ! -f .env ]; then
     echo "Creating .env from example..."
@@ -18,10 +35,10 @@ echo "Installing Node.js dependencies..."
 npm install
 
 echo "Building Docker services..."
-docker-compose build
+"${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" build
 
 echo "Starting database services..."
-docker-compose up -d postgres redis
+"${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" up -d postgres redis
 
 echo "Waiting for database to be ready..."
 sleep 5


### PR DESCRIPTION
## Summary
- teach `scripts/setup.sh` to use the real Compose file under `infrastructure/docker/docker-compose.yml`
- detect `docker compose` vs `docker-compose` explicitly and fail clearly when Compose is unavailable

## Validation
- `bash -n scripts/setup.sh`
- `docker compose -f infrastructure/docker/docker-compose.yml config`

## Scope
- `scripts/setup.sh`
