### PR TITLE
test(cli): add webhook delivery contract coverage

### DIFF
--- a/tests/test_cli_webhooks_contract.py
+++ b/tests/test_cli_webhooks_contract.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any
 from types import SimpleNamespace
+from typing import Any
 
 from click.testing import CliRunner
 
@@ -27,7 +27,7 @@ class DummyResponse:
         return self._payload
 
 
-def test_webhooks_list_hits_contract_route(monkeypatch) -> None:
+def test_webhooks_list_hits_contract_route_and_forwards_filters(monkeypatch) -> None:
     captured: dict[str, Any] = {}
 
     def fake_get(path: str, params: dict[str, Any] | None = None) -> DummyResponse:
@@ -37,7 +37,7 @@ def test_webhooks_list_hits_contract_route(monkeypatch) -> None:
             200,
             [
                 {
-                    "id": "wh-1",
+                    "id": "wh-123",
                     "url": "https://example.com/hook",
                     "is_active": True,
                     "events": ["agent.status"],
@@ -46,26 +46,22 @@ def test_webhooks_list_hits_contract_route(monkeypatch) -> None:
         )
 
     monkeypatch.setattr("cli.commands.webhooks.CLIConfig", DummyConfig)
-    monkeypatch.setattr(
-        "cli.commands.webhooks.get_client", lambda config: SimpleNamespace(get=fake_get)
-    )
+    monkeypatch.setattr("cli.commands.webhooks.get_client", lambda config: SimpleNamespace(get=fake_get))
 
     runner = CliRunner()
-    result = runner.invoke(cli, ["webhooks", "list", "--limit", "5", "--skip", "2"])
+    result = runner.invoke(cli, ["webhooks", "list", "--limit", "25", "--skip", "5"])
 
     assert result.exit_code == 0
     assert captured == {
         "path": "/webhooks",
-        "params": {
-            "limit": 5,
-            "skip": 2,
-        },
+        "params": {"limit": 25, "skip": 5},
     }
-    assert "wh-1 | https://example.com/hook | active | events: agent.status" in result.output
+    assert "wh-123 | https://example.com/hook | active | events: agent.status" in result.output
 
 
-def test_webhook_deliveries_hits_contract_route_and_filters(monkeypatch) -> None:
+def test_webhooks_deliveries_hits_live_delivery_route_and_query_contract(monkeypatch) -> None:
     captured: dict[str, Any] = {}
+    webhook_id = "wh-delivery-1"
 
     def fake_get(path: str, params: dict[str, Any] | None = None) -> DummyResponse:
         captured["path"] = path
@@ -74,24 +70,19 @@ def test_webhook_deliveries_hits_contract_route_and_filters(monkeypatch) -> None
             200,
             [
                 {
-                    "id": "dlv-1",
-                    "webhook_id": "wh-1",
+                    "id": "delivery-1",
                     "event": "agent.status",
-                    "payload": "{}",
-                    "status_code": 200,
                     "success": False,
-                    "error_message": None,
-                    "attempts": 1,
-                    "created_at": "2026-03-14T16:00:00Z",
+                    "attempts": 2,
+                    "status_code": 502,
                     "delivered_at": None,
+                    "created_at": "2026-03-12T15:00:00",
                 }
             ],
         )
 
     monkeypatch.setattr("cli.commands.webhooks.CLIConfig", DummyConfig)
-    monkeypatch.setattr(
-        "cli.commands.webhooks.get_client", lambda config: SimpleNamespace(get=fake_get)
-    )
+    monkeypatch.setattr("cli.commands.webhooks.get_client", lambda config: SimpleNamespace(get=fake_get))
 
     runner = CliRunner()
     result = runner.invoke(
@@ -99,24 +90,58 @@ def test_webhook_deliveries_hits_contract_route_and_filters(monkeypatch) -> None
         [
             "webhooks",
             "deliveries",
-            "wh-1",
+            webhook_id,
+            "--skip",
+            "3",
             "--limit",
             "10",
-            "--skip",
-            "1",
             "--event",
             "agent.status",
             "--success",
-            "false",
+            "true",
         ],
     )
 
     assert result.exit_code == 0
-    assert captured["path"] == "/webhooks/wh-1/deliveries"
-    assert captured["params"] == {
-        "skip": 1,
-        "limit": 10,
-        "event": "agent.status",
-        "success": False,
+    assert captured == {
+        "path": f"/webhooks/{webhook_id}/deliveries",
+        "params": {
+            "skip": 3,
+            "limit": 10,
+            "event": "agent.status",
+            "success": True,
+        },
     }
-    assert "dlv-1 | event=agent.status | success=False | attempts=1 | status=200" in result.output
+    assert "delivery-1 | event=agent.status | success=False | attempts=2 | status=502" in result.output
+
+
+def test_webhooks_get_hits_contract_route_and_prints_created_timestamp(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(path: str, params: dict[str, Any] | None = None) -> DummyResponse:
+        captured["path"] = path
+        captured["params"] = params
+        return DummyResponse(
+            200,
+            {
+                "id": "wh-456",
+                "url": "https://example.com/hook",
+                "is_active": False,
+                "events": ["deployment.failed"],
+                "created_at": "2026-03-12T15:00:00",
+            },
+        )
+
+    monkeypatch.setattr("cli.commands.webhooks.CLIConfig", DummyConfig)
+    monkeypatch.setattr("cli.commands.webhooks.get_client", lambda config: SimpleNamespace(get=fake_get))
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["webhooks", "get", "wh-456"])
+
+    assert result.exit_code == 0
+    assert captured == {
+        "path": "/webhooks/wh-456",
+        "params": None,
+    }
+    assert "wh-456 | https://example.com/hook | inactive" in result.output
+    assert "Created: 2026-03-12T15:00:00" in result.output


### PR DESCRIPTION
Closes #93

Adds focused CLI contract tests for webhook list/deliveries/get routes and filters so live paths and response rendering remain aligned with API contract.

- verify  filters
- verify  query serialization and output
- verify  output mapping

Smallest-value backend slice from issue #93.