### PR TITLE
test(web): preserve forbidden responses for dashboard agents

### DIFF
--- a/tests/unit/dashboardRoutes.test.ts
+++ b/tests/unit/dashboardRoutes.test.ts
@@ -28,6 +28,25 @@ describe('dashboard route proxies', () => {
     expect(global.fetch).not.toHaveBeenCalled()
   })
 
+  it('preserves upstream forbidden responses for dashboard agents proxy', async () => {
+    getAuthToken.mockResolvedValue('token')
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: 'Forbidden' }),
+    })
+    const { GET } = await import('../../app/api/dashboard/agents/route')
+
+    const response = await GET(mockRequest())
+
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/agents?limit=20', {
+      headers: { Authorization: 'Bearer token' },
+      cache: 'no-store',
+    })
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ detail: 'Forbidden' })
+  })
+
   it('preserves upstream forbidden responses for dashboard deployments proxy', async () => {
     getAuthToken.mockResolvedValue('token')
     ;(global.fetch as jest.Mock).mockResolvedValue({


### PR DESCRIPTION
## Summary
- add focused unit coverage that the dashboard agents proxy preserves upstream 403 responses for ownership-sensitive reads

## Validation
- `npx jest --runInBand tests/unit/dashboardRoutes.test.ts`
- `npm run build`

## Scope
- `tests/unit/dashboardRoutes.test.ts`
