### PR TITLE
[codex] validate heartbeat status contract

### DIFF
--- a/src/api/routes/agent_runtime.py
+++ b/src/api/routes/agent_runtime.py
@@ -52,7 +52,7 @@ class AgentRegisterResponse(BaseModel):
 
 class HeartbeatRequest(BaseModel):
     agent_id: str
-    status: str = "running"
+    status: AgentStatus = AgentStatus.RUNNING
     message: Optional[str] = None
     timestamp: str
     platform: Optional[str] = None
@@ -160,7 +160,8 @@ async def heartbeat(
     # Update agent status and last heartbeat
     previous_status = agent.status
     now = datetime.utcnow()
-    agent.status = request.status
+    new_status = request.status.value
+    agent.status = new_status
     agent.last_heartbeat = now
 
     await db.commit()
@@ -172,7 +173,7 @@ async def heartbeat(
             {
                 "agent_id": str(agent.id),
                 "agent_name": agent.name,
-                "status": agent.status,
+                "status": new_status,
                 "previous_status": previous_status,
                 "message": request.message,
                 "platform": request.platform,
@@ -185,7 +186,7 @@ async def heartbeat(
             "Failed to emit agent.heartbeat webhook", extra={"agent_id": str(agent.id)}
         )
 
-    if previous_status != agent.status:
+    if previous_status != new_status:
         try:
             await trigger_webhook_event(
                 db,
@@ -194,7 +195,7 @@ async def heartbeat(
                     "agent_id": str(agent.id),
                     "agent_name": agent.name,
                     "old_status": previous_status,
-                    "new_status": agent.status,
+                    "new_status": new_status,
                     "message": request.message,
                     "platform": request.platform,
                     "hostname": request.hostname,

--- a/tests/api/test_ingest.py
+++ b/tests/api/test_ingest.py
@@ -60,6 +60,35 @@ async def test_ingest_unauthorized_agent(client: AsyncClient, test_user):
 
 
 @pytest.mark.asyncio
+async def test_agent_runtime_heartbeat_rejects_unknown_status_value(
+    client: AsyncClient, db_session, test_agent
+):
+    from src.api.routes.agent_runtime import get_current_agent
+    from src.api.models.models import AgentStatus
+
+    test_agent.status = AgentStatus.CREATING.value
+    await db_session.commit()
+
+    client.app.dependency_overrides[get_current_agent] = lambda: test_agent
+
+    response = await client.post(
+        "/agents/heartbeat",
+        json={
+            "agent_id": str(test_agent.id),
+            "status": "unexpected_status",
+            "timestamp": datetime.utcnow().isoformat(),
+        },
+    )
+
+    assert response.status_code == 422
+
+    await db_session.refresh(test_agent)
+    assert test_agent.status == AgentStatus.CREATING.value
+
+    client.app.dependency_overrides.pop(get_current_agent, None)
+
+
+@pytest.mark.asyncio
 async def test_agent_runtime_heartbeat_triggers_heartbeat_webhook_without_status_change(
     client: AsyncClient, db_session, test_agent, monkeypatch
 ):


### PR DESCRIPTION
## Issue
This is a focused backend slice for #92.

## Cause and user impact
`POST /agents/heartbeat` accepted any free-form `status` string and persisted it directly. That let invalid status values enter agent records and heartbeat webhooks, which weakens runtime monitoring assumptions and event-contract consistency.

## Root cause
The runtime heartbeat request model used `status: str`, while adjacent ingest/runtime paths rely on the `AgentStatus` enum contract.

## Fix
- Tightened `HeartbeatRequest.status` to `AgentStatus` with `running` as the default.
- Normalized the runtime path to persist and emit `request.status.value` so DB/webhook payloads stay string-stable.
- Kept status-change event emission behavior the same, but based on normalized values.
- Added regression coverage to reject unknown heartbeat status values and confirm no status mutation on invalid payloads.

## Validation
- `pytest tests/api/test_ingest.py -q`
- `pytest tests/api/test_agent_runtime.py tests/api/test_agent_runtime_contract.py -q`

## Notes
This PR intentionally ships one narrow contract-hardening slice; broader heartbeat audit work for #92 can continue in follow-up PRs.
