### PR TITLE
feat(web): add one-command local demo validation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,32 +79,19 @@ git clone https://github.com/fortunexbt/mutx-dev
 cd mutx-dev
 ```
 
-Run the platform locally:
-
-```bash
-make up
-```
-
-Create your first agent:
-
-```bash
-mutx agent create
-```
-
 ### Demo Validation
 
-Verify the demo path works locally:
+Verify the demo path works locally in one command:
 
 ```bash
 npm run demo:validate
 ```
 
 This validates:
-- Homepage loads (`/`)
-- App shell loads (`/app`)
-- Static pages load (`/contact`, `/privacy-policy`)
-
-Success output confirms the demo path is ready for presentation.
+- API health (`/health`) and readiness (`/ready`),
+- Homepage loads (`/`),
+- App shell loads (`/app`),
+- Static pages load (`/contact`, `/privacy-policy`).
 
 More details in the docs:
 

--- a/docs/deployment/quickstart.md
+++ b/docs/deployment/quickstart.md
@@ -41,6 +41,18 @@ DATABASE_URL=postgresql://mutx:mutx_password@localhost:5432/mutx
 {% endstep %}
 
 {% step %}
+### One-command morning demo validation
+
+Use this for the canonical morning-run path (start everything + validate):
+
+```bash
+npm run demo:validate
+```
+
+This validates API health and the demo-facing routes in one go.
+{% endstep %}
+
+{% step %}
 ### Start the local demo stack
 
 Use the repo's canonical bootstrap script when you want the fastest morning-demo path:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "generate-types": "openapi-typescript docs/api/openapi.json -o app/types/api.ts",
     "test:app": "jest --runInBand tests/unit/controlPlane.test.ts",
-    "demo:validate": "node scripts/validate-demo.js"
+    "demo:validate": "bash scripts/demo-validate.sh"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.0",

--- a/scripts/demo-validate.sh
+++ b/scripts/demo-validate.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/infrastructure/docker/docker-compose.yml"
+
+echo "🚀 Starting MUTX local demo stack for validation..."
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "✗ Docker is required for one-command demo validation."
+  echo "  Install Docker Desktop and rerun this command."
+  exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker compose -f "$COMPOSE_FILE")
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker-compose -f "$COMPOSE_FILE")
+else
+  echo "✗ docker compose is required for one-command demo validation."
+  echo "  Install Docker Compose or a Docker distribution with compose support."
+  exit 1
+fi
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "✗ Compose file missing at $COMPOSE_FILE"
+  exit 1
+fi
+
+if [[ ! -f "$ROOT_DIR/.env" && -f "$ROOT_DIR/.env.example" ]]; then
+  echo "Creating .env from .env.example for container defaults..."
+  cp "$ROOT_DIR/.env.example" "$ROOT_DIR/.env"
+fi
+
+"${COMPOSE_CMD[@]}" up --build -d postgres redis api frontend
+
+echo "Demo stack booted. Running validation checks (frontend + API)."
+
+DEMO_SKIP_START=1 \
+DEMO_API_URL="${DEMO_API_URL:-http://localhost:8000}" \
+DEMO_PORT="${DEMO_PORT:-3000}" \
+DEMO_HOST="${DEMO_HOST:-localhost}" \
+DEMO_CHECK_API="${DEMO_CHECK_API:-1}" \
+node "$ROOT_DIR/scripts/validate-demo.js"
+
+echo "Stack is running and ready for demo use."
+echo "Frontend: http://localhost:3000"
+echo "API: http://localhost:8000"
+echo "Stop stack later with: docker compose -f infrastructure/docker/docker-compose.yml down"

--- a/scripts/validate-demo.js
+++ b/scripts/validate-demo.js
@@ -4,10 +4,21 @@ const http = require('http');
 const { spawn } = require('child_process');
 const { URL } = require('url');
 
-let DEMO_PORT = 3000;
-const DEMO_HOST = 'localhost';
-const STARTUP_TIMEOUT = 90000;
-const CHECK_INTERVAL = 2000;
+const DEMO_HOST = process.env.DEMO_HOST || 'localhost';
+let DEMO_PORT = Number(process.env.DEMO_PORT || process.env.PORT || '3000');
+const API_BASE_URL = process.env.DEMO_API_URL || process.env.DEMO_API_BASE || 'http://localhost:8000';
+const STARTUP_TIMEOUT = Number(process.env.DEMO_STARTUP_TIMEOUT || '90000');
+const CHECK_INTERVAL = Number(process.env.DEMO_CHECK_INTERVAL || '2000');
+const USE_EXISTING_FRONTEND = process.env.DEMO_SKIP_START === '1' || process.env.DEMO_USE_EXISTING_FRONTEND === '1';
+const CHECK_API = process.env.DEMO_CHECK_API !== '0';
+
+function formatApiUrl(path) {
+  const base = API_BASE_URL.replace(/\/$/, '');
+  if (!path.startsWith('/')) {
+    path = `/${path}`;
+  }
+  return `${base}${path}`;
+}
 
 function get(url) {
   return new Promise((resolve, reject) => {
@@ -24,27 +35,30 @@ function get(url) {
   });
 }
 
-async function waitForServer(host, port, timeout) {
+async function waitForServer(url, timeout, label = 'server') {
   const start = Date.now();
   while (Date.now() - start < timeout) {
     try {
-      await get(`http://${host}:${port}`);
+      await get(url);
       return true;
     } catch {
       await new Promise(r => setTimeout(r, CHECK_INTERVAL));
     }
   }
-  return false;
+  throw new Error(`${label} did not become ready within ${timeout}ms`);
 }
 
-async function validateRoute(path, expectedStatus = 200) {
-  const url = new URL(path, `http://${DEMO_HOST}:${DEMO_PORT}`);
-  console.log(`  Validating ${path}...`);
+async function validateRoute(pathOrUrl, expectedStatus = 200) {
+  const url = /^https?:\/\//.test(pathOrUrl)
+    ? pathOrUrl
+    : `http://${DEMO_HOST}:${DEMO_PORT}${pathOrUrl.startsWith('/') ? pathOrUrl : `/${pathOrUrl}`}`;
+
+  console.log(`  Validating ${new URL(url).pathname} at ${url}...`);
   const res = await get(url);
   if (res.status !== expectedStatus) {
-    throw new Error(`${path} returned ${res.status}, expected ${expectedStatus}`);
+    throw new Error(`${url} returned ${res.status}, expected ${expectedStatus}`);
   }
-  console.log(`  ✓ ${path} -> ${res.status}`);
+  console.log(`  ✓ ${new URL(url).pathname} -> ${res.status}`);
   return true;
 }
 
@@ -56,60 +70,69 @@ async function main() {
   let detectedPort = null;
 
   try {
-    console.log('Starting Next.js dev server...');
-    devServer = spawn('npm', ['run', 'dev'], {
-      stdio: 'pipe',
-      detached: true,
-      env: { ...process.env }
-    });
-
-    devServer.stdout.on('data', (data) => {
-      const output = data.toString();
-      const portMatch = output.match(/localhost:(\d+)/);
-      if (portMatch) {
-        detectedPort = parseInt(portMatch[1], 10);
-      }
-    });
-
-    devServer.stderr.on('data', (data) => {
-      const output = data.toString();
-      const portMatch = output.match(/localhost:(\d+)/);
-      if (portMatch) {
-        detectedPort = parseInt(portMatch[1], 10);
-      }
-    });
-
-    console.log(`Waiting for server...`);
-    
-    const start = Date.now();
-    while (!detectedPort && Date.now() - start < STARTUP_TIMEOUT) {
-      await new Promise(r => setTimeout(r, 500));
-    }
-
-    if (!detectedPort) {
-      detectedPort = 3000;
-      const ready = await waitForServer(DEMO_HOST, detectedPort, 5000);
-      if (!ready) {
-        throw new Error(`Server did not start within ${STARTUP_TIMEOUT}ms`);
-      }
+    if (USE_EXISTING_FRONTEND) {
+      console.log('Using existing frontend server from environment.');
+      const candidate = `http://${DEMO_HOST}:${DEMO_PORT}`;
+      await waitForServer(candidate, STARTUP_TIMEOUT, `Frontend on ${candidate}`);
     } else {
-      DEMO_PORT = detectedPort;
+      console.log('Starting Next.js dev server...');
+      devServer = spawn('npm', ['run', 'dev'], {
+        stdio: 'pipe',
+        detached: true,
+        env: { ...process.env },
+        cwd: process.cwd(),
+      });
+
+      devServer.stdout.on('data', (data) => {
+        const output = data.toString();
+        const portMatch = output.match(/localhost:(\d+)/);
+        if (portMatch) {
+          detectedPort = parseInt(portMatch[1], 10);
+        }
+      });
+
+      devServer.stderr.on('data', (data) => {
+        const output = data.toString();
+        const portMatch = output.match(/localhost:(\d+)/);
+        if (portMatch) {
+          detectedPort = parseInt(portMatch[1], 10);
+        }
+      });
+
+      console.log('Waiting for server...');
+
+      const start = Date.now();
+      while (!detectedPort && Date.now() - start < STARTUP_TIMEOUT) {
+        await new Promise(r => setTimeout(r, 500));
+      }
+
+      if (!detectedPort) {
+        detectedPort = DEMO_PORT;
+        await waitForServer(`http://${DEMO_HOST}:${DEMO_PORT}`, 5000, `Frontend on ${DEMO_HOST}:${DEMO_PORT}`);
+      } else {
+        DEMO_PORT = detectedPort;
+      }
     }
 
-    console.log(`Server ready on port ${DEMO_PORT}. Validating demo routes...\n`);
+    const frontendBase = `http://${DEMO_HOST}:${DEMO_PORT}`;
+    console.log(`Server ready on ${frontendBase}. Validating demo routes...\n`);
 
-    await validateRoute('/', 200);
-    await validateRoute('/app', 200);
-    await validateRoute('/contact', 200);
-    await validateRoute('/privacy-policy', 200);
+    if (CHECK_API) {
+      await validateRoute(formatApiUrl('/health'));
+      await validateRoute(formatApiUrl('/ready'));
+    }
+
+    await validateRoute('/');
+    await validateRoute('/app');
+    await validateRoute('/contact');
+    await validateRoute('/privacy-policy');
 
     console.log('\n=====================');
     console.log('✓ Demo validation passed');
     console.log('=====================\n');
-    console.log(`Demo available at: http://${DEMO_HOST}:${DEMO_PORT}`);
+    console.log(`Demo available at: ${frontendBase}`);
     console.log('  - Homepage: /');
     console.log('  - App shell: /app');
-
     return 0;
   } catch (err) {
     console.error('\n=====================');


### PR DESCRIPTION
Closes #172

## Scope
- Adds a new one-command local demo validation wrapper at scripts/demo-validate.sh
- Updates scripts/validate-demo.js to verify API health/readiness plus frontend routes and to support checking an already-running frontend
- Rewires npm script demo:validate to run the wrapper flow
- Updates README and docs/deployment quickstart to document the one-command demo path

## Validation
- node --check scripts/validate-demo.js
- bash -n scripts/demo-validate.sh
- DEMO_CHECK_API=0 node scripts/validate-demo.js (frontend route smoke)
- Full command requires a running Docker daemon; environment here lacked access to docker.sock for full-stack validation.