### PR TITLE
feat(web): make contact page institutional

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { ArrowRight, BookOpen, Github, Mail, MessageSquareText } from 'lucide-react'
+import { ArrowRight, BookOpen, Github, Mail } from 'lucide-react'
 
 import { ContactLeadForm } from '@/components/ContactLeadForm'
-import { WaitlistForm } from '@/components/WaitlistForm'
 
 const GITHUB_URL = 'https://github.com/fortunexbt/mutx-dev'
 const DOCS_URL = 'https://docs.mutx.dev'
@@ -11,27 +10,46 @@ const CONTACT_EMAIL = 'hello@mutx.dev'
 
 export const metadata: Metadata = {
   title: 'Contact | MUTX',
-  description: 'Contact MUTX for demos, hosted access, integrations, and operator workflow questions.',
+  description: 'Institutional contact for MUTX: funding, partnerships, contributions, ideas, demos, and hosted access.',
 }
 
-const quickLinks = [
+const inquiryTracks = [
+  {
+    title: 'Funding',
+    body: 'Investor conversations, strategic capital, and financing discussions around MUTX as the control plane for AI agents.',
+  },
+  {
+    title: 'Partnerships',
+    body: 'Distribution, infrastructure, enterprise, and ecosystem conversations where MUTX should be part of the operating stack.',
+  },
+  {
+    title: 'Contributions',
+    body: 'Open-source collaboration across code, docs, design, infrastructure, and operator workflows.',
+  },
+  {
+    title: 'Ideas',
+    body: 'Product ideas, design-partner workflows, integration proposals, and gaps worth closing before broader rollout.',
+  },
+]
+
+const directChannels = [
   {
     title: 'Email',
-    body: 'If you already know what you need, email the team directly.',
+    body: 'Use direct email if you already know the conversation you want to have.',
     href: `mailto:${CONTACT_EMAIL}`,
     label: CONTACT_EMAIL,
     icon: Mail,
   },
   {
     title: 'Docs',
-    body: 'Inspect the live product surface, API, and operator contract first.',
+    body: 'Inspect the current surface, contract, and product truth before reaching out.',
     href: DOCS_URL,
     label: 'docs.mutx.dev',
     icon: BookOpen,
   },
   {
     title: 'GitHub',
-    body: 'Review the actual repo, issues, and shipping state before the call.',
+    body: 'Review the live repo, issues, and shipping state directly.',
     href: GITHUB_URL,
     label: 'fortunexbt/mutx-dev',
     icon: Github,
@@ -42,53 +60,62 @@ export default function ContactPage() {
   return (
     <main className="min-h-screen bg-black px-6 py-20 text-white">
       <div className="mx-auto max-w-7xl">
-        <div className="mb-14 max-w-3xl">
+        <div className="mb-14 max-w-4xl">
           <div className="eyebrow mb-5">Contact</div>
-          <h1 className="text-4xl font-medium tracking-tight sm:text-6xl">Talk to the team behind MUTX.</h1>
-          <p className="mt-5 max-w-2xl text-base leading-7 text-white/60 sm:text-lg">
-            Use this page for live demos, hosted access, operator workflow questions, integrations, or enterprise fit checks.
-            If you want to inspect the product first, start with the docs and GitHub, then send the exact workflow you want to evaluate.
+          <h1 className="text-4xl font-medium tracking-tight sm:text-6xl">Contact MUTX.</h1>
+          <p className="mt-5 max-w-3xl text-base leading-7 text-white/60 sm:text-lg">
+            This page is for institutional inbound: funding, partnerships, contributions, ideas, demos, hosted access,
+            and other serious conversations around MUTX. Keep it concise, pick the right inquiry type, and we will route it correctly.
           </p>
         </div>
 
-        <div className="grid gap-5 md:grid-cols-3">
-          {quickLinks.map((item) => (
-            <a
-              key={item.title}
-              href={item.href}
-              target={item.href.startsWith('http') ? '_blank' : undefined}
-              rel={item.href.startsWith('http') ? 'noreferrer' : undefined}
-              className="rounded-2xl border border-white/10 bg-[#0d0d0d] p-5 transition-colors hover:border-white/20 hover:bg-[#121212]"
-            >
-              <item.icon className="h-5 w-5 text-white/80" />
-              <h2 className="mt-4 text-lg font-medium text-white">{item.title}</h2>
-              <p className="mt-2 text-sm leading-6 text-white/60">{item.body}</p>
-              <div className="mt-4 inline-flex items-center gap-2 text-sm text-white/80">
-                <span>{item.label}</span>
-                <ArrowRight className="h-4 w-4" />
-              </div>
-            </a>
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {inquiryTracks.map((track) => (
+            <div key={track.title} className="rounded-2xl border border-white/10 bg-[#0d0d0d] p-5">
+              <p className="text-sm font-medium text-white">{track.title}</p>
+              <p className="mt-3 text-sm leading-6 text-white/60">{track.body}</p>
+            </div>
           ))}
         </div>
 
-        <div className="mt-10 grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+        <div className="mt-10 grid gap-8 lg:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
           <ContactLeadForm />
 
           <div className="space-y-6">
             <div className="rounded-2xl border border-white/10 bg-[#0d0d0d] p-6">
-              <div className="mb-4 flex items-center gap-3">
-                <MessageSquareText className="h-5 w-5 text-white/80" />
-                <h2 className="text-xl font-medium text-white">Best inbound messages</h2>
-              </div>
-              <ul className="space-y-3 text-sm leading-6 text-white/60">
-                <li>• the exact workflow you want to demo</li>
-                <li>• whether you need hosted MUTX or open-source support</li>
-                <li>• your team size, runtime, and deployment constraints</li>
-                <li>• whether the blocker is dashboard UX, API surface, or production rollout</li>
+              <h2 className="text-xl font-medium text-white">What to include</h2>
+              <ul className="mt-4 space-y-3 text-sm leading-6 text-white/60">
+                <li>• who you are and what organization you represent</li>
+                <li>• the exact funding, partnership, contribution, or product angle</li>
+                <li>• what you need to see from MUTX in the near term</li>
+                <li>• timing, deployment constraints, and decision context if relevant</li>
               </ul>
             </div>
 
-            <WaitlistForm source="contact-page" className="bg-[#0d0d0d]" />
+            <div className="rounded-2xl border border-white/10 bg-[#0d0d0d] p-6">
+              <h2 className="text-xl font-medium text-white">Direct channels</h2>
+              <div className="mt-4 space-y-4">
+                {directChannels.map((item) => (
+                  <a
+                    key={item.title}
+                    href={item.href}
+                    target={item.href.startsWith('http') ? '_blank' : undefined}
+                    rel={item.href.startsWith('http') ? 'noreferrer' : undefined}
+                    className="block rounded-xl border border-white/10 bg-black/40 p-4 transition-colors hover:border-white/20 hover:bg-black/60"
+                  >
+                    <div className="flex items-center gap-3 text-white">
+                      <item.icon className="h-4 w-4 text-white/80" />
+                      <span className="font-medium">{item.title}</span>
+                    </div>
+                    <p className="mt-2 text-sm leading-6 text-white/60">{item.body}</p>
+                    <div className="mt-3 inline-flex items-center gap-2 text-sm text-white/80">
+                      <span>{item.label}</span>
+                      <ArrowRight className="h-4 w-4" />
+                    </div>
+                  </a>
+                ))}
+              </div>
+            </div>
 
             <div className="flex flex-wrap gap-4 text-sm text-white/60">
               <Link href="/" className="transition-colors hover:text-white">

--- a/components/ContactLeadForm.tsx
+++ b/components/ContactLeadForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type FormEvent, useState } from 'react'
+import { type FormEvent, useMemo, useState } from 'react'
 import { AlertCircle, CheckCircle2, Loader2, Send } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
@@ -10,15 +10,39 @@ type ContactLeadFormProps = {
   className?: string
 }
 
+const INQUIRY_TYPES = [
+  { value: 'funding', label: 'Funding' },
+  { value: 'partnerships', label: 'Partnerships' },
+  { value: 'contributions', label: 'Contributions' },
+  { value: 'ideas', label: 'Ideas' },
+  { value: 'demo-hosted-access', label: 'Demo / hosted access' },
+  { value: 'general', label: 'General' },
+] as const
+
+const MESSAGE_PLACEHOLDERS: Record<string, string> = {
+  funding: 'What kind of financing conversation is relevant, what stage are you evaluating, and what part of the MUTX roadmap matters most?',
+  partnerships: 'Describe the partnership, distribution, infrastructure, enterprise, or integration angle you want to explore.',
+  contributions: 'Tell us what you want to contribute: code, docs, design, infrastructure, GTM support, or ecosystem work.',
+  ideas: 'Share the product idea, operator workflow, feature gap, or design-partner use case you think MUTX should support.',
+  'demo-hosted-access': 'Tell us what you need to see in a live demo or hosted evaluation, and what environment or workflow you are trying to validate.',
+  general: 'Summarize the context, what you need, and how MUTX can help.',
+}
+
 export function ContactLeadForm({ source = 'contact-page', className }: ContactLeadFormProps) {
+  const [inquiryType, setInquiryType] = useState('general')
   const [email, setEmail] = useState('')
   const [name, setName] = useState('')
-  const [company, setCompany] = useState('')
+  const [organization, setOrganization] = useState('')
   const [message, setMessage] = useState('')
   const [honeypot, setHoneypot] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
+
+  const inquiryLabel = useMemo(
+    () => INQUIRY_TYPES.find((item) => item.value === inquiryType)?.label ?? 'General',
+    [inquiryType],
+  )
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -33,9 +57,9 @@ export function ContactLeadForm({ source = 'contact-page', className }: ContactL
         body: JSON.stringify({
           email,
           name,
-          company,
-          message,
-          source,
+          company: organization,
+          message: `Inquiry type: ${inquiryLabel}\n\n${message.trim()}`,
+          source: `${source}:${inquiryType}`,
           honeypot,
         }),
       })
@@ -45,11 +69,12 @@ export function ContactLeadForm({ source = 'contact-page', className }: ContactL
         throw new Error(payload.detail || payload.error || 'Failed to send contact request')
       }
 
+      setInquiryType('general')
       setEmail('')
       setName('')
-      setCompany('')
+      setOrganization('')
       setMessage('')
-      setSuccess("Message received. We'll follow up shortly.")
+      setSuccess('Message received. The right MUTX lane will follow up.')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to send contact request')
     } finally {
@@ -60,10 +85,10 @@ export function ContactLeadForm({ source = 'contact-page', className }: ContactL
   return (
     <div className={cn('rounded-2xl border border-white/10 bg-[#0d0d0d] p-6 shadow-xl', className)}>
       <div className="mb-5">
-        <div className="eyebrow mb-3">Direct contact</div>
-        <h2 className="text-2xl font-medium text-white">Tell us what you need</h2>
+        <div className="eyebrow mb-3">Institutional contact</div>
+        <h2 className="text-2xl font-medium text-white">Send a structured inquiry</h2>
         <p className="mt-2 text-sm leading-6 text-white/60">
-          Use this form for demos, integrations, hosted access, or fit questions. It writes into the live MUTX leads surface.
+          Use one slim form for funding, partnerships, contributions, ideas, demos, or general inbound.
         </p>
       </div>
 
@@ -72,7 +97,7 @@ export function ContactLeadForm({ source = 'contact-page', className }: ContactL
           <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0" />
           <div>
             <p className="font-medium">{success}</p>
-            <p className="mt-1 text-sm text-emerald-100/70">If it is urgent, you can also email hello@mutx.dev directly.</p>
+            <p className="mt-1 text-sm text-emerald-100/70">If it is urgent, email hello@mutx.dev directly.</p>
           </div>
         </div>
       ) : (
@@ -86,6 +111,22 @@ export function ContactLeadForm({ source = 'contact-page', className }: ContactL
             autoComplete="off"
             className="hidden"
           />
+
+          <label className="block text-sm text-white/70">
+            <span className="mb-2 block">Inquiry type</span>
+            <select
+              required
+              value={inquiryType}
+              onChange={(event) => setInquiryType(event.target.value)}
+              className="w-full rounded-lg border border-white/10 bg-black px-4 py-2.5 text-sm text-white focus:border-white/30 focus:outline-none focus:ring-1 focus:ring-white/20"
+            >
+              {INQUIRY_TYPES.map((item) => (
+                <option key={item.value} value={item.value}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          </label>
 
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="block text-sm text-white/70">
@@ -112,22 +153,22 @@ export function ContactLeadForm({ source = 'contact-page', className }: ContactL
           </div>
 
           <label className="block text-sm text-white/70">
-            <span className="mb-2 block">Company</span>
+            <span className="mb-2 block">Organization</span>
             <input
-              value={company}
-              onChange={(event) => setCompany(event.target.value)}
-              placeholder="Acme, Inc."
+              value={organization}
+              onChange={(event) => setOrganization(event.target.value)}
+              placeholder="Firm, company, studio, or fund"
               className="w-full rounded-lg border border-white/10 bg-black px-4 py-2.5 text-sm text-white placeholder:text-white/30 focus:border-white/30 focus:outline-none focus:ring-1 focus:ring-white/20"
             />
           </label>
 
           <label className="block text-sm text-white/70">
-            <span className="mb-2 block">What are you trying to do?</span>
+            <span className="mb-2 block">Message</span>
             <textarea
               required
               value={message}
               onChange={(event) => setMessage(event.target.value)}
-              placeholder="Hosted evaluation, agent deployment workflows, dashboard demo, API/SDK fit, or enterprise rollout questions."
+              placeholder={MESSAGE_PLACEHOLDERS[inquiryType]}
               rows={6}
               className="w-full rounded-lg border border-white/10 bg-black px-4 py-3 text-sm text-white placeholder:text-white/30 focus:border-white/30 focus:outline-none focus:ring-1 focus:ring-white/20"
             />
@@ -146,7 +187,7 @@ export function ContactLeadForm({ source = 'contact-page', className }: ContactL
             className="inline-flex items-center gap-2 rounded-lg bg-white px-5 py-2.5 text-sm font-medium text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
-            {loading ? 'Sending…' : 'Send message'}
+            {loading ? 'Sending…' : 'Send inquiry'}
           </button>
         </form>
       )}


### PR DESCRIPTION
## Summary
- make `/contact` more institutional and concise
- add clear inquiry tracks for funding, partnerships, contributions, and ideas
- route inbound through a slim inquiry-type form while keeping the existing design language

## Validation
- ./node_modules/.bin/tsc --noEmit
- npm run build