### PR TITLE
[codex] Fix local bootstrap scripts after Compose relocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,19 @@ git clone https://github.com/fortunexbt/mutx-dev
 cd mutx-dev
 ```
 
-### Demo Validation
+### Canonical Local Bootstrap
 
-Verify the demo path works locally in one command:
+Start the local MUTX stack from repo root with:
+
+```bash
+./scripts/dev.sh
+```
+
+This is the canonical local entrypoint and uses `infrastructure/docker/docker-compose.yml` explicitly.
+
+### Optional Demo Validation
+
+If you want a one-command demo sanity check, run:
 
 ```bash
 npm run demo:validate

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -12,7 +12,7 @@ This repo ships both a local development compose file and a production-oriented 
 Start everything:
 
 ```bash
-docker-compose up
+docker compose -f infrastructure/docker/docker-compose.yml up --build
 ```
 
 Run only data services in the background:
@@ -31,13 +31,13 @@ The local compose file currently starts:
 ## Useful Commands
 
 ```bash
-docker-compose ps
-docker-compose logs -f api
-docker-compose logs -f frontend
-docker-compose restart api
-docker-compose build api
-docker-compose down
-docker-compose down -v
+docker compose -f infrastructure/docker/docker-compose.yml ps
+docker compose -f infrastructure/docker/docker-compose.yml logs -f api
+docker compose -f infrastructure/docker/docker-compose.yml logs -f frontend
+docker compose -f infrastructure/docker/docker-compose.yml restart api
+docker compose -f infrastructure/docker/docker-compose.yml build api
+docker compose -f infrastructure/docker/docker-compose.yml down
+docker compose -f infrastructure/docker/docker-compose.yml down -v
 ```
 
 ## Validate the Local Stack
@@ -55,20 +55,20 @@ open http://localhost:3000
 The production file in this repo is:
 
 ```
-docker-compose.production.yml
+infrastructure/docker/docker-compose.production.yml
 ```
 
 Bring it up with:
 
 ```bash
-docker-compose -f docker-compose.production.yml up -d --build
+docker compose -f infrastructure/docker/docker-compose.production.yml up -d --build
 ```
 
 Inspect it with:
 
 ```bash
-docker-compose -f docker-compose.production.yml ps
-docker-compose -f docker-compose.production.yml logs -f api
+docker compose -f infrastructure/docker/docker-compose.production.yml ps
+docker compose -f infrastructure/docker/docker-compose.production.yml logs -f api
 ```
 
 ## Environment Variables

--- a/docs/deployment/quickstart.md
+++ b/docs/deployment/quickstart.md
@@ -22,8 +22,8 @@ You need:
 ### Install dependencies
 
 ```bash
-git clone https://github.com/fortunexbt/mutx.dev.git
-cd mutx.dev
+git clone https://github.com/fortunexbt/mutx-dev.git
+cd mutx-dev
 
 npm install
 python3 -m venv .venv
@@ -41,9 +41,9 @@ DATABASE_URL=postgresql://mutx:mutx_password@localhost:5432/mutx
 {% endstep %}
 
 {% step %}
-### One-command morning demo validation
+### Optional one-command demo validation
 
-Use this for the canonical morning-run path (start everything + validate):
+Use this when you want a smoke check that boots the stack and validates routes in one run:
 
 ```bash
 npm run demo:validate
@@ -55,7 +55,7 @@ This validates API health and the demo-facing routes in one go.
 {% step %}
 ### Start the local demo stack
 
-Use the repo's canonical bootstrap script when you want the fastest morning-demo path:
+Use the canonical local bootstrap entrypoint from repo root:
 
 ```bash
 ./scripts/dev.sh
@@ -72,7 +72,7 @@ uvicorn src.api.main:app --reload --port 8000
 {% step %}
 ### Start the web app
 
-In another terminal:
+In another terminal for manual mode (skip this if you launched `./scripts/dev.sh`, because frontend is already running in Compose):
 
 ```bash
 npm run dev

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,23 +8,24 @@ This quickstart is for the current repo as it exists now: Next.js frontend plus 
 - FastAPI control plane on port `8000`
 - Postgres and Redis via Docker Compose
 
-## 1. Install dependencies
+## 1. Canonical local bootstrap (repo root)
+
+```bash
+./scripts/dev.sh
+```
+
+This is the supported local bootstrap entrypoint. It uses `infrastructure/docker/docker-compose.yml` explicitly, creates `.env` from `.env.example` when needed, and starts PostgreSQL, Redis, API, and frontend containers.
+
+## 2. Manual split-process workflow (optional)
+
+If you prefer host processes for API and web:
 
 ```bash
 npm install
 pip install -r requirements.txt
-```
-
-## 2. Start backing services
-
-```bash
 docker compose -f infrastructure/docker/docker-compose.yml up -d postgres redis
-```
-
-## 3. Start the API
-
-```bash
 uvicorn src.api.main:app --reload --port 8000
+npm run dev
 ```
 
 Backend truth checks:
@@ -34,19 +35,13 @@ curl http://localhost:8000/health
 curl http://localhost:8000/ready
 ```
 
-## 4. Start the web surface
-
-```bash
-npm run dev
-```
-
 Then use:
 
 - `http://localhost:3000` for the marketing site shape
 - `http://localhost:3000/app` for the app shell preview
 - `http://localhost:3000/api/*` for the Next.js same-origin proxy layer
 
-## 5. Register or log in
+## 3. Register or log in
 
 Use either the browser flows or direct API calls.
 
@@ -58,7 +53,7 @@ curl -X POST "$BASE_URL/auth/register"   -H "Content-Type: application/json"   -
 curl -X POST "$BASE_URL/auth/login"   -H "Content-Type: application/json"   -d '{"email":"you@example.com","password":"StrongPass1!"}'
 ```
 
-## 6. Inspect real resources
+## 4. Inspect real resources
 
 ```bash
 curl "$BASE_URL/agents?limit=10&skip=0"   -H "Authorization: Bearer YOUR_ACCESS_TOKEN"

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -20,8 +20,8 @@ DATABASE_URL=postgresql://mutx:mutx_password@localhost:5432/mutx
 Then confirm Postgres is up:
 
 ```bash
-docker-compose up -d postgres
-docker-compose exec postgres pg_isready -U mutx
+docker compose -f infrastructure/docker/docker-compose.yml up -d postgres
+docker compose -f infrastructure/docker/docker-compose.yml exec postgres pg_isready -U mutx
 ```
 
 ## CLI login works, but agent creation fails

--- a/docs/troubleshooting/debugging.md
+++ b/docs/troubleshooting/debugging.md
@@ -10,10 +10,10 @@ This guide reflects the current stack and route surface.
 ## Container and Service Logs
 
 ```bash
-docker-compose logs -f api
-docker-compose logs -f frontend
-docker-compose logs -f postgres
-docker-compose logs -f redis
+docker compose -f infrastructure/docker/docker-compose.yml logs -f api
+docker compose -f infrastructure/docker/docker-compose.yml logs -f frontend
+docker compose -f infrastructure/docker/docker-compose.yml logs -f postgres
+docker compose -f infrastructure/docker/docker-compose.yml logs -f redis
 ```
 
 ## API Health Checks
@@ -53,8 +53,8 @@ curl -X POST http://localhost:8000/auth/login \
 ## Database Checks
 
 ```bash
-docker-compose exec postgres pg_isready -U mutx
-docker-compose exec postgres psql -U mutx -d mutx -c "SELECT now();"
+docker compose -f infrastructure/docker/docker-compose.yml exec postgres pg_isready -U mutx
+docker compose -f infrastructure/docker/docker-compose.yml exec postgres psql -U mutx -d mutx -c "SELECT now();"
 ```
 
 If the API is degraded, compare the running DB host to your `.env` `DATABASE_URL`.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,30 +1,49 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 echo "Setting up mutx.dev..."
 
-ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/infrastructure/docker/docker-compose.yml"
 cd "$ROOT_DIR"
 
-COMPOSE_FILE="$ROOT_DIR/infrastructure/docker/docker-compose.yml"
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required for local setup."
+    echo "Install Docker Desktop or Docker Engine and retry."
+    exit 1
+fi
 
-if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+if ! docker info >/dev/null 2>&1; then
+    echo "Docker daemon is not running."
+    echo "Start Docker Desktop (or the Docker service) and retry."
+    exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
     COMPOSE_CMD=(docker compose)
 elif command -v docker-compose >/dev/null 2>&1; then
     COMPOSE_CMD=(docker-compose)
 else
-    echo "Docker Compose is required (docker compose or docker-compose)."
+    echo "Docker Compose is required (docker compose plugin or docker-compose)."
     exit 1
 fi
 
 if [ ! -f "$COMPOSE_FILE" ]; then
     echo "Compose file not found at $COMPOSE_FILE"
+    echo "Expected local stack file: infrastructure/docker/docker-compose.yml"
     exit 1
 fi
 
-if [ ! -f .env ]; then
-    echo "Creating .env from example..."
-    cp .env.example .env
+if [ ! -f "$ROOT_DIR/.env" ]; then
+    if [ -f "$ROOT_DIR/.env.example" ]; then
+        echo "Creating .env from .env.example..."
+        cp "$ROOT_DIR/.env.example" "$ROOT_DIR/.env"
+    else
+        echo "Missing $ROOT_DIR/.env.example"
+        echo "Create $ROOT_DIR/.env with required local values and retry."
+        exit 1
+    fi
 fi
 
 echo "Installing Python dependencies..."
@@ -47,4 +66,4 @@ echo "Running migrations..."
 PYTHONPATH=./src/api alembic upgrade head
 
 echo "Setup complete!"
-echo "Run ./scripts/dev.sh to start development services"
+echo "Canonical local bootstrap command: ./scripts/dev.sh"


### PR DESCRIPTION
## Summary
This PR finishes the local bootstrap cleanup for issue #115 after Docker Compose files were moved under `infrastructure/docker/`.

The repo now has one canonical local bootstrap entrypoint from repo root: `./scripts/dev.sh`. Supporting setup and troubleshooting guidance now consistently references explicit compose file paths instead of implicit root-level defaults.

## User impact
Before this change, contributors could follow valid-looking commands and helper flows that still assumed root-level compose files, which caused bootstrap failures or confusing drift between scripts and docs.

With this change:
- local bootstrap guidance in repo/docs is aligned to one entrypoint (`./scripts/dev.sh`)
- setup helper checks fail early with clear Docker/env prerequisite messages
- local troubleshooting/docker commands now call compose with explicit file paths that match the relocated files

## Root cause
Compose files were relocated to `infrastructure/docker/`, but setup/troubleshooting guidance and helper flows were partially updated. This left mismatched entrypoints and stale commands spread across docs.

## What changed
- hardened `scripts/setup.sh` prerequisite detection and failure output:
  - checks Docker CLI presence
  - checks Docker daemon availability
  - checks Compose availability (`docker compose` plugin or `docker-compose`)
  - validates explicit local compose file path
  - validates `.env` / `.env.example` prerequisites with actionable errors
- updated top-level README quickstart section to point to canonical local bootstrap command
- aligned quickstart docs wording to treat `./scripts/dev.sh` as canonical bootstrap and `npm run demo:validate` as optional validation flow
- replaced stale local `docker-compose` commands in troubleshooting/docker docs with explicit `docker compose -f infrastructure/docker/...` usage

## Validation
- `bash -n scripts/dev.sh scripts/setup.sh scripts/demo-validate.sh`
- `docker compose -f infrastructure/docker/docker-compose.yml config --services`
- `./scripts/dev.sh` (expected failure in this environment): clear message for missing Docker daemon
- `./scripts/setup.sh` (expected failure in this environment): clear message for missing Docker daemon

## Notes
I could not run a full container bootstrap end-to-end here because Docker daemon is not running in this environment, but bootstrap command behavior and prerequisite failure messaging are now explicit and consistent.

Closes #115
