### PR TITLE
fix: use anchor tag for external URL in app preview page

### DIFF
--- a/app/app/[[...slug]]/page.tsx
+++ b/app/app/[[...slug]]/page.tsx
@@ -62,10 +62,10 @@ export default function AppPreviewPage() {
                 <Github className="h-4 w-4" />
                 GitHub
               </a>
-              <Link href="https://mutx.dev" className="flex items-center gap-2 rounded-xl px-3 py-2 text-cyan-400 transition hover:bg-cyan-400/10">
+              <a href="https://mutx.dev" target="_blank" rel="noreferrer" className="flex items-center gap-2 rounded-xl px-3 py-2 text-cyan-400 transition hover:bg-cyan-400/10">
                 <ArrowRight className="h-4 w-4" />
                 Marketing site
-              </Link>
+              </a>
             </div>
           </aside>
 


### PR DESCRIPTION
## Summary
- Replace Next.js Link with standard anchor tag for external URL (mutx.dev) in the app preview page
- External links should use `<a>` tag for proper SEO, accessibility, and browser behavior

## Changes
- `app/app/[[...slug]]/page.tsx`: Changed `<Link href="https://mutx.dev">` to `<a href="https://mutx.dev" target="_blank" rel="noreferrer">`

## Validation
- Lint passes
- Build succeeds