### PR TITLE
[codex] Close deployment surface parity drift across SDK/docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -82,6 +82,9 @@ mutx status
 | `mutx deploy restart` | reliable | uses `POST /deployments/{id}/restart`                                    |
 | `mutx deploy delete`  | reliable | uses `DELETE /deployments/{id}`                                          |
 
+Intentional omission: there is currently no dedicated `mutx deploy get` command for `GET /deployments/{id}`.
+Use `mutx deploy list` plus deployment-specific `events`, `logs`, and `metrics` commands for targeted inspection.
+
 `mutx agents create` now relies on authenticated ownership instead of a client-supplied `user_id`.
 
 ## Example Session

--- a/docs/contracts/api/deployments.md
+++ b/docs/contracts/api/deployments.md
@@ -10,8 +10,8 @@ Deployment records are exposed through `/deployments`, and creation is available
 ## Current Implementation Notes
 
 * Every deployment route requires authenticated control-plane access.
-* `POST /deployments` creates a deployment when given an owned `agent_id`.
-* `POST /agents/{agent_id}/deploy` is still available as the agent-centric create path.
+* `POST /deployments` is the canonical create path, starts the deployment in `pending`, and records a `create` lifecycle event.
+* `POST /agents/{agent_id}/deploy` is the legacy agent-centric create path and returns a lightweight payload with `deployment_id` and `status` (`deploying`).
 * `POST /deployments/{deployment_id}/scale` only succeeds when the deployment status is `running` or `ready`.
 * `POST /deployments/{deployment_id}/restart` currently allows `stopped`, `failed`, and `killed` deployments.
 
@@ -34,20 +34,22 @@ Deployment records are exposed through `/deployments`, and creation is available
 ```bash
 BASE_URL=http://localhost:8000
 
-curl -X POST "$BASE_URL/agents/YOUR_AGENT_ID/deploy" \
-  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
-```
-
-That returns a deployment id you can use with the routes below.
-
-Direct deployment creation is also available:
-
-```bash
 curl -X POST "$BASE_URL/deployments" \
   -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"agent_id": "YOUR_AGENT_ID", "replicas": 1}'
 ```
+
+Canonical `POST /deployments` returns the full deployment record (including status and lifecycle events).
+
+Legacy agent-scoped create remains available:
+
+```bash
+curl -X POST "$BASE_URL/agents/YOUR_AGENT_ID/deploy" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+That route returns a lightweight payload with `deployment_id` and `status`.
 
 ## List Deployments
 

--- a/sdk/mutx/deployments.py
+++ b/sdk/mutx/deployments.py
@@ -7,6 +7,15 @@ from uuid import UUID
 import httpx
 
 
+def _parse_datetime(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    # FastAPI serializers may emit UTC timestamps with a trailing "Z".
+    if value.endswith("Z"):
+        value = f"{value[:-1]}+00:00"
+    return datetime.fromisoformat(value)
+
+
 class DeploymentEvent:
     def __init__(self, data: dict[str, Any]):
         self.id = UUID(data["id"])
@@ -15,7 +24,7 @@ class DeploymentEvent:
         self.status = data["status"]
         self.node_id = data.get("node_id")
         self.error_message = data.get("error_message")
-        self.created_at = datetime.fromisoformat(data["created_at"])
+        self.created_at = _parse_datetime(data["created_at"])
         self._data = data
 
 
@@ -39,10 +48,8 @@ class Deployment:
         self.status = data["status"]
         self.replicas = data["replicas"]
         self.node_id = data.get("node_id")
-        self.started_at = (
-            datetime.fromisoformat(data["started_at"]) if data.get("started_at") else None
-        )
-        self.ended_at = datetime.fromisoformat(data["ended_at"]) if data.get("ended_at") else None
+        self.started_at = _parse_datetime(data.get("started_at"))
+        self.ended_at = _parse_datetime(data.get("ended_at"))
         self.error_message = data.get("error_message")
         self.events = [DeploymentEvent(item) for item in data.get("events", [])]
         self._data = data

--- a/tests/test_sdk_deployments_contract.py
+++ b/tests/test_sdk_deployments_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 import uuid
 from pathlib import Path
@@ -51,6 +52,106 @@ def _event_history_payload(deployment_id: uuid.UUID, **overrides: Any) -> dict[s
     }
     payload.update(overrides)
     return payload
+
+
+def _metrics_payload() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": str(uuid.uuid4()),
+            "agent_id": str(uuid.uuid4()),
+            "cpu_usage": 0.61,
+            "memory_usage": 0.44,
+            "timestamp": "2026-03-12T10:15:00",
+        }
+    ]
+
+
+def test_deployments_create_hits_canonical_route_and_maps_payload() -> None:
+    agent_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["body"] = request.content.decode()
+        return httpx.Response(
+            201,
+            json=_deployment_payload(agent_id=str(agent_id), status="pending", replicas=3),
+        )
+
+    with httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler)) as client:
+        deployment = Deployments(client).create(agent_id, replicas=3)
+
+    assert captured["path"] == "/deployments"
+    assert json.loads(captured["body"]) == {"agent_id": str(agent_id), "replicas": 3}
+    assert deployment.agent_id == agent_id
+    assert deployment.status == "pending"
+    assert deployment.replicas == 3
+
+
+@pytest.mark.asyncio
+async def test_deployments_acreate_hits_canonical_route_and_maps_payload() -> None:
+    agent_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["body"] = request.content.decode()
+        return httpx.Response(
+            201,
+            json=_deployment_payload(agent_id=str(agent_id), status="pending", replicas=2),
+        )
+
+    async with httpx.AsyncClient(
+        base_url="https://api.test",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        deployment = await Deployments(client).acreate(agent_id, replicas=2)
+
+    assert captured["path"] == "/deployments"
+    assert json.loads(captured["body"]) == {"agent_id": str(agent_id), "replicas": 2}
+    assert deployment.agent_id == agent_id
+    assert deployment.status == "pending"
+    assert deployment.replicas == 2
+
+
+def test_deployments_restart_hits_contract_route_and_maps_payload() -> None:
+    deployment_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["body"] = request.content.decode()
+        return httpx.Response(200, json=_deployment_payload(id=str(deployment_id), status="pending"))
+
+    with httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler)) as client:
+        deployment = Deployments(client).restart(deployment_id)
+
+    assert captured["path"] == f"/deployments/{deployment_id}/restart"
+    assert captured["body"] == ""
+    assert deployment.id == deployment_id
+    assert deployment.status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_deployments_arestart_hits_contract_route_and_maps_payload() -> None:
+    deployment_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["body"] = request.content.decode()
+        return httpx.Response(200, json=_deployment_payload(id=str(deployment_id), status="pending"))
+
+    async with httpx.AsyncClient(
+        base_url="https://api.test",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        deployment = await Deployments(client).arestart(deployment_id)
+
+    assert captured["path"] == f"/deployments/{deployment_id}/restart"
+    assert captured["body"] == ""
+    assert deployment.id == deployment_id
+    assert deployment.status == "pending"
 
 
 def test_deployments_events_hits_contract_route_and_maps_payload() -> None:
@@ -139,6 +240,34 @@ def test_deployment_parser_accepts_nullable_started_at_and_nested_events() -> No
     assert deployment.events[0].event_type == "create"
 
 
+def test_deployment_parser_accepts_z_suffix_timestamps() -> None:
+    deployment_id = uuid.uuid4()
+    payload = _deployment_payload(
+        id=str(deployment_id),
+        started_at="2026-03-12T09:00:00Z",
+        ended_at="2026-03-12T09:30:00Z",
+        events=[
+            {
+                "id": str(uuid.uuid4()),
+                "deployment_id": str(deployment_id),
+                "event_type": "restart",
+                "status": "pending",
+                "node_id": None,
+                "error_message": None,
+                "created_at": "2026-03-12T09:45:00Z",
+            }
+        ],
+    )
+
+    deployment = Deployment(payload)
+
+    assert deployment.started_at is not None
+    assert deployment.started_at.tzinfo is not None
+    assert deployment.ended_at is not None
+    assert deployment.ended_at.tzinfo is not None
+    assert deployment.events[0].created_at.tzinfo is not None
+
+
 def test_deployments_logs_support_level_filter_param() -> None:
     deployment_id = uuid.uuid4()
     captured: dict[str, Any] = {}
@@ -175,3 +304,42 @@ async def test_deployments_alogs_support_level_filter_param() -> None:
     assert payload == []
     assert captured["path"] == f"/deployments/{deployment_id}/logs"
     assert captured["query"] == {"skip": "4", "limit": "75", "level": "INFO"}
+
+
+def test_deployments_metrics_hits_contract_route_and_query_params() -> None:
+    deployment_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["query"] = dict(request.url.params)
+        return httpx.Response(200, json=_metrics_payload())
+
+    with httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler)) as client:
+        payload = Deployments(client).metrics(deployment_id, skip=5, limit=15)
+
+    assert captured["path"] == f"/deployments/{deployment_id}/metrics"
+    assert captured["query"] == {"skip": "5", "limit": "15"}
+    assert payload[0]["cpu_usage"] == 0.61
+    assert payload[0]["memory_usage"] == 0.44
+
+
+@pytest.mark.asyncio
+async def test_deployments_ametrics_hits_contract_route_and_query_params() -> None:
+    deployment_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["query"] = dict(request.url.params)
+        return httpx.Response(200, json=_metrics_payload())
+
+    async with httpx.AsyncClient(
+        base_url="https://api.test",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        payload = await Deployments(client).ametrics(deployment_id, skip=6, limit=12)
+
+    assert captured["path"] == f"/deployments/{deployment_id}/metrics"
+    assert captured["query"] == {"skip": "6", "limit": "12"}
+    assert payload[0]["cpu_usage"] == 0.61


### PR DESCRIPTION
## Summary
This PR closes the remaining deployment-surface parity drift by tightening SDK payload truthfulness, filling missing SDK contract tests, and clarifying deployment/CLI docs where intentional CLI coverage boundaries exist.

Specifically:
- adds robust deployment datetime parsing in the SDK for both plain ISO and `Z`-suffixed UTC timestamps
- extends SDK deployment contract coverage to include create, restart, and metrics (sync + async), in addition to existing events/logs coverage
- updates deployment API docs to reflect current create-path behavior (`POST /deployments` canonical vs `POST /agents/{agent_id}/deploy` legacy payload)
- updates CLI docs to explicitly call out the intentional omission of a dedicated `mutx deploy get` command

## Cause and Effect
Issue #117 identified parity drift between the live deployment backend surface and surrounding client/docs contracts.
Without these updates, operator expectations around supported payload shapes and command availability can drift, leading to brittle client integrations and avoidable support confusion.

## Root Cause
Deployment route capabilities evolved in the backend and were partially reflected across prior slices, but SDK-focused create/restart/metrics contract checks and explicit CLI omission docs were still incomplete.

## Fix
- `sdk/mutx/deployments.py`
  - introduced `_parse_datetime()` to normalize and parse `Z`-suffixed timestamps
  - applied parser to deployment and deployment-event datetime fields
- `tests/test_sdk_deployments_contract.py`
  - added focused tests for `create`, `acreate`, `restart`, `arestart`, `metrics`, and `ametrics`
  - added timestamp parsing coverage for `Z`-suffixed payload values
- `docs/contracts/api/deployments.md`
  - clarified canonical vs legacy deployment create behavior and payload shape expectations
- `docs/cli.md`
  - documented intentional omission for `mutx deploy get`

## Validation
- `pytest -q tests/test_sdk_deployments_contract.py tests/test_cli_deploy_contract.py tests/api/test_deployments.py`
  - result: `50 passed`

Closes #117.
