### PR TITLE
test(web): cover dashboard proxy auth suite cleanly

### DIFF
--- a/tests/unit/dashboardRoutes.test.ts
+++ b/tests/unit/dashboardRoutes.test.ts
@@ -47,6 +47,37 @@ describe('dashboard route proxies', () => {
     await expect(response.json()).resolves.toEqual({ detail: 'Forbidden' })
   })
 
+  it('preserves successful list responses for dashboard agents proxy', async () => {
+    getAuthToken.mockResolvedValue('token')
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ([
+        {
+          id: 'agent_123',
+          name: 'runtime-agent',
+          status: 'running',
+        },
+      ]),
+    })
+    const { GET } = await import('../../app/api/dashboard/agents/route')
+
+    const response = await GET(mockRequest())
+
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/agents?limit=20', {
+      headers: { Authorization: 'Bearer token' },
+      cache: 'no-store',
+    })
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual([
+      {
+        id: 'agent_123',
+        name: 'runtime-agent',
+        status: 'running',
+      },
+    ])
+  })
+
   it('preserves upstream forbidden responses for dashboard deployments proxy', async () => {
     getAuthToken.mockResolvedValue('token')
     ;(global.fetch as jest.Mock).mockResolvedValue({
@@ -66,12 +97,53 @@ describe('dashboard route proxies', () => {
     await expect(response.json()).resolves.toEqual({ detail: 'Forbidden' })
   })
 
+  it('preserves successful list responses for dashboard deployments proxy', async () => {
+    getAuthToken.mockResolvedValue('token')
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ([
+        {
+          id: 'dep_123',
+          agent_id: 'agent_123',
+          status: 'running',
+        },
+      ]),
+    })
+    const { GET } = await import('../../app/api/dashboard/deployments/route')
+
+    const response = await GET(mockRequest())
+
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/deployments?limit=20', {
+      headers: { Authorization: 'Bearer token' },
+      cache: 'no-store',
+    })
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual([
+      {
+        id: 'dep_123',
+        agent_id: 'agent_123',
+        status: 'running',
+      },
+    ])
+  })
+
+  it('returns 401 from dashboard deployments proxy when no auth token exists', async () => {
+    getAuthToken.mockResolvedValue(null)
+    const { GET } = await import('../../app/api/dashboard/deployments/route')
+
+    const response = await GET(mockRequest())
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ detail: 'Unauthorized' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
   it('preserves upstream health payloads and statuses', async () => {
     ;(global.fetch as jest.Mock).mockResolvedValue({
       status: 503,
       json: async () => ({ status: 'degraded', detail: 'database unavailable' }),
     })
-
     const { GET } = await import('../../app/api/dashboard/health/route')
 
     const response = await GET()
@@ -83,6 +155,19 @@ describe('dashboard route proxies', () => {
     await expect(response.json()).resolves.toEqual({
       status: 'degraded',
       detail: 'database unavailable',
+    })
+  })
+
+  it('returns a fallback health payload when the health proxy throws', async () => {
+    ;(global.fetch as jest.Mock).mockRejectedValue(new Error('socket hang up'))
+    const { GET } = await import('../../app/api/dashboard/health/route')
+
+    const response = await GET()
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      status: 'unknown',
+      error: 'Failed to connect to API',
     })
   })
 })


### PR DESCRIPTION
## Summary
- replace the conflicted dashboard auth test stack with one clean suite on current main
- cover 401, 403, and successful passthrough for dashboard agents/deployments plus health route passthrough and fallback behavior

## Validation
- `npx jest --runInBand tests/unit/dashboardRoutes.test.ts`
- `npm run build`

## Scope
- `tests/unit/dashboardRoutes.test.ts`

## Notes
- supersedes the conflicted dashboard test branches by restacking the same intent on current main only
