### PR TITLE
frontend: honor plan quota for API key dashboard

### DIFF
--- a/components/app/AppDashboardClient.tsx
+++ b/components/app/AppDashboardClient.tsx
@@ -21,7 +21,7 @@ import {
 
 import { Card } from "@/components/ui/Card";
 import { type components } from "@/app/types/api";
-import { getLatestActiveApiKey, getLatestRevokedApiKey } from "@/components/app/apiKeyHelpers";
+import { getApiKeyLimit, getLatestActiveApiKey, getLatestRevokedApiKey } from "@/components/app/apiKeyHelpers";
 
 type User = components["schemas"]["UserResponse"];
 type Agent = components["schemas"]["AgentResponse"];
@@ -177,9 +177,9 @@ export function AppDashboardClient() {
   ).length;
   const activeKeys = apiKeys.filter((apiKey) => apiKey.is_active).length;
   const revokedKeys = apiKeys.length - activeKeys;
-  const apiKeyLimit = 10;
-  const apiKeyCapacityRemaining = Math.max(apiKeyLimit - activeKeys, 0);
-  const apiKeyLimitReached = activeKeys >= apiKeyLimit;
+  const apiKeyLimit = getApiKeyLimit(user?.plan);
+  const apiKeyCapacityRemaining = apiKeyLimit === null ? null : Math.max(apiKeyLimit - activeKeys, 0);
+  const apiKeyLimitReached = apiKeyLimit !== null && activeKeys >= apiKeyLimit;
   const latestDeploymentEvent = deployments
     .flatMap((deployment) => deployment.events ?? [])
     .sort(

--- a/components/app/apiKeyHelpers.ts
+++ b/components/app/apiKeyHelpers.ts
@@ -14,6 +14,20 @@ function sortByCreatedAtDesc(apiKeys: ApiKey[]) {
   );
 }
 
+const API_KEY_LIMIT_BY_PLAN: Record<string, number | null> = {
+  free: 2,
+  starter: 10,
+  pro: 50,
+  enterprise: null,
+};
+
+export function getApiKeyLimit(plan?: string | null): number | null {
+  const normalizedPlan = (plan ?? "").trim().toLowerCase();
+  return Object.prototype.hasOwnProperty.call(API_KEY_LIMIT_BY_PLAN, normalizedPlan)
+    ? API_KEY_LIMIT_BY_PLAN[normalizedPlan]
+    : 10;
+}
+
 export function getLatestActiveApiKey(apiKeys: ApiKey[]) {
   return sortByCreatedAtDesc(apiKeys).find((apiKey) => apiKey.is_active) ?? null;
 }

--- a/tests/unit/apiKeyHelpers.test.ts
+++ b/tests/unit/apiKeyHelpers.test.ts
@@ -1,5 +1,6 @@
 import type { components } from "@/app/types/api";
 import {
+  getApiKeyLimit,
   getLatestActiveApiKey,
   getLatestRevokedApiKey,
 } from "@/components/app/apiKeyHelpers";
@@ -87,5 +88,16 @@ describe("api key dashboard selectors", () => {
 
     expect(getLatestRevokedApiKey(keys)).toBeNull();
     expect(getLatestActiveApiKey(keys)).not.toBeNull();
+  });
+
+  it("maps plan quotas to API key limits", () => {
+    expect(getApiKeyLimit("free")).toBe(2);
+    expect(getApiKeyLimit("starter")).toBe(10);
+    expect(getApiKeyLimit("pro")).toBe(50);
+    expect(getApiKeyLimit("enterprise")).toBeNull();
+  });
+
+  it("keeps unknown plans on a safe starter-style limit", () => {
+    expect(getApiKeyLimit("mystery-tier")).toBe(10);
   });
 });


### PR DESCRIPTION
## Summary\n- Make API key dashboard capacity logic derive limits from user plan instead of hardcoded 10.\n- Add a helper + tests for plan quota mapping.\n- Keep enterprise plans unlimited in client-side readiness and limit indicators.\n\nFixes #95: API key lifecycle follow-through.