### PR TITLE
autonomy: auto-resolve stale claimed issues when merged PR already closes issue

### DIFF
--- a/.github/workflows/autonomous-dispatch.yml
+++ b/.github/workflows/autonomous-dispatch.yml
@@ -54,6 +54,17 @@ jobs:
             const { owner, repo } = context.repo;
             const staleMinutes = parseInt(process.env.AUTONOMY_STALE_CLAIM_MINUTES || '120', 10);
             const cutoff = Date.now() - staleMinutes * 60 * 1000;
+
+            const hasResolveKeyword = (text = '', issueNumber = '') => {
+              const lower = String(text || '').toLowerCase();
+              const needles = [
+                `closes #${issueNumber}`,
+                `fixes #${issueNumber}`,
+                `resolves #${issueNumber}`,
+              ];
+              return needles.some((needle) => lower.includes(needle));
+            };
+
             const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
@@ -88,17 +99,63 @@ jobs:
 
               let hasOpenPr = false;
               if (branchName) {
-                const prs = await github.paginate(github.rest.pulls.list, {
+                const openPrsForBranch = await github.paginate(github.rest.pulls.list, {
                   owner,
                   repo,
                   state: 'open',
                   head: `${owner}:${branchName}`,
                   per_page: 100,
                 });
-                hasOpenPr = prs.length > 0;
+                hasOpenPr = openPrsForBranch.length > 0;
               }
 
               if (hasOpenPr) {
+                continue;
+              }
+
+              const relatedPrs = await github.paginate(github.rest.search.issuesAndPullRequests, {
+                q: `repo:${owner}/${repo} is:pr is:merged #${issue.number}`,
+                per_page: 100,
+              });
+
+              const closeSignalPrs = relatedPrs.filter((item) =>
+                item && item.pull_request && hasResolveKeyword(item.body || '', String(issue.number))
+              );
+
+              if (closeSignalPrs.length > 0) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                }).catch(() => null);
+
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  name: 'autonomy:claimed',
+                }).catch(() => null);
+
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  name: 'autonomy:ready',
+                }).catch(() => null);
+
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: [
+                    'Autonomous dispatch auto-resolved stale claim because a merged PR references this issue.',
+                    '',
+                    `- matching PR(s): ${closeSignalPrs.map((pr) => `#${pr.number}`).join(', ')}`,
+                    '- this prevents endless reclaim/retry churn when resolution is already merged.',
+                  ].join('\n'),
+                }).catch(() => null);
+
                 continue;
               }
 
@@ -116,7 +173,7 @@ jobs:
                 body: [
                   'Autonomous dispatch released this stale claim.',
                   '',
-                  '- no open PR was found for the claimed branch' + (branchName ? ` - \`${branchName}\`` : ''),
+                  '- no open PR was found for the claimed branch' + (branchName ? ` - ${branchName}` : ''),
                   `- stale threshold: ${staleMinutes} minutes`,
                   '- the issue is eligible for re-dispatch',
                 ].join('\n'),


### PR DESCRIPTION
Closes #112

This PR hardens stale claimed-issue cleanup in `.github/workflows/autonomous-dispatch.yml`:
- when a stale claimed issue has no open PR but the issue number is already referenced by a merged PR with a closing keyword (`Closes` / `Fixes` / `Resolves`), auto-close the issue and de-queue it
- de-queue from both `autonomy:claimed` and `autonomy:ready`
- keep previous stale-claim fallback behavior for unresolved issues

This avoids endless reclaim loops on already completed work and cuts token burn.
