### PR TITLE
autonomy: enforce queue health + codex review handoff

### DIFF
--- a/.github/workflows/autonomous-dispatch.yml
+++ b/.github/workflows/autonomous-dispatch.yml
@@ -123,11 +123,13 @@ jobs:
               });
             }
 
-      - name: Capture autonomy-ready issues
+      - name: Capture autonomy queue and health
+        id: queue_health
         uses: actions/github-script@v7
         with:
           script: |
             const { owner, repo } = context.repo;
+            const fs = require('fs');
             const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
@@ -135,8 +137,72 @@ jobs:
               labels: 'autonomy:ready',
               per_page: 100,
             });
-            const fs = require('fs');
+            const openPrs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const emptyQueueViolation = issues.length === 0 && openPrs.length === 0;
+            const stalledQueueViolation = issues.length > 0 && openPrs.length === 0;
+            const violations = [];
+            if (emptyQueueViolation) {
+              violations.push('queue floor failed: zero autonomy:ready issues and zero open PRs');
+            }
+            if (stalledQueueViolation) {
+              violations.push('queue handoff failed: autonomy:ready issues exist but zero open PRs');
+            }
+
+            const snapshot = {
+              generated_at: new Date().toISOString(),
+              open_autonomy_ready_issues: issues.length,
+              open_pull_requests: openPrs.length,
+              violations,
+            };
+
             fs.writeFileSync('autonomy-queue.json', JSON.stringify(issues, null, 2));
+            fs.writeFileSync('autonomy-queue-health.json', JSON.stringify(snapshot, null, 2));
+
+            const lines = [
+              '## Queue Health',
+              '',
+              `- open \`autonomy:ready\` issues: ${issues.length}`,
+              `- open PRs: ${openPrs.length}`,
+            ];
+            if (violations.length === 0) {
+              lines.push('- status: healthy');
+            } else {
+              lines.push('- status: policy violation');
+              lines.push('');
+              for (const violation of violations) {
+                lines.push(`- violation: ${violation}`);
+                core.warning(`Queue policy violation: ${violation}`);
+              }
+            }
+            await core.summary.addRaw(lines.join('\n')).write();
+
+            core.setOutput('empty_violation', String(emptyQueueViolation));
+            core.setOutput('stalled_violation', String(stalledQueueViolation));
+
+      - name: Upload queue health snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: autonomy-queue-health
+          path: autonomy-queue-health.json
+
+      - name: Enforce queue floor
+        if: ${{ steps.queue_health.outputs.empty_violation == 'true' }}
+        run: |
+          echo "Queue floor violation: no autonomy:ready issues and no open PRs."
+          cat autonomy-queue-health.json
+          exit 1
+
+      - name: Flag stalled queue handoff
+        if: ${{ steps.queue_health.outputs.stalled_violation == 'true' }}
+        run: |
+          echo "Queue handoff violation: autonomy:ready issues exist but there are no open PRs."
+          cat autonomy-queue-health.json
 
       - name: Build work order
         run: python scripts/autonomy/build_work_order.py --queue autonomy-queue.json --output autonomy-work-order.json

--- a/docs/autonomy/activation.md
+++ b/docs/autonomy/activation.md
@@ -68,7 +68,11 @@ If a generated patch exceeds the configured size or file-count guardrails, the e
 
 If `AUTONOMY_REVIEWER_MAP` is set, the executor also assigns the mapped GitHub login to the PR and leaves a reviewer-routing comment.
 
+When the executor opens or updates a PR, it also posts the required handoff comment: `@codex please review` (idempotent if already present).
+
 If an issue stays labeled `autonomy:claimed` past `AUTONOMY_STALE_CLAIM_MINUTES` and no open PR exists for the claimed branch, the dispatch workflow automatically releases the claim and comments on the issue.
+
+The dispatch workflow writes `autonomy-queue-health.json` each run and uploads it as a workflow artifact. It hard-fails when both open `autonomy:ready` issues and open PRs are zero, and logs a queue-handoff violation when ready issues exist but open PRs are zero.
 
 ## Dispatch Logic
 

--- a/scripts/autonomy/execute_work_order.py
+++ b/scripts/autonomy/execute_work_order.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 
 DEFAULT_MAX_CHANGED_FILES = 6
+CODEX_REVIEW_COMMENT = "@codex please review"
 
 
 def run(command: list[str], *, cwd: str | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -113,6 +114,27 @@ def maybe_comment_issue(work_order: dict, brief_path: Path) -> None:
     run(["gh", "issue", "comment", str(work_order["issue"]), "--body", body], check=False)
 
 
+def pr_has_codex_review_comment(pr_ref: str) -> bool:
+    result = run(
+        ["gh", "pr", "view", pr_ref, "--json", "comments", "--jq", ".comments[].body"],
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+    return CODEX_REVIEW_COMMENT.lower() in result.stdout.lower()
+
+
+def maybe_comment_codex_review(pr_ref: str) -> None:
+    if not os.environ.get("GH_TOKEN"):
+        return
+    if pr_has_codex_review_comment(pr_ref):
+        print("Codex review handoff already present.")
+        return
+    result = run(["gh", "pr", "comment", pr_ref, "--body", CODEX_REVIEW_COMMENT], check=False)
+    if result.returncode != 0:
+        print("Failed to post Codex review handoff comment.")
+
+
 def run_agent_command(work_order: dict, brief_path: Path) -> int:
     template = os.environ.get("AUTONOMY_AGENT_CMD_TEMPLATE", "").strip()
     if not template:
@@ -178,6 +200,7 @@ def maybe_open_pr(work_order: dict, base_branch: str) -> None:
         ],
         check=False,
     )
+    maybe_comment_codex_review(work_order["branch"])
     reviewer_login = resolve_reviewer_login(work_order["reviewer"])
     if reviewer_login and os.environ.get("GH_TOKEN"):
         run(


### PR DESCRIPTION
## Summary
- add mandatory, idempotent `@codex please review` handoff comment in `scripts/autonomy/execute_work_order.py` when autonomy opens/updates a PR
- add queue-health detection in `.github/workflows/autonomous-dispatch.yml` for queue-floor and stalled-handoff policy violations
- persist queue state as `autonomy-queue-health.json` artifact each dispatch run
- hard-fail dispatch when both `autonomy:ready` issues and open PRs are zero; log stalled-handoff violations
- document the new behavior in `docs/autonomy/activation.md`

## Validation
- `python3 -m compileall scripts/autonomy/execute_work_order.py`
- `python3 scripts/autonomy/execute_work_order.py --help`
- `ruby -ryaml -e "YAML.load_file('.github/workflows/autonomous-dispatch.yml')"`

Progress on #112
