### PR TITLE
feat(web): ship public contact page

### DIFF
--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+
+import { getApiBaseUrl } from '@/app/api/_lib/controlPlane'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+
+    if (body?.honeypot) {
+      return NextResponse.json({ error: 'Invalid input' }, { status: 400 })
+    }
+
+    const response = await fetch(`${API_BASE_URL}/leads`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: body?.email,
+        name: body?.name,
+        company: body?.company,
+        message: body?.message,
+        source: body?.source || 'contact-page',
+      }),
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to submit lead' }))
+    if (!response.ok) {
+      return NextResponse.json(payload, { status: response.status })
+    }
+
+    return NextResponse.json(payload, { status: 201 })
+  } catch (error) {
+    console.error('Lead capture proxy error:', error)
+    return NextResponse.json({ error: 'Failed to connect to API' }, { status: 500 })
+  }
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,109 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, BookOpen, Github, Mail, MessageSquareText } from 'lucide-react'
+
+import { ContactLeadForm } from '@/components/ContactLeadForm'
+import { WaitlistForm } from '@/components/WaitlistForm'
+
+const GITHUB_URL = 'https://github.com/fortunexbt/mutx-dev'
+const DOCS_URL = 'https://docs.mutx.dev'
+const CONTACT_EMAIL = 'hello@mutx.dev'
+
+export const metadata: Metadata = {
+  title: 'Contact | MUTX',
+  description: 'Contact MUTX for demos, hosted access, integrations, and operator workflow questions.',
+}
+
+const quickLinks = [
+  {
+    title: 'Email',
+    body: 'If you already know what you need, email the team directly.',
+    href: `mailto:${CONTACT_EMAIL}`,
+    label: CONTACT_EMAIL,
+    icon: Mail,
+  },
+  {
+    title: 'Docs',
+    body: 'Inspect the live product surface, API, and operator contract first.',
+    href: DOCS_URL,
+    label: 'docs.mutx.dev',
+    icon: BookOpen,
+  },
+  {
+    title: 'GitHub',
+    body: 'Review the actual repo, issues, and shipping state before the call.',
+    href: GITHUB_URL,
+    label: 'fortunexbt/mutx-dev',
+    icon: Github,
+  },
+]
+
+export default function ContactPage() {
+  return (
+    <main className="min-h-screen bg-black px-6 py-20 text-white">
+      <div className="mx-auto max-w-7xl">
+        <div className="mb-14 max-w-3xl">
+          <div className="eyebrow mb-5">Contact</div>
+          <h1 className="text-4xl font-medium tracking-tight sm:text-6xl">Talk to the team behind MUTX.</h1>
+          <p className="mt-5 max-w-2xl text-base leading-7 text-white/60 sm:text-lg">
+            Use this page for live demos, hosted access, operator workflow questions, integrations, or enterprise fit checks.
+            If you want to inspect the product first, start with the docs and GitHub, then send the exact workflow you want to evaluate.
+          </p>
+        </div>
+
+        <div className="grid gap-5 md:grid-cols-3">
+          {quickLinks.map((item) => (
+            <a
+              key={item.title}
+              href={item.href}
+              target={item.href.startsWith('http') ? '_blank' : undefined}
+              rel={item.href.startsWith('http') ? 'noreferrer' : undefined}
+              className="rounded-2xl border border-white/10 bg-[#0d0d0d] p-5 transition-colors hover:border-white/20 hover:bg-[#121212]"
+            >
+              <item.icon className="h-5 w-5 text-white/80" />
+              <h2 className="mt-4 text-lg font-medium text-white">{item.title}</h2>
+              <p className="mt-2 text-sm leading-6 text-white/60">{item.body}</p>
+              <div className="mt-4 inline-flex items-center gap-2 text-sm text-white/80">
+                <span>{item.label}</span>
+                <ArrowRight className="h-4 w-4" />
+              </div>
+            </a>
+          ))}
+        </div>
+
+        <div className="mt-10 grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+          <ContactLeadForm />
+
+          <div className="space-y-6">
+            <div className="rounded-2xl border border-white/10 bg-[#0d0d0d] p-6">
+              <div className="mb-4 flex items-center gap-3">
+                <MessageSquareText className="h-5 w-5 text-white/80" />
+                <h2 className="text-xl font-medium text-white">Best inbound messages</h2>
+              </div>
+              <ul className="space-y-3 text-sm leading-6 text-white/60">
+                <li>• the exact workflow you want to demo</li>
+                <li>• whether you need hosted MUTX or open-source support</li>
+                <li>• your team size, runtime, and deployment constraints</li>
+                <li>• whether the blocker is dashboard UX, API surface, or production rollout</li>
+              </ul>
+            </div>
+
+            <WaitlistForm source="contact-page" className="bg-[#0d0d0d]" />
+
+            <div className="flex flex-wrap gap-4 text-sm text-white/60">
+              <Link href="/" className="transition-colors hover:text-white">
+                Back to mutx.dev
+              </Link>
+              <a href={DOCS_URL} target="_blank" rel="noreferrer" className="transition-colors hover:text-white">
+                Documentation
+              </a>
+              <a href={GITHUB_URL} target="_blank" rel="noreferrer" className="transition-colors hover:text-white">
+                Repository
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ const navItems = [
   { label: 'What Exists', href: '#platform' },
   { label: 'Docs', href: 'https://docs.mutx.dev', external: true },
   { label: 'GitHub', href: GITHUB_URL, external: true },
-  { label: 'Contact', href: '#contact' },
+  { label: 'Contact', href: '/contact' },
 ]
 
 const features = [
@@ -298,7 +298,7 @@ curl <span className="text-green-400">&quot;$BASE_URL/health&quot;</span>
           <a href={GITHUB_URL} target="_blank" rel="noreferrer" className="hover:text-white transition-colors">GitHub</a>
           <a href="https://docs.mutx.dev" target="_blank" rel="noreferrer" className="hover:text-white transition-colors">Docs</a>
           <Link href="/privacy-policy" className="hover:text-white transition-colors">Privacy Policy</Link>
-          <a href="mailto:hello.dev" className="hover:text-white transition-colors">Contact</a>
+          <Link href="/contact" className="hover:text-white transition-colors">Contact</Link>
         </div>
       </footer>
     </div>

--- a/components/ContactLeadForm.tsx
+++ b/components/ContactLeadForm.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { type FormEvent, useState } from 'react'
+import { AlertCircle, CheckCircle2, Loader2, Send } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+type ContactLeadFormProps = {
+  source?: string
+  className?: string
+}
+
+export function ContactLeadForm({ source = 'contact-page', className }: ContactLeadFormProps) {
+  const [email, setEmail] = useState('')
+  const [name, setName] = useState('')
+  const [company, setCompany] = useState('')
+  const [message, setMessage] = useState('')
+  const [honeypot, setHoneypot] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setLoading(true)
+    setError('')
+    setSuccess('')
+
+    try {
+      const response = await fetch('/api/leads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          name,
+          company,
+          message,
+          source,
+          honeypot,
+        }),
+      })
+
+      const payload = await response.json().catch(() => ({}))
+      if (!response.ok) {
+        throw new Error(payload.detail || payload.error || 'Failed to send contact request')
+      }
+
+      setEmail('')
+      setName('')
+      setCompany('')
+      setMessage('')
+      setSuccess("Message received. We'll follow up shortly.")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send contact request')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className={cn('rounded-2xl border border-white/10 bg-[#0d0d0d] p-6 shadow-xl', className)}>
+      <div className="mb-5">
+        <div className="eyebrow mb-3">Direct contact</div>
+        <h2 className="text-2xl font-medium text-white">Tell us what you need</h2>
+        <p className="mt-2 text-sm leading-6 text-white/60">
+          Use this form for demos, integrations, hosted access, or fit questions. It writes into the live MUTX leads surface.
+        </p>
+      </div>
+
+      {success ? (
+        <div className="flex items-start gap-3 rounded-xl border border-emerald-400/20 bg-emerald-400/10 px-4 py-3 text-emerald-100">
+          <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0" />
+          <div>
+            <p className="font-medium">{success}</p>
+            <p className="mt-1 text-sm text-emerald-100/70">If it is urgent, you can also email hello@mutx.dev directly.</p>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            name="company_website"
+            value={honeypot}
+            onChange={(event) => setHoneypot(event.target.value)}
+            tabIndex={-1}
+            autoComplete="off"
+            className="hidden"
+          />
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="block text-sm text-white/70">
+              <span className="mb-2 block">Name</span>
+              <input
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Your name"
+                className="w-full rounded-lg border border-white/10 bg-black px-4 py-2.5 text-sm text-white placeholder:text-white/30 focus:border-white/30 focus:outline-none focus:ring-1 focus:ring-white/20"
+              />
+            </label>
+
+            <label className="block text-sm text-white/70">
+              <span className="mb-2 block">Work email</span>
+              <input
+                type="email"
+                required
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="you@company.com"
+                className="w-full rounded-lg border border-white/10 bg-black px-4 py-2.5 text-sm text-white placeholder:text-white/30 focus:border-white/30 focus:outline-none focus:ring-1 focus:ring-white/20"
+              />
+            </label>
+          </div>
+
+          <label className="block text-sm text-white/70">
+            <span className="mb-2 block">Company</span>
+            <input
+              value={company}
+              onChange={(event) => setCompany(event.target.value)}
+              placeholder="Acme, Inc."
+              className="w-full rounded-lg border border-white/10 bg-black px-4 py-2.5 text-sm text-white placeholder:text-white/30 focus:border-white/30 focus:outline-none focus:ring-1 focus:ring-white/20"
+            />
+          </label>
+
+          <label className="block text-sm text-white/70">
+            <span className="mb-2 block">What are you trying to do?</span>
+            <textarea
+              required
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+              placeholder="Hosted evaluation, agent deployment workflows, dashboard demo, API/SDK fit, or enterprise rollout questions."
+              rows={6}
+              className="w-full rounded-lg border border-white/10 bg-black px-4 py-3 text-sm text-white placeholder:text-white/30 focus:border-white/30 focus:outline-none focus:ring-1 focus:ring-white/20"
+            />
+          </label>
+
+          {error ? (
+            <div className="flex items-start gap-3 rounded-xl border border-rose-400/20 bg-rose-400/10 px-4 py-3 text-rose-100">
+              <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+              <p className="text-sm">{error}</p>
+            </div>
+          ) : null}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="inline-flex items-center gap-2 rounded-lg bg-white px-5 py-2.5 text-sm font-medium text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+            {loading ? 'Sending…' : 'Send message'}
+          </button>
+        </form>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a public `/contact` page for demos, hosted access, and fit questions
- proxy contact submissions through a same-origin `/api/leads` route into the existing public leads API
- update the landing page nav/footer to point at the new contact page

## Validation
- npm run build