### PR TITLE
test(web): harden API key dashboard ordering tests

### DIFF
--- a/tests/unit/apiKeyHelpers.test.ts
+++ b/tests/unit/apiKeyHelpers.test.ts
@@ -90,6 +90,34 @@ describe("api key dashboard selectors", () => {
     expect(getLatestActiveApiKey(keys)).not.toBeNull();
   });
 
+  it("ignores malformed timestamps when selecting newest active key", () => {
+    const keys: ApiKey[] = [
+      baseKey({
+        id: "good-active",
+        name: "Good Active",
+        created_at: "2026-03-14T12:00:00.000Z",
+        is_active: true,
+      }),
+      baseKey({
+        id: "bad-active",
+        name: "Bad Active",
+        created_at: "not-a-date",
+        is_active: true,
+      }),
+      baseKey({
+        id: "older-revoked",
+        name: "Older Revoked",
+        created_at: null,
+        is_active: false,
+      }),
+    ];
+
+    const activeKey = getLatestActiveApiKey(keys);
+
+    expect(activeKey).not.toBeNull();
+    expect(activeKey?.id).toBe("good-active");
+  });
+
   it("maps plan quotas to API key limits", () => {
     expect(getApiKeyLimit("free")).toBe(2);
     expect(getApiKeyLimit("starter")).toBe(10);


### PR DESCRIPTION
## Summary\n- Adds a regression test ensuring malformed/nullable key timestamps are treated as oldest and do not shadow valid key ordering.\n\n## Why\n- Tie-back to issue #95 API key lifecycle visibility: dashboard selectors now explicitly guard malformed API telemetry when choosing the newest active key.\n\n## Validation\n- npx jest tests/unit/apiKeyHelpers.test.ts --runInBand\n- npm run test:app\n\nCloses #95