### PR TITLE
feat(cli): add deployment logs and metrics commands

### DIFF
--- a/cli/commands/deploy.py
+++ b/cli/commands/deploy.py
@@ -201,6 +201,94 @@ def restart_deployment(deployment_id: str):
         click.echo(f"Error: {response.text}", err=True)
 
 
+@deploy_group.command(name="logs")
+@click.argument("deployment_id")
+@click.option("--limit", "-l", default=100, help="Number of log lines to fetch")
+@click.option("--skip", "-s", default=0, help="Number of log lines to skip")
+@click.option("--level", default=None, help="Filter by log level (e.g. ERROR)")
+def deployment_logs(deployment_id: str, limit: int, skip: int, level: Optional[str]):
+    """Get deployment logs"""
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        return
+
+    params = {"limit": limit, "skip": skip}
+    if level:
+        params["level"] = level
+
+    client = get_client(config)
+    response = client.get(f"/deployments/{deployment_id}/logs", params=params)
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 200:
+        logs = response.json()
+        if not logs:
+            click.echo("No deployment logs found.")
+            return
+
+        for log in logs:
+            click.echo(
+                " | ".join(
+                    [
+                        str(log.get("timestamp", "")),
+                        str(log.get("level", "unknown")),
+                        str(log.get("message", "")),
+                    ]
+                )
+            )
+    elif response.status_code == 404:
+        click.echo("Error: Deployment not found", err=True)
+    else:
+        click.echo(f"Error: {response.text}", err=True)
+
+
+@deploy_group.command(name="metrics")
+@click.argument("deployment_id")
+@click.option("--limit", "-l", default=100, help="Number of metric points to fetch")
+@click.option("--skip", "-s", default=0, help="Number of metric points to skip")
+def deployment_metrics(deployment_id: str, limit: int, skip: int):
+    """Get deployment metrics"""
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        return
+
+    client = get_client(config)
+    response = client.get(
+        f"/deployments/{deployment_id}/metrics",
+        params={"limit": limit, "skip": skip},
+    )
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 200:
+        metrics = response.json()
+        if not metrics:
+            click.echo("No deployment metrics found.")
+            return
+
+        for metric in metrics:
+            click.echo(
+                " | ".join(
+                    [
+                        str(metric.get("timestamp", "")),
+                        f"cpu: {metric.get('cpu_usage', 'n/a')}",
+                        f"memory: {metric.get('memory_usage', 'n/a')}",
+                    ]
+                )
+            )
+    elif response.status_code == 404:
+        click.echo("Error: Deployment not found", err=True)
+    else:
+        click.echo(f"Error: {response.text}", err=True)
+
+
 @deploy_group.command(name="delete")
 @click.argument("deployment_id")
 @click.option("--force", "-f", is_flag=True, help="Force deletion without confirmation")

--- a/tests/test_cli_deploy_contract.py
+++ b/tests/test_cli_deploy_contract.py
@@ -160,3 +160,78 @@ def test_deploy_restart_hits_contract_route_and_renders_status(monkeypatch) -> N
     }
     assert "Restarted deployment: dep-789" in result.output
     assert "Status: pending" in result.output
+
+
+def test_deploy_logs_hits_contract_route_and_supports_level_filter(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(path: str, params: dict[str, Any] | None = None) -> DummyResponse:
+        captured["path"] = path
+        captured["params"] = params
+        return DummyResponse(
+            200,
+            [
+                {
+                    "timestamp": "2026-03-12T15:05:00",
+                    "level": "ERROR",
+                    "message": "probe failed",
+                }
+            ],
+        )
+
+    monkeypatch.setattr("cli.commands.deploy.CLIConfig", DummyConfig)
+    monkeypatch.setattr("cli.commands.deploy.get_client", lambda config: SimpleNamespace(get=fake_get))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["deploy", "logs", "dep-123", "--limit", "20", "--skip", "3", "--level", "ERROR"],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "path": "/deployments/dep-123/logs",
+        "params": {
+            "limit": 20,
+            "skip": 3,
+            "level": "ERROR",
+        },
+    }
+    assert "2026-03-12T15:05:00 | ERROR | probe failed" in result.output
+
+
+def test_deploy_metrics_hits_contract_route_and_renders_points(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(path: str, params: dict[str, Any] | None = None) -> DummyResponse:
+        captured["path"] = path
+        captured["params"] = params
+        return DummyResponse(
+            200,
+            [
+                {
+                    "timestamp": "2026-03-12T15:10:00",
+                    "cpu_usage": 0.5,
+                    "memory_usage": 0.75,
+                }
+            ],
+        )
+
+    monkeypatch.setattr("cli.commands.deploy.CLIConfig", DummyConfig)
+    monkeypatch.setattr("cli.commands.deploy.get_client", lambda config: SimpleNamespace(get=fake_get))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["deploy", "metrics", "dep-123", "--limit", "10", "--skip", "1"],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "path": "/deployments/dep-123/metrics",
+        "params": {
+            "limit": 10,
+            "skip": 1,
+        },
+    }
+    assert "2026-03-12T15:10:00 | cpu: 0.5 | memory: 0.75" in result.output


### PR DESCRIPTION
## Summary
- add `mutx deploy logs` CLI support for `/deployments/{id}/logs`
- add `mutx deploy metrics` CLI support for `/deployments/{id}/metrics`
- cover route/query/output contract behavior in focused CLI tests

## Validation
- `pytest -q tests/test_cli_deploy_contract.py`

## Issue
Refs #117
