### PR TITLE
Fix local dev bootstrap after Compose relocation

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,12 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # MUTX Local Development Bootstrap
 # Starts all services via Docker Compose: PostgreSQL, Redis, Backend API, Frontend
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/infrastructure/docker/docker-compose.yml"
 
 # Colors
 RED='\033[0;31m'
@@ -19,93 +20,111 @@ echo -e "${BLUE}🚀 MUTX Local Development Bootstrap${NC}"
 echo "========================================"
 
 # Check for Docker
-if ! command -v docker &> /dev/null; then
-    echo -e "${RED}✗ Docker not found. Please install Docker.${NC}"
-    exit 1
+if ! command -v docker >/dev/null 2>&1; then
+  echo -e "${RED}✗ Docker not found. Install Docker Desktop or Docker Engine first.${NC}"
+  exit 1
 fi
 
-if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null; then
-    echo -e "${RED}✗ docker-compose not found. Please install docker-compose.${NC}"
-    exit 1
+if ! docker info >/dev/null 2>&1; then
+  echo -e "${RED}✗ Docker daemon is not running.${NC}"
+  echo "  Start Docker Desktop (or the Docker service) and retry."
+  exit 1
 fi
 
-# Use docker compose (v2) or docker-compose (v1)
-COMPOSE_CMD="docker compose"
-if ! docker compose version &> /dev/null; then
-    COMPOSE_CMD="docker-compose"
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker compose -f "$COMPOSE_FILE")
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker-compose -f "$COMPOSE_FILE")
+else
+  echo -e "${RED}✗ Docker Compose not found.${NC}"
+  echo "  Install Docker Compose (\`docker compose\` plugin or \`docker-compose\`) and retry."
+  exit 1
 fi
 
-# Check if .env exists, create from example if not
-if [ ! -f ".env" ]; then
-    if [ -f ".env.example" ]; then
-        echo -e "${YELLOW}Creating .env from .env.example...${NC}"
-        cp .env.example .env
-        # Generate a stable JWT secret
-        JWT_SECRET=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))" 2>/dev/null || openssl rand -base64 24)
-        sed -i '' "s/JWT_SECRET=replace-with-a-stable-secret/JWT_SECRET=$JWT_SECRET/" .env
-        echo -e "${GREEN}✓ Created .env with generated JWT_SECRET${NC}"
+if [ ! -f "$COMPOSE_FILE" ]; then
+  echo -e "${RED}✗ Compose file not found at:${NC} $COMPOSE_FILE"
+  echo "  Verify your checkout includes infrastructure/docker/docker-compose.yml"
+  exit 1
+fi
+
+# Check if .env exists in repo root, create from example if not
+if [ ! -f "$ROOT_DIR/.env" ]; then
+  if [ -f "$ROOT_DIR/.env.example" ]; then
+    echo -e "${YELLOW}Creating .env from .env.example...${NC}"
+    cp "$ROOT_DIR/.env.example" "$ROOT_DIR/.env"
+
+    # Generate a stable JWT secret
+    JWT_SECRET=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))" 2>/dev/null || openssl rand -base64 24)
+    if sed --version >/dev/null 2>&1; then
+      sed -i "s|JWT_SECRET=replace-with-a-stable-secret|JWT_SECRET=$JWT_SECRET|" "$ROOT_DIR/.env"
     else
-        echo -e "${RED}✗ No .env.example found${NC}"
-        exit 1
+      sed -i '' "s|JWT_SECRET=replace-with-a-stable-secret|JWT_SECRET=$JWT_SECRET|" "$ROOT_DIR/.env"
     fi
+
+    echo -e "${GREEN}✓ Created .env with generated JWT_SECRET${NC}"
+  else
+    echo -e "${RED}✗ Missing $ROOT_DIR/.env.example${NC}"
+    echo "  Create .env manually with required local variables and retry."
+    exit 1
+  fi
 fi
 
 # Function to cleanup on exit
 cleanup() {
-    echo -e "\n${YELLOW}Shutting down services...${NC}"
-    $COMPOSE_CMD down
-    exit 0
+  echo -e "\n${YELLOW}Shutting down services...${NC}"
+  "${COMPOSE_CMD[@]}" down
+  exit 0
 }
 
 trap cleanup SIGINT SIGTERM
 
 # Build and start all services
 echo -e "\n${BLUE}🐳 Building and starting all services...${NC}"
-$COMPOSE_CMD up --build -d
+"${COMPOSE_CMD[@]}" up --build -d
 
 # Wait for services to be healthy
 echo -e "\n${YELLOW}Waiting for services to be ready...${NC}"
 
 # Wait for PostgreSQL
-for i in {1..30}; do
-    if $COMPOSE_CMD exec -T postgres pg_isready -U mutx &> /dev/null; then
-        echo -e "${GREEN}✓ PostgreSQL is ready${NC}"
-        break
-    fi
-    sleep 1
+for _ in {1..30}; do
+  if "${COMPOSE_CMD[@]}" exec -T postgres pg_isready -U mutx >/dev/null 2>&1; then
+    echo -e "${GREEN}✓ PostgreSQL is ready${NC}"
+    break
+  fi
+  sleep 1
 done
 
 # Wait for Redis
-for i in {1..10}; do
-    if $COMPOSE_CMD exec -T redis redis-cli ping &> /dev/null; then
-        echo -e "${GREEN}✓ Redis is ready${NC}"
-        break
-    fi
-    sleep 1
+for _ in {1..10}; do
+  if "${COMPOSE_CMD[@]}" exec -T redis redis-cli ping >/dev/null 2>&1; then
+    echo -e "${GREEN}✓ Redis is ready${NC}"
+    break
+  fi
+  sleep 1
 done
 
 # Wait for API
-for i in {1..60}; do
-    if curl -s http://localhost:8000/health &> /dev/null; then
-        echo -e "${GREEN}✓ Backend API is ready${NC}"
-        break
-    fi
-    sleep 1
+for _ in {1..60}; do
+  if curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
+    echo -e "${GREEN}✓ Backend API is ready${NC}"
+    break
+  fi
+  sleep 1
 done
 
 # Wait for Frontend
-for i in {1..60}; do
-    if curl -s http://localhost:3000 &> /dev/null; then
-        echo -e "${GREEN}✓ Frontend is ready${NC}"
-        break
-    fi
-    sleep 1
+for _ in {1..60}; do
+  if curl -fsS http://localhost:3000 >/dev/null 2>&1; then
+    echo -e "${GREEN}✓ Frontend is ready${NC}"
+    break
+  fi
+  sleep 1
 done
 
 # Show service status
 echo ""
 echo -e "${BLUE}📊 Service Status:${NC}"
-$COMPOSE_CMD ps
+"${COMPOSE_CMD[@]}" ps
 
 # Summary
 echo ""
@@ -113,13 +132,13 @@ echo "========================================"
 echo -e "${GREEN}🎉 All services are running!${NC}"
 echo "========================================"
 echo ""
-echo -e "  ${BLUE}Frontend:${NC}  http://localhost:3000"
+echo -e "  ${BLUE}Frontend:${NC}   http://localhost:3000"
 echo -e "  ${BLUE}Backend API:${NC} http://localhost:8000"
-echo -e "  ${BLUE}API Docs:${NC}  http://localhost:8000/docs"
-echo -e "  ${BLUE}Health:${NC}    http://localhost:8000/health"
+echo -e "  ${BLUE}API Docs:${NC}   http://localhost:8000/docs"
+echo -e "  ${BLUE}Health:${NC}     http://localhost:8000/health"
 echo ""
 echo "Press Ctrl+C to stop all services"
 echo ""
 
 # Follow logs
-$COMPOSE_CMD logs -f
+"${COMPOSE_CMD[@]}" logs -f


### PR DESCRIPTION
## Summary
- update `scripts/dev.sh` to resolve paths from repo root instead of `scripts/`
- point all compose operations to `infrastructure/docker/docker-compose.yml` explicitly
- add clearer prerequisite checks for Docker CLI, Docker daemon, Compose, and missing env template

## Why
This is the smallest mergeable slice for #115: it restores the canonical `./scripts/dev.sh` local bootstrap path from repo root after compose files moved under `infrastructure/docker/`.

## Validation
- `bash -n scripts/dev.sh`
- `docker compose -f infrastructure/docker/docker-compose.yml config --services`
- `./scripts/dev.sh` now exits early with clear prerequisite output when daemon is stopped

Refs #115
