### PR TITLE
test(web): cover unauthorized API key list proxy

### DIFF
--- a/tests/unit/apiKeyRoutes.test.ts
+++ b/tests/unit/apiKeyRoutes.test.ts
@@ -36,6 +36,17 @@ describe('API key route proxies', () => {
     expect(global.fetch).not.toHaveBeenCalled()
   })
 
+  it('returns 401 from list proxy when no auth token exists', async () => {
+    getAuthToken.mockResolvedValue(null)
+    const { GET } = await import('../../app/api/api-keys/route')
+
+    const response = await GET(mockRequest())
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
   it('preserves upstream forbidden responses for rotate proxy', async () => {
     getAuthToken.mockResolvedValue('token')
     ;(global.fetch as jest.Mock).mockResolvedValue({


### PR DESCRIPTION
## Summary
- add focused unit coverage that the API key list proxy returns 401 without an auth token and does not call the backend

## Validation
- `npx jest --runInBand tests/unit/apiKeyRoutes.test.ts`
- `npm run build`

## Scope
- `tests/unit/apiKeyRoutes.test.ts`
