### PR TITLE
test(frontend): run full app unit suite in validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "generate-types": "openapi-typescript docs/api/openapi.json -o app/types/api.ts",
-    "test:app": "jest --runInBand tests/unit/controlPlane.test.ts",
+    "test:app": "jest --runInBand tests/unit",
     "demo:validate": "bash scripts/demo-validate.sh"
   },
   "dependencies": {


### PR DESCRIPTION
## Scope
- Make app-level validation run all unit tests under tests/unit instead of only controlPlane.test.ts.

## Why
#96 notes CI truthfulness and flaky lane reduction; the new API key malformed-timestamp regression test is in tests/unit/apiKeyHelpers.test.ts and was not being executed by the current validation entrypoint.

Closes #96
