### PR TITLE
fix(webhooks): canonicalize status event contract

### DIFF
--- a/docs/contracts/api/webhooks.md
+++ b/docs/contracts/api/webhooks.md
@@ -48,9 +48,9 @@ Register your own endpoint(s) to receive notifications from MUTX.
 
 ### Supported Events
 
-Exact event values from `src/api/services/webhook_handler.py` include:
+Canonical outgoing event values include:
 
-* `agent.status_update`
+* `agent.status`
 * `agent.heartbeat`
 * `agent.error`
 * `agent.started`
@@ -61,6 +61,10 @@ Exact event values from `src/api/services/webhook_handler.py` include:
 * `deployment.failed`
 * `deployment.rolled_back`
 * `metrics.report`
+
+Legacy compatibility:
+
+* `agent.status_update` is still accepted at registration time, but runtime status-change webhooks are emitted as `agent.status`.
 
 Wildcard subscriptions currently accepted by route validation:
 

--- a/src/api/services/webhook_handler.py
+++ b/src/api/services/webhook_handler.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 
 
 class WebhookEventType(str, Enum):
+    AGENT_STATUS = "agent.status"
+    # Legacy alias retained for backwards compatibility.
     AGENT_STATUS_UPDATE = "agent.status_update"
     AGENT_HEARTBEAT = "agent.heartbeat"
     AGENT_ERROR = "agent.error"
@@ -282,11 +284,14 @@ class WebhookHandler:
         self.monitoring_service = monitoring_service
         self.self_healing_service = self_healing_service
 
+        agent_status_processor = AgentStatusUpdateProcessor(
+            monitoring_service,
+            self_healing_service,
+        )
+
         self._processors: Dict[WebhookEventType, EventProcessor] = {
-            WebhookEventType.AGENT_STATUS_UPDATE: AgentStatusUpdateProcessor(
-                monitoring_service,
-                self_healing_service,
-            ),
+            WebhookEventType.AGENT_STATUS: agent_status_processor,
+            WebhookEventType.AGENT_STATUS_UPDATE: agent_status_processor,
             WebhookEventType.AGENT_HEARTBEAT: HeartbeatProcessor(monitoring_service),
             WebhookEventType.METRICS_REPORT: MetricsReportProcessor(monitoring_service),
             WebhookEventType.DEPLOYMENT_CREATED: DeploymentEventProcessor(
@@ -334,7 +339,7 @@ class WebhookHandler:
                 return ProcessedWebhook(
                     webhook_id=webhook_id,
                     payload=WebhookPayload(
-                        event_type=WebhookEventType.AGENT_STATUS_UPDATE,
+                        event_type=WebhookEventType.AGENT_STATUS,
                         source=WebhookSource.UNKNOWN,
                         timestamp=received_at,
                     ),
@@ -347,7 +352,7 @@ class WebhookHandler:
                 return ProcessedWebhook(
                     webhook_id=webhook_id,
                     payload=WebhookPayload(
-                        event_type=WebhookEventType.AGENT_STATUS_UPDATE,
+                        event_type=WebhookEventType.AGENT_STATUS,
                         source=WebhookSource.UNKNOWN,
                         timestamp=received_at,
                     ),
@@ -392,7 +397,7 @@ class WebhookHandler:
             return ProcessedWebhook(
                 webhook_id=webhook_id,
                 payload=WebhookPayload(
-                    event_type=WebhookEventType.AGENT_STATUS_UPDATE,
+                    event_type=WebhookEventType.AGENT_STATUS,
                     source=WebhookSource.UNKNOWN,
                     timestamp=received_at,
                 ),
@@ -437,7 +442,7 @@ def create_status_update_payload(
     metadata: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     return {
-        "event_type": WebhookEventType.AGENT_STATUS_UPDATE.value,
+        "event_type": WebhookEventType.AGENT_STATUS.value,
         "source": WebhookSource.AGENT.value,
         "timestamp": datetime.utcnow().isoformat(),
         "agent_id": agent_id,

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -50,6 +50,23 @@ async def test_webhook_lifecycle(client: AsyncClient, test_user):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "event_name",
+    ["agent.heartbeat", "agent.status", "agent.status_update"],
+)
+async def test_webhook_create_accepts_runtime_status_event_names(
+    client: AsyncClient, event_name: str
+):
+    response = await client.post(
+        "/webhooks/",
+        json={"url": "https://example.com/webhook", "events": [event_name]},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["events"] == [event_name]
+
+
+@pytest.mark.asyncio
 async def test_webhook_list_honors_skip_and_limit(client: AsyncClient):
     for idx in range(3):
         response = await client.post(


### PR DESCRIPTION
## Summary
- make `agent.status` the canonical webhook status event
- preserve `agent.status_update` as a legacy registration alias
- add regression coverage and align webhook contract docs with runtime behavior

## Validation
- `pytest tests/api/test_ingest.py tests/api/test_webhooks.py`

## Issue
Refs #92
