### PR TITLE
fix(monitor): stop self-healing on cancel

### DIFF
--- a/src/api/services/monitor.py
+++ b/src/api/services/monitor.py
@@ -74,24 +74,33 @@ async def start_background_monitor():
     logger.info("Starting background agent monitor...")
     self_healing = get_self_healing_service()
     await self_healing.start()
+    try:
+        while True:
+            try:
+                async with database_module.async_session_maker() as session:
+                    # 1. Run actual monitoring and self-healing logic
+                    await monitor_agent_health(session)
 
-    while True:
+                    # 2. Add synthetic activity for "lively" UI feel (demo only)
+                    result = await session.execute(select(Agent).where(Agent.status == "running"))
+                    running_agents = result.scalars().all()
+                    for agent in running_agents:
+                        if random.random() < 0.3:
+                            await _generate_synthetic_logs(session, agent.id)
+
+                    await session.commit()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.error(f"Error in background monitor: {e}")
+                await asyncio.sleep(5)
+
+            await asyncio.sleep(5)  # Run every 5 seconds
+    except asyncio.CancelledError:
+        logger.info("Background agent monitor cancellation requested")
+        raise
+    finally:
         try:
-            async with database_module.async_session_maker() as session:
-                # 1. Run actual monitoring and self-healing logic
-                await monitor_agent_health(session)
-
-                # 2. Add synthetic activity for "lively" UI feel (demo only)
-                result = await session.execute(select(Agent).where(Agent.status == "running"))
-                running_agents = result.scalars().all()
-                for agent in running_agents:
-                    if random.random() < 0.3:
-                        await _generate_synthetic_logs(session, agent.id)
-
-                await session.commit()
-
-        except Exception as e:
-            logger.error(f"Error in background monitor: {e}")
-            await asyncio.sleep(5)
-
-        await asyncio.sleep(5)  # Run every 5 seconds
+            await self_healing.stop()
+        except Exception:
+            logger.exception("Failed to stop self-healing service cleanly")

--- a/tests/api/test_monitor.py
+++ b/tests/api/test_monitor.py
@@ -1,0 +1,118 @@
+import asyncio
+
+import pytest
+
+from src.api.services import monitor as monitor_module
+
+
+class _FakeExecuteResult:
+    def scalars(self):
+        return self
+
+    def all(self):
+        return []
+
+
+class _FakeSession:
+    async def execute(self, _query):
+        return _FakeExecuteResult()
+
+    async def commit(self):
+        return None
+
+
+class _FakeSessionManager:
+    async def __aenter__(self):
+        return _FakeSession()
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+        return False
+
+
+def _fake_session_maker():
+    return _FakeSessionManager()
+
+
+class _FakeSelfHealing:
+    def __init__(self, *, fail_stop: bool = False):
+        self.start_calls = 0
+        self.stop_calls = 0
+        self.fail_stop = fail_stop
+
+    async def start(self):
+        self.start_calls += 1
+
+    async def stop(self):
+        self.stop_calls += 1
+        if self.fail_stop:
+            raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_start_background_monitor_stops_self_healing_on_cancel(monkeypatch):
+    monitor_cycle_started = asyncio.Event()
+    fake_self_healing = _FakeSelfHealing()
+
+    async def fake_monitor_agent_health(_session):
+        monitor_cycle_started.set()
+
+    monkeypatch.setattr(
+        monitor_module,
+        "get_self_healing_service",
+        lambda: fake_self_healing,
+    )
+    monkeypatch.setattr(
+        monitor_module,
+        "monitor_agent_health",
+        fake_monitor_agent_health,
+    )
+    monkeypatch.setattr(
+        monitor_module.database_module,
+        "async_session_maker",
+        _fake_session_maker,
+    )
+
+    task = asyncio.create_task(monitor_module.start_background_monitor())
+    await asyncio.wait_for(monitor_cycle_started.wait(), timeout=1)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert fake_self_healing.start_calls == 1
+    assert fake_self_healing.stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_start_background_monitor_cancellation_survives_stop_failure(monkeypatch):
+    monitor_cycle_started = asyncio.Event()
+    fake_self_healing = _FakeSelfHealing(fail_stop=True)
+
+    async def fake_monitor_agent_health(_session):
+        monitor_cycle_started.set()
+
+    monkeypatch.setattr(
+        monitor_module,
+        "get_self_healing_service",
+        lambda: fake_self_healing,
+    )
+    monkeypatch.setattr(
+        monitor_module,
+        "monitor_agent_health",
+        fake_monitor_agent_health,
+    )
+    monkeypatch.setattr(
+        monitor_module.database_module,
+        "async_session_maker",
+        _fake_session_maker,
+    )
+
+    task = asyncio.create_task(monitor_module.start_background_monitor())
+    await asyncio.wait_for(monitor_cycle_started.wait(), timeout=1)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert fake_self_healing.start_calls == 1
+    assert fake_self_healing.stop_calls == 1


### PR DESCRIPTION
## Summary
- stop the self-healing scheduler when the background monitor is cancelled
- preserve cancellation propagation even if scheduler shutdown itself fails
- add focused async lifecycle tests for the cancellation path

## Why
Issue #39 still had a concrete backend gap: monitor startup launched self-healing work, but monitor task cancellation did not guarantee the scheduler was stopped.

## Validation
- `pytest -q tests/api/test_monitor.py tests/api/test_monitoring.py`

## Issue
Refs #39
