### PR TITLE
test(web): cover unauthorized API key create proxy

### DIFF
--- a/tests/unit/apiKeyRoutes.test.ts
+++ b/tests/unit/apiKeyRoutes.test.ts
@@ -47,6 +47,17 @@ describe('API key route proxies', () => {
     expect(global.fetch).not.toHaveBeenCalled()
   })
 
+  it('returns 401 from create proxy when no auth token exists', async () => {
+    getAuthToken.mockResolvedValue(null)
+    const { POST } = await import('../../app/api/api-keys/route')
+
+    const response = await POST(mockJsonRequest({ name: 'build-key' }))
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
   it('preserves upstream forbidden responses for rotate proxy', async () => {
     getAuthToken.mockResolvedValue('token')
     ;(global.fetch as jest.Mock).mockResolvedValue({


### PR DESCRIPTION
## Summary
- add focused unit coverage that the API key create proxy returns 401 without an auth token and does not call the backend

## Validation
- `npx jest --runInBand tests/unit/apiKeyRoutes.test.ts`
- `npm run build`

## Scope
- `tests/unit/apiKeyRoutes.test.ts`
