### PR TITLE
chore(site): use monochrome docs icon in hero CTA

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -159,7 +159,7 @@ export default function LandingPage() {
                   rel="noreferrer"
                   className="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-white/10"
                 >
-                  <BookOpen className="h-4 w-4" />
+                  <GitBranch className="h-4 w-4 opacity-80" />
                   Open Docs
                   <ArrowRight className="h-4 w-4" />
                 </a>


### PR DESCRIPTION
## Summary\n- keep the hero CTA pointed at docs.mutx.dev\n- keep the CTA label as Open Docs\n- swap the CTA icon to a monochrome docs-style mark\n\n## Validation\n- not run (hero icon-only change)\n