### PR TITLE
fix(api-keys): keep managed key auth verifiable

### DIFF
--- a/src/api/routes/api_keys.py
+++ b/src/api/routes/api_keys.py
@@ -1,4 +1,3 @@
-import hashlib
 import secrets
 import uuid
 from datetime import datetime, timedelta
@@ -12,6 +11,7 @@ from src.api.database import get_db
 from src.api.middleware.auth import get_current_user
 from src.api.models.models import APIKey, User
 from src.api.models.schemas import APIKeyCreate, APIKeyCreateResponse, APIKeyResponse
+from src.api.services.user_service import hash_api_key
 
 router = APIRouter(prefix="/api-keys", tags=["api-keys"])
 
@@ -23,11 +23,6 @@ def generate_api_key() -> str:
     """Generate a new API key with 'mutx_live_' prefix."""
     random_part = secrets.token_urlsafe(32)
     return f"mutx_live_{random_part}"
-
-
-def hash_key(key: str) -> str:
-    """Hash an API key for storage."""
-    return hashlib.sha256(key.encode()).hexdigest()
 
 
 async def get_owned_api_key(
@@ -69,7 +64,7 @@ async def create_api_key(
         )
 
     plain_key = generate_api_key()
-    key_hash = hash_key(plain_key)
+    key_hash = hash_api_key(plain_key)
 
     expires_at = None
     if key_data.expires_in_days:
@@ -137,7 +132,7 @@ async def rotate_api_key(
         )
 
     plain_key = generate_api_key()
-    key_hash = hash_key(plain_key)
+    key_hash = hash_api_key(plain_key)
 
     old_key.is_active = False
 

--- a/src/api/services/user_service.py
+++ b/src/api/services/user_service.py
@@ -1,8 +1,10 @@
+import hashlib
 import secrets
 import uuid
 from datetime import datetime, timedelta
 from typing import Optional
 
+from passlib.exc import UnknownHashError
 from passlib.context import CryptContext
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,11 +28,17 @@ def generate_user_api_key() -> str:
 
 
 def hash_api_key(key: str) -> str:
-    return api_key_context.hash(key)
+    return hashlib.sha256(key.encode()).hexdigest()
 
 
 def verify_api_key(plain_key: str, hashed_key: str) -> bool:
-    return api_key_context.verify(plain_key, hashed_key)
+    if secrets.compare_digest(hash_api_key(plain_key), hashed_key):
+        return True
+
+    try:
+        return api_key_context.verify(plain_key, hashed_key)
+    except (UnknownHashError, ValueError):
+        return False
 
 
 class UserService:

--- a/tests/api/test_api_keys.py
+++ b/tests/api/test_api_keys.py
@@ -2,6 +2,7 @@
 Tests for /api-keys endpoints.
 """
 
+import hashlib
 import uuid
 
 import pytest
@@ -10,7 +11,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.models.models import APIKey
-from src.api.routes.api_keys import MAX_ACTIVE_API_KEYS_PER_USER, hash_key
+from src.api.routes.api_keys import MAX_ACTIVE_API_KEYS_PER_USER
+from src.api.services.user_service import verify_api_key
 
 
 class TestListAPIKeys:
@@ -80,7 +82,7 @@ class TestCreateAPIKey:
         result = await db_session.execute(select(APIKey).where(APIKey.user_id == test_user.id))
         stored_key = result.scalar_one()
         assert stored_key.name == "new-key"
-        assert stored_key.key_hash == hash_key(data["key"])
+        assert verify_api_key(data["key"], stored_key.key_hash)
         assert stored_key.is_active is True
         assert stored_key.expires_at is not None
 
@@ -245,7 +247,7 @@ class TestRotateAPIKey:
         active_keys = [item for item in keys if item.is_active]
         assert len(active_keys) == 1
         assert active_keys[0].name == "to-rotate"
-        assert active_keys[0].key_hash == hash_key(data["key"])
+        assert verify_api_key(data["key"], active_keys[0].key_hash)
 
     @pytest.mark.asyncio
     async def test_rotate_revoked_api_key_conflicts(
@@ -284,3 +286,12 @@ class TestRotateAPIKey:
         response = await client.post(f"/api-keys/{key.id}/rotate")
         assert response.status_code == 404
         assert response.json()["detail"] == "API key not found"
+
+
+class TestVerifyAPIKeyCompatibility:
+    """Compatibility tests for legacy API key hashes."""
+
+    def test_verify_api_key_accepts_legacy_sha256_hash(self):
+        plain_key = "mutx_live_legacy_example"
+        legacy_hash = hashlib.sha256(plain_key.encode()).hexdigest()
+        assert verify_api_key(plain_key, legacy_hash)

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 import uuid
 
+from src.api.auth.jwt import create_access_token
 from src.api.models.models import WebhookDeliveryLog
 
 
@@ -199,6 +200,50 @@ async def test_webhook_delivery_history_supports_legacy_user_api_key_auth(
     response = await client_no_auth.get(
         f"/webhooks/{webhook_id}/deliveries",
         headers={"X-API-Key": "legacy-webhook-key"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["event"] == "agent.heartbeat"
+
+
+@pytest.mark.asyncio
+async def test_webhook_delivery_history_supports_managed_api_key_auth(
+    client_no_auth: AsyncClient, db_session, test_user
+):
+    access_token, _ = create_access_token(test_user.id)
+
+    create_response = await client_no_auth.post(
+        "/webhooks/",
+        json={"url": "https://example.com/webhook", "events": ["*"]},
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert create_response.status_code == 201
+    webhook_id = uuid.UUID(create_response.json()["id"])
+
+    key_response = await client_no_auth.post(
+        "/api-keys",
+        json={"name": "managed-webhook-key"},
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert key_response.status_code == 201
+    managed_api_key = key_response.json()["key"]
+
+    db_session.add(
+        WebhookDeliveryLog(
+            webhook_id=webhook_id,
+            event="agent.heartbeat",
+            payload='{"status":"running"}',
+            success=True,
+            attempts=1,
+        )
+    )
+    await db_session.commit()
+
+    response = await client_no_auth.get(
+        f"/webhooks/{webhook_id}/deliveries",
+        headers={"X-API-Key": managed_api_key},
     )
 
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- unify managed API-key hashing so `/api-keys` and runtime verification stay compatible
- preserve verification for older bcrypt-shaped managed-key records
- add focused managed-key lifecycle coverage through webhook auth

## Validation
- `pytest tests/api/test_api_keys.py tests/api/test_webhooks.py`

## Issue
Refs #95
