### PR TITLE
docs: align API key list contract text with revoked-key behavior

### DIFF
--- a/docs/contracts/api/api-keys.md
+++ b/docs/contracts/api/api-keys.md
@@ -24,7 +24,7 @@ curl -H "X-API-Key: mutx_live_your_key_here" https://api.mutx.dev/agents
 
 ### List Keys
 
-Returns a list of all active API keys associated with your account.
+Returns a list of all API keys (including revoked keys for auditability) associated with your account.
 
 * **Endpoint**: `GET /api-keys`
 * **Auth**: JWT required


### PR DESCRIPTION
Closes #95

Small contract follow-through slice for API key lifecycle coherency.

- Documents that `GET /api-keys` returns all keys, including revoked ones, matching current backend behavior.
- Keeps API/SDK route expectations aligned with auditability semantics.
- Validation: `pytest -q tests/api/test_api_keys.py`
