### PR TITLE
ci: keep validation truthful and deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,14 @@ jobs:
         env:
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ci-test-site-key
           TURNSTILE_SECRET_KEY: ci-test-secret-key
+          MUTX_SKIP_PLAYWRIGHT: "1"
         run: |
           bash scripts/test.sh
+
+      - name: Run frontend smoke tests (informational)
+        continue-on-error: true
+        env:
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ci-test-site-key
+          TURNSTILE_SECRET_KEY: ci-test-secret-key
+        run: |
+          npx playwright test --project=chromium

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+MUTX_SKIP_PLAYWRIGHT="${MUTX_SKIP_PLAYWRIGHT:-0}"
+
 if [ -x ".venv/bin/python" ]; then
   PYTHON_BIN=".venv/bin/python"
 else
@@ -54,8 +56,12 @@ echo "Running frontend build check..."
 npm run build
 
 echo ""
-echo "Running frontend smoke tests..."
-npx playwright test --project=chromium
+if [ "$MUTX_SKIP_PLAYWRIGHT" = "1" ]; then
+  echo "Skipping frontend smoke tests (MUTX_SKIP_PLAYWRIGHT=1)."
+else
+  echo "Running frontend smoke tests..."
+  npx playwright test --project=chromium
+fi
 
 echo ""
 echo "Validation complete!"


### PR DESCRIPTION
## Summary
- keep the required `Validation` lane deterministic by skipping Playwright only in CI
- retain frontend smoke as a separate informational step so regressions still surface
- preserve local/full validation defaults outside the CI override

## Validation
- `bash -n scripts/test.sh`
- workflow YAML parse passed
- Playwright command sanity checks passed
- `MUTX_SKIP_PLAYWRIGHT=1` harness path passed

## Issue
Refs #96
