### PR TITLE
feat(cli): add webhook contract commands

### DIFF
--- a/cli/commands/webhooks.py
+++ b/cli/commands/webhooks.py
@@ -1,0 +1,120 @@
+import click
+from typing import Any, Optional
+
+from cli.config import CLIConfig, get_client
+
+
+@click.group(name="webhooks")
+def webhooks_group():
+    """Manage webhooks and delivery history"""
+    pass
+
+
+@webhooks_group.command(name="list")
+@click.option("--limit", "-l", default=50, help="Number of webhooks to fetch")
+@click.option("--skip", "-s", default=0, help="Number of webhooks to skip")
+def list_webhooks(limit: int, skip: int):
+    """List all configured webhooks"""
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        return
+
+    client = get_client(config)
+    response = client.get("/webhooks", params={"limit": limit, "skip": skip})
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    webhooks = response.json()
+    if not webhooks:
+        click.echo("No webhooks found.")
+        return
+
+    for webhook in webhooks:
+        active = "active" if webhook.get("is_active", False) else "inactive"
+        events = ",".join(webhook.get("events", [])) or "*"
+        click.echo(f"{webhook['id']} | {webhook['url']} | {active} | events: {events}")
+
+
+@webhooks_group.command(name="deliveries")
+@click.argument("webhook_id")
+@click.option("--skip", "-s", default=0, help="Number of deliveries to skip")
+@click.option("--limit", "-l", default=50, help="Number of deliveries to fetch")
+@click.option("--event", help="Filter by event")
+@click.option(
+    "--success",
+    type=click.Choice(["true", "false"], case_sensitive=False),
+    help="Filter by success status (true/false)",
+)
+def webhook_deliveries(
+    webhook_id: str, skip: int, limit: int, event: Optional[str], success: Optional[str]
+):
+    """Fetch delivery history for a webhook"""
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        return
+
+    params: dict[str, Any] = {"skip": skip, "limit": limit}
+    if event:
+        params["event"] = event
+    if success is not None:
+        params["success"] = success.lower() == "true"
+
+    client = get_client(config)
+    response = client.get(f"/webhooks/{webhook_id}/deliveries", params=params)
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    deliveries = response.json()
+    if not deliveries:
+        click.echo("No webhook deliveries found.")
+        return
+
+    for item in deliveries:
+        click.echo(
+            f"{item['id']} | event={item['event']} | success={item['success']} | attempts={item['attempts']} | status={item.get('status_code') or 'n/a'}"
+        )
+
+
+@webhooks_group.command(name="get")
+@click.argument("webhook_id")
+def get_webhook(webhook_id: str):
+    """Fetch one webhook by id"""
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        return
+
+    client = get_client(config)
+    response = client.get(f"/webhooks/{webhook_id}")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 404:
+        click.echo("Error: Webhook not found", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    webhook = response.json()
+    active = "active" if webhook.get("is_active", False) else "inactive"
+    click.echo(f"{webhook['id']} | {webhook['url']} | {active}")
+    click.echo(f"Events: {','.join(webhook.get('events', [])) or '*'}")
+    click.echo(f"Created: {webhook.get('created_at')}")

--- a/cli/main.py
+++ b/cli/main.py
@@ -5,6 +5,7 @@ from cli.commands.agents import agents_group
 from cli.commands.api_keys import api_keys_group
 from cli.commands.clawhub import clawhub_group
 from cli.commands.deploy import deploy_group
+from cli.commands.webhooks import webhooks_group
 
 
 @click.group()
@@ -103,6 +104,7 @@ cli.add_command(agents_group)
 cli.add_command(api_keys_group)
 cli.add_command(clawhub_group)
 cli.add_command(deploy_group)
+cli.add_command(webhooks_group)
 
 
 if __name__ == "__main__":

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -81,6 +81,9 @@ mutx status
 | `mutx deploy scale`   | reliable | uses `POST /deployments/{id}/scale`                                      |
 | `mutx deploy restart` | reliable | uses `POST /deployments/{id}/restart`                                    |
 | `mutx deploy delete`  | reliable | uses `DELETE /deployments/{id}`                                          |
+| `mutx webhooks list` | reliable | uses `GET /webhooks`                                                     |
+| `mutx webhooks get`  | reliable | uses `GET /webhooks/{id}`                                                  |
+| `mutx webhooks deliveries` | reliable | uses `GET /webhooks/{id}/deliveries`                                  |
 
 Intentional omission: there is currently no dedicated `mutx deploy get` command for `GET /deployments/{id}`.
 Use `mutx deploy list` plus deployment-specific `events`, `logs`, and `metrics` commands for targeted inspection.
@@ -110,6 +113,9 @@ mutx deploy create --agent-id YOUR_AGENT_ID --replicas 1
 
 # Restart a failed deployment
 mutx deploy restart YOUR_DEPLOYMENT_ID
+
+# Fetch webhook delivery history
+mutx webhooks deliveries YOUR_WEBHOOK_ID --limit 10
 ```
 
 ## When in Doubt

--- a/tests/test_cli_webhooks_contract.py
+++ b/tests/test_cli_webhooks_contract.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cli.main import cli
+
+
+class DummyConfig:
+    def is_authenticated(self) -> bool:
+        return True
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, payload: Any):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def test_webhooks_list_hits_contract_route(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(path: str, params: dict[str, Any] | None = None) -> DummyResponse:
+        captured["path"] = path
+        captured["params"] = params
+        return DummyResponse(
+            200,
+            [
+                {
+                    "id": "wh-1",
+                    "url": "https://example.com/hook",
+                    "is_active": True,
+                    "events": ["agent.status"],
+                }
+            ],
+        )
+
+    monkeypatch.setattr("cli.commands.webhooks.CLIConfig", DummyConfig)
+    monkeypatch.setattr(
+        "cli.commands.webhooks.get_client", lambda config: SimpleNamespace(get=fake_get)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["webhooks", "list", "--limit", "5", "--skip", "2"])
+
+    assert result.exit_code == 0
+    assert captured == {
+        "path": "/webhooks",
+        "params": {
+            "limit": 5,
+            "skip": 2,
+        },
+    }
+    assert "wh-1 | https://example.com/hook | active | events: agent.status" in result.output
+
+
+def test_webhook_deliveries_hits_contract_route_and_filters(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(path: str, params: dict[str, Any] | None = None) -> DummyResponse:
+        captured["path"] = path
+        captured["params"] = params
+        return DummyResponse(
+            200,
+            [
+                {
+                    "id": "dlv-1",
+                    "webhook_id": "wh-1",
+                    "event": "agent.status",
+                    "payload": "{}",
+                    "status_code": 200,
+                    "success": False,
+                    "error_message": None,
+                    "attempts": 1,
+                    "created_at": "2026-03-14T16:00:00Z",
+                    "delivered_at": None,
+                }
+            ],
+        )
+
+    monkeypatch.setattr("cli.commands.webhooks.CLIConfig", DummyConfig)
+    monkeypatch.setattr(
+        "cli.commands.webhooks.get_client", lambda config: SimpleNamespace(get=fake_get)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "webhooks",
+            "deliveries",
+            "wh-1",
+            "--limit",
+            "10",
+            "--skip",
+            "1",
+            "--event",
+            "agent.status",
+            "--success",
+            "false",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["path"] == "/webhooks/wh-1/deliveries"
+    assert captured["params"] == {
+        "skip": 1,
+        "limit": 10,
+        "event": "agent.status",
+        "success": False,
+    }
+    assert "dlv-1 | event=agent.status | success=False | attempts=1 | status=200" in result.output


### PR DESCRIPTION
## Summary
- Adds missing CLI surface for webhooks: list/get/deliveries.
- Routes to live /webhooks contract endpoints with skip/limit/event/success filtering.
- Adds focused contract tests asserting path and queryshape for list/deliveries.
- Updates CLI docs to include webhook command entries.

Refs #93