### PR TITLE
fix(frontend): add timeout fallback to dashboard health proxy

### DIFF
--- a/app/api/dashboard/health/route.ts
+++ b/app/api/dashboard/health/route.ts
@@ -3,16 +3,28 @@ import { NextResponse } from 'next/server'
 import { getApiBaseUrl } from '@/app/api/_lib/controlPlane'
 
 const API_BASE_URL = getApiBaseUrl()
+const HEALTH_TIMEOUT_MS = Number(process.env.DASHBOARD_HEALTH_TIMEOUT_MS ?? '2500')
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => {
+    controller.abort()
+  }, Math.max(50, HEALTH_TIMEOUT_MS))
+
   try {
-    const response = await fetch(`${API_BASE_URL}/health`, { cache: 'no-store' })
+    const response = await fetch(`${API_BASE_URL}/health`, {
+      cache: 'no-store',
+      signal: controller.signal,
+    })
+    clearTimeout(timeoutId)
     const payload = await response.json().catch(() => ({ status: 'unknown' }))
     return NextResponse.json(payload, { status: response.status })
   } catch (error) {
     console.error('Dashboard health proxy error:', error)
     return NextResponse.json({ status: 'unknown', error: 'Failed to connect to API' }, { status: 500 })
+  } finally {
+    clearTimeout(timeoutId)
   }
 }

--- a/tests/unit/dashboardRoutes.test.ts
+++ b/tests/unit/dashboardRoutes.test.ts
@@ -207,9 +207,12 @@ describe('dashboard route proxies', () => {
 
     const response = await GET()
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/health', {
-      cache: 'no-store',
-    })
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/health',
+      expect.objectContaining({
+        cache: 'no-store',
+      })
+    )
     expect(response.status).toBe(503)
     await expect(response.json()).resolves.toEqual({
       status: 'degraded',


### PR DESCRIPTION
Refs #39.

This is a minimal frontend self-healing slice for monitoring surfaces:

- adds a bounded timeout to the dashboard health proxy using AbortController
- returns deterministic unknown/error payload on timeout/failure
- avoids hanging the route when control plane health checks stall
- keeps call shape unchanged for successful responses

Validation:
- npm run test:app
- npm run lint