### PR TITLE
docs(sdk): note async client deprecation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ task = agent.run_task(
 print(f"Autonomous agent operating: {task.id}")
 ```
 
+Note: `MutxAsyncClient` is currently deprecated until the async resource surface is fully implemented. Prefer `MutxClient` or direct `httpx.AsyncClient` integrations for now.
+
 ---
 
 ## 🗺️ Roadmap & Maturity


### PR DESCRIPTION
## Summary
- add a README note that `MutxAsyncClient` is deprecated until the async resource surface is fully implemented
- steer contributors toward `MutxClient` or direct `httpx.AsyncClient` usage for now

## Validation
- docs-only slice; verified the note matches the current deprecation warning in `sdk/mutx/__init__.py`

## Scope
- `README.md`
