### PR TITLE
test(web): cover unauthorized API key rotate proxy

### DIFF
--- a/tests/unit/apiKeyRoutes.test.ts
+++ b/tests/unit/apiKeyRoutes.test.ts
@@ -47,11 +47,84 @@ describe('API key route proxies', () => {
     expect(global.fetch).not.toHaveBeenCalled()
   })
 
+  it('preserves upstream forbidden responses for list proxy', async () => {
+    getAuthToken.mockResolvedValue('token')
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: 'Forbidden' }),
+    })
+
+    const { GET } = await import('../../app/api/api-keys/route')
+
+    const response = await GET(mockRequest())
+
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/api-keys', {
+      headers: {
+        Authorization: 'Bearer token',
+      },
+    })
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ detail: 'Forbidden' })
+  })
+
   it('returns 401 from create proxy when no auth token exists', async () => {
     getAuthToken.mockResolvedValue(null)
     const { POST } = await import('../../app/api/api-keys/route')
 
     const response = await POST(mockJsonRequest({ name: 'build-key' }))
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 from rotate proxy when no auth token exists', async () => {
+    getAuthToken.mockResolvedValue(null)
+    const { POST } = await import('../../app/api/api-keys/[id]/rotate/route')
+
+    const response = await POST(mockRequest(), {
+      params: Promise.resolve({ id: 'key_123' }),
+    })
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 from rotate proxy when no auth token exists', async () => {
+    getAuthToken.mockResolvedValue(null)
+    const { POST } = await import('../../app/api/api-keys/[id]/rotate/route')
+
+    const response = await POST(mockRequest(), {
+      params: Promise.resolve({ id: 'key_123' }),
+    })
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 from rotate proxy when no auth token exists', async () => {
+    getAuthToken.mockResolvedValue(null)
+    const { POST } = await import('../../app/api/api-keys/[id]/rotate/route')
+
+    const response = await POST(mockRequest(), {
+      params: Promise.resolve({ id: 'key_123' }),
+    })
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 from rotate proxy when no auth token exists', async () => {
+    getAuthToken.mockResolvedValue(null)
+    const { POST } = await import('../../app/api/api-keys/[id]/rotate/route')
+
+    const response = await POST(mockRequest(), {
+      params: Promise.resolve({ id: 'key_123' }),
+    })
 
     expect(response.status).toBe(401)
     await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })


### PR DESCRIPTION
## Summary
- add focused unit coverage that the API key rotate proxy returns 401 without an auth token and does not call the backend

## Validation
- `npx jest --runInBand tests/unit/apiKeyRoutes.test.ts`
- `npm run build` (first run hit local `.next` copyfile ENOENT, second run succeeded)

## Scope
- `tests/unit/apiKeyRoutes.test.ts`
