### PR TITLE
docs: update compose command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ npm install
 pip install -r requirements.txt
 
 # 2. Start infra & services
-docker-compose -f infrastructure/docker/docker-compose.yml up -d postgres redis
+docker compose -f infrastructure/docker/docker-compose.yml up -d postgres redis
 uvicorn src.api.main:app --reload --port 8000
 npm run dev
 ```

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -13,7 +13,7 @@ docker-compose up
 Run only data services in the background:
 
 ```bash
-docker-compose up -d postgres redis
+docker compose -f infrastructure/docker/docker-compose.yml up -d postgres redis
 ```
 
 The local compose file currently starts:

--- a/docs/deployment/quickstart.md
+++ b/docs/deployment/quickstart.md
@@ -31,7 +31,7 @@ DATABASE_URL=postgresql://mutx:mutx_password@localhost:5432/mutx
 ## 2. Start local services
 
 ```bash
-docker-compose up -d postgres redis
+docker compose -f infrastructure/docker/docker-compose.yml up -d postgres redis
 ```
 
 ## 3. Start the API


### PR DESCRIPTION
## Summary
- replace stale `docker-compose` examples with the repo's current `docker compose -f infrastructure/docker/docker-compose.yml ...` invocation in quickstart docs

## Validation
- docs-only slice; command examples verified against `scripts/setup.sh` and `infrastructure/docker/docker-compose.yml`

## Scope
- `README.md`
- `docs/deployment/quickstart.md`
- `docs/deployment/docker.md`
