### PR TITLE
SDK deployment events parity + logs/metrics contract coverage

### DIFF
--- a/sdk/mutx/deployments.py
+++ b/sdk/mutx/deployments.py
@@ -7,6 +7,31 @@ from uuid import UUID
 import httpx
 
 
+class DeploymentEvent:
+    def __init__(self, data: dict[str, Any]):
+        self.id = UUID(data["id"])
+        self.deployment_id = UUID(data["deployment_id"])
+        self.event_type = data["event_type"]
+        self.status = data["status"]
+        self.node_id = data.get("node_id")
+        self.error_message = data.get("error_message")
+        self.created_at = datetime.fromisoformat(data["created_at"])
+        self._data = data
+
+
+class DeploymentEventHistory:
+    def __init__(self, data: dict[str, Any]):
+        self.deployment_id = UUID(data["deployment_id"])
+        self.deployment_status = data["deployment_status"]
+        self.items = [DeploymentEvent(item) for item in data.get("items", [])]
+        self.total = data["total"]
+        self.skip = data["skip"]
+        self.limit = data["limit"]
+        self.event_type = data.get("event_type")
+        self.status = data.get("status")
+        self._data = data
+
+
 class Deployment:
     def __init__(self, data: dict[str, Any]):
         self.id = UUID(data["id"])
@@ -14,9 +39,12 @@ class Deployment:
         self.status = data["status"]
         self.replicas = data["replicas"]
         self.node_id = data.get("node_id")
-        self.started_at = datetime.fromisoformat(data["started_at"])
+        self.started_at = (
+            datetime.fromisoformat(data["started_at"]) if data.get("started_at") else None
+        )
         self.ended_at = datetime.fromisoformat(data["ended_at"]) if data.get("ended_at") else None
         self.error_message = data.get("error_message")
+        self.events = [DeploymentEvent(item) for item in data.get("events", [])]
         self._data = data
 
     def __repr__(self) -> str:
@@ -133,6 +161,50 @@ class Deployments:
         response.raise_for_status()
         return Deployment(response.json())
 
+    def events(
+        self,
+        deployment_id: UUID | str,
+        skip: int = 0,
+        limit: int = 100,
+        event_type: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> DeploymentEventHistory:
+        params: dict[str, Any] = {"skip": skip, "limit": limit}
+        if event_type:
+            params["event_type"] = event_type
+        if status:
+            params["status"] = status
+
+        self._require_sync_client()
+        response = self._client.get(
+            f"/deployments/{deployment_id}/events",
+            params=params,
+        )
+        response.raise_for_status()
+        return DeploymentEventHistory(response.json())
+
+    async def aevents(
+        self,
+        deployment_id: UUID | str,
+        skip: int = 0,
+        limit: int = 100,
+        event_type: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> DeploymentEventHistory:
+        params: dict[str, Any] = {"skip": skip, "limit": limit}
+        if event_type:
+            params["event_type"] = event_type
+        if status:
+            params["status"] = status
+
+        self._require_async_client()
+        response = await self._client.get(
+            f"/deployments/{deployment_id}/events",
+            params=params,
+        )
+        response.raise_for_status()
+        return DeploymentEventHistory(response.json())
+
     def scale(self, deployment_id: UUID | str, replicas: int) -> Deployment:
         self._require_sync_client()
         response = self._client.post(
@@ -178,11 +250,16 @@ class Deployments:
         deployment_id: UUID | str,
         skip: int = 0,
         limit: int = 100,
+        level: Optional[str] = None,
     ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"skip": skip, "limit": limit}
+        if level:
+            params["level"] = level
+
         self._require_sync_client()
         response = self._client.get(
             f"/deployments/{deployment_id}/logs",
-            params={"skip": skip, "limit": limit},
+            params=params,
         )
         response.raise_for_status()
         return response.json()
@@ -192,11 +269,16 @@ class Deployments:
         deployment_id: UUID | str,
         skip: int = 0,
         limit: int = 100,
+        level: Optional[str] = None,
     ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"skip": skip, "limit": limit}
+        if level:
+            params["level"] = level
+
         self._require_async_client()
         response = await self._client.get(
             f"/deployments/{deployment_id}/logs",
-            params={"skip": skip, "limit": limit},
+            params=params,
         )
         response.raise_for_status()
         return response.json()

--- a/tests/api/test_deployments.py
+++ b/tests/api/test_deployments.py
@@ -6,7 +6,14 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.models.models import Agent, Deployment, AgentStatus, DeploymentEvent
+from src.api.models.models import (
+    Agent,
+    AgentLog,
+    AgentMetric,
+    AgentStatus,
+    Deployment,
+    DeploymentEvent,
+)
 
 
 class TestListDeployments:
@@ -316,6 +323,90 @@ class TestDeploymentEvents:
         self, other_user_client: AsyncClient, test_deployment
     ):
         response = await other_user_client.get(f"/deployments/{test_deployment.id}/events")
+        assert response.status_code == 403
+
+
+class TestDeploymentLogs:
+    """Tests for GET /deployments/{deployment_id}/logs endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_deployment_logs_supports_level_filter(
+        self, client: AsyncClient, test_deployment, db_session: AsyncSession
+    ):
+        db_session.add_all(
+            [
+                AgentLog(
+                    agent_id=test_deployment.agent_id,
+                    level="INFO",
+                    message="startup complete",
+                    extra_data='{"node":"node-1"}',
+                ),
+                AgentLog(
+                    agent_id=test_deployment.agent_id,
+                    level="ERROR",
+                    message="probe failed",
+                    extra_data='{"node":"node-1"}',
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/deployments/{test_deployment.id}/logs?level=ERROR&limit=10")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["agent_id"] == str(test_deployment.agent_id)
+        assert data[0]["level"] == "ERROR"
+        assert data[0]["message"] == "probe failed"
+
+    @pytest.mark.asyncio
+    async def test_get_deployment_logs_other_user_forbidden(
+        self, other_user_client: AsyncClient, test_deployment
+    ):
+        response = await other_user_client.get(f"/deployments/{test_deployment.id}/logs")
+        assert response.status_code == 403
+
+
+class TestDeploymentMetrics:
+    """Tests for GET /deployments/{deployment_id}/metrics endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_deployment_metrics_returns_agent_metrics_descending(
+        self, client: AsyncClient, test_deployment, db_session: AsyncSession
+    ):
+        db_session.add_all(
+            [
+                AgentMetric(
+                    agent_id=test_deployment.agent_id,
+                    cpu_usage=0.22,
+                    memory_usage=0.40,
+                    timestamp=datetime.fromisoformat("2026-03-12T09:00:00"),
+                ),
+                AgentMetric(
+                    agent_id=test_deployment.agent_id,
+                    cpu_usage=0.85,
+                    memory_usage=0.92,
+                    timestamp=datetime.fromisoformat("2026-03-12T09:10:00"),
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/deployments/{test_deployment.id}/metrics?limit=10")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data) == 2
+        assert data[0]["agent_id"] == str(test_deployment.agent_id)
+        assert data[0]["cpu_usage"] == 0.85
+        assert data[1]["cpu_usage"] == 0.22
+
+    @pytest.mark.asyncio
+    async def test_get_deployment_metrics_other_user_forbidden(
+        self, other_user_client: AsyncClient, test_deployment
+    ):
+        response = await other_user_client.get(f"/deployments/{test_deployment.id}/metrics")
         assert response.status_code == 403
 
 

--- a/tests/test_sdk_deployments_contract.py
+++ b/tests/test_sdk_deployments_contract.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sdk"))
+
+from mutx.deployments import Deployment, Deployments
+
+
+def _deployment_payload(**overrides: Any) -> dict[str, Any]:
+    payload = {
+        "id": str(uuid.uuid4()),
+        "agent_id": str(uuid.uuid4()),
+        "status": "running",
+        "replicas": 1,
+        "node_id": "node-1",
+        "started_at": "2026-03-12T09:05:00",
+        "ended_at": None,
+        "error_message": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _event_history_payload(deployment_id: uuid.UUID, **overrides: Any) -> dict[str, Any]:
+    payload = {
+        "deployment_id": str(deployment_id),
+        "deployment_status": "running",
+        "items": [
+            {
+                "id": str(uuid.uuid4()),
+                "deployment_id": str(deployment_id),
+                "event_type": "scale",
+                "status": "running",
+                "node_id": "node-1",
+                "error_message": None,
+                "created_at": "2026-03-12T10:00:00",
+            }
+        ],
+        "total": 1,
+        "skip": 0,
+        "limit": 100,
+        "event_type": None,
+        "status": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_deployments_events_hits_contract_route_and_maps_payload() -> None:
+    deployment_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["query"] = dict(request.url.params)
+        return httpx.Response(
+            200,
+            json=_event_history_payload(
+                deployment_id,
+                deployment_status="failed",
+                event_type="restart",
+                status="failed",
+            ),
+        )
+
+    with httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler)) as client:
+        history = Deployments(client).events(
+            deployment_id,
+            skip=3,
+            limit=25,
+            event_type="restart",
+            status="failed",
+        )
+
+    assert captured["path"] == f"/deployments/{deployment_id}/events"
+    assert captured["query"] == {
+        "skip": "3",
+        "limit": "25",
+        "event_type": "restart",
+        "status": "failed",
+    }
+    assert history.deployment_id == deployment_id
+    assert history.deployment_status == "failed"
+    assert history.total == 1
+    assert history.items[0].event_type == "scale"
+
+
+@pytest.mark.asyncio
+async def test_deployments_aevents_hits_contract_route_and_maps_payload() -> None:
+    deployment_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["query"] = dict(request.url.params)
+        return httpx.Response(200, json=_event_history_payload(deployment_id))
+
+    async with httpx.AsyncClient(
+        base_url="https://api.test",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        history = await Deployments(client).aevents(deployment_id, skip=1, limit=10)
+
+    assert captured["path"] == f"/deployments/{deployment_id}/events"
+    assert captured["query"] == {"skip": "1", "limit": "10"}
+    assert history.deployment_id == deployment_id
+    assert history.items[0].status == "running"
+
+
+def test_deployment_parser_accepts_nullable_started_at_and_nested_events() -> None:
+    deployment_id = uuid.uuid4()
+    payload = _deployment_payload(
+        id=str(deployment_id),
+        started_at=None,
+        events=[
+            {
+                "id": str(uuid.uuid4()),
+                "deployment_id": str(deployment_id),
+                "event_type": "create",
+                "status": "pending",
+                "node_id": None,
+                "error_message": None,
+                "created_at": "2026-03-12T09:00:00",
+            }
+        ],
+    )
+
+    deployment = Deployment(payload)
+
+    assert deployment.started_at is None
+    assert len(deployment.events) == 1
+    assert deployment.events[0].event_type == "create"
+
+
+def test_deployments_logs_support_level_filter_param() -> None:
+    deployment_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["query"] = dict(request.url.params)
+        return httpx.Response(200, json=[])
+
+    with httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler)) as client:
+        payload = Deployments(client).logs(deployment_id, skip=2, limit=50, level="ERROR")
+
+    assert payload == []
+    assert captured["path"] == f"/deployments/{deployment_id}/logs"
+    assert captured["query"] == {"skip": "2", "limit": "50", "level": "ERROR"}
+
+
+@pytest.mark.asyncio
+async def test_deployments_alogs_support_level_filter_param() -> None:
+    deployment_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["query"] = dict(request.url.params)
+        return httpx.Response(200, json=[])
+
+    async with httpx.AsyncClient(
+        base_url="https://api.test",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        payload = await Deployments(client).alogs(deployment_id, skip=4, limit=75, level="INFO")
+
+    assert payload == []
+    assert captured["path"] == f"/deployments/{deployment_id}/logs"
+    assert captured["query"] == {"skip": "4", "limit": "75", "level": "INFO"}


### PR DESCRIPTION
## Summary
- add SDK deployment event-history methods (`events` and `aevents`) mapped to `/deployments/{id}/events`
- make SDK deployment parsing resilient to nullable `started_at` and expose nested deployment `events`
- add SDK `level` filter support for deployment logs to match backend route query support
- add focused backend contract tests for deployment logs and metrics endpoints

## Validation
- `pytest -q tests/test_sdk_deployments_contract.py tests/api/test_deployments.py tests/test_cli_deploy_contract.py`
- `pytest -q tests/test_sdk_async_resources_contract.py tests/test_sdk_async_client_contract.py`

Related: #117
