### PR TITLE
test(api): add monitor heartbeat self-healing coverage

### DIFF
--- a/tests/api/test_monitor.py
+++ b/tests/api/test_monitor.py
@@ -1,40 +1,69 @@
 import asyncio
+import uuid
+from datetime import datetime, timedelta
+from types import SimpleNamespace
 
 import pytest
 
 from src.api.services import monitor as monitor_module
+from src.api.services.monitoring import STALE_THRESHOLD_SECONDS
 
 
 class _FakeExecuteResult:
+    def __init__(self, *, scalar_value=None, scalar_values=None):
+        self._scalar_value = scalar_value
+        self._scalar_values = scalar_values or []
+
+    def scalar_one_or_none(self):
+        return self._scalar_value
+
     def scalars(self):
         return self
 
     def all(self):
-        return []
+        return self._scalar_values
 
 
 class _FakeSession:
-    async def execute(self, _query):
-        return _FakeExecuteResult()
+    def __init__(self, result: _FakeExecuteResult):
+        self.result = result
 
-    async def commit(self):
-        return None
+    async def execute(self, _query):
+        return self.result
 
 
 class _FakeSessionManager:
+    def __init__(self, result: _FakeExecuteResult):
+        self.result = result
+
     async def __aenter__(self):
-        return _FakeSession()
+        return _FakeSession(self.result)
 
     async def __aexit__(self, _exc_type, _exc, _tb):
         return False
 
 
-def _fake_session_maker():
-    return _FakeSessionManager()
+def _fake_session_maker(result: _FakeExecuteResult):
+    return _FakeSessionManager(result)
 
 
 class _FakeSelfHealing:
-    def __init__(self, *, fail_stop: bool = False):
+    def __init__(self, tracked_agents):
+        self.registered = []
+        self.unregistered = []
+        self.health_check_scheduler = SimpleNamespace(
+            get_all_health=lambda: tracked_agents,
+        )
+
+    def register_agent(self, agent_id, health_check_fn):
+        self.registered.append((agent_id, health_check_fn))
+
+    def unregister_agent(self, agent_id):
+        self.unregistered.append(agent_id)
+
+
+class _FakeSelfHealingMissingScheduler:
+    def __init__(self, fail_stop: bool = False):
         self.start_calls = 0
         self.stop_calls = 0
         self.fail_stop = fail_stop
@@ -51,7 +80,7 @@ class _FakeSelfHealing:
 @pytest.mark.asyncio
 async def test_start_background_monitor_stops_self_healing_on_cancel(monkeypatch):
     monitor_cycle_started = asyncio.Event()
-    fake_self_healing = _FakeSelfHealing()
+    fake_self_healing = _FakeSelfHealingMissingScheduler()
 
     async def fake_monitor_agent_health(_session):
         monitor_cycle_started.set()
@@ -69,7 +98,7 @@ async def test_start_background_monitor_stops_self_healing_on_cancel(monkeypatch
     monkeypatch.setattr(
         monitor_module.database_module,
         "async_session_maker",
-        _fake_session_maker,
+        lambda: _fake_session_maker(_FakeExecuteResult()),
     )
 
     task = asyncio.create_task(monitor_module.start_background_monitor())
@@ -86,7 +115,7 @@ async def test_start_background_monitor_stops_self_healing_on_cancel(monkeypatch
 @pytest.mark.asyncio
 async def test_start_background_monitor_cancellation_survives_stop_failure(monkeypatch):
     monitor_cycle_started = asyncio.Event()
-    fake_self_healing = _FakeSelfHealing(fail_stop=True)
+    fake_self_healing = _FakeSelfHealingMissingScheduler(fail_stop=True)
 
     async def fake_monitor_agent_health(_session):
         monitor_cycle_started.set()
@@ -104,7 +133,7 @@ async def test_start_background_monitor_cancellation_survives_stop_failure(monke
     monkeypatch.setattr(
         monitor_module.database_module,
         "async_session_maker",
-        _fake_session_maker,
+        lambda: _fake_session_maker(_FakeExecuteResult()),
     )
 
     task = asyncio.create_task(monitor_module.start_background_monitor())
@@ -116,3 +145,88 @@ async def test_start_background_monitor_cancellation_survives_stop_failure(monke
 
     assert fake_self_healing.start_calls == 1
     assert fake_self_healing.stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_agent_heartbeat_check_returns_false_for_unknown_agent(monkeypatch):
+    monkeypatch.setattr(
+        monitor_module.database_module,
+        "async_session_maker",
+        lambda: _fake_session_maker(_FakeExecuteResult(scalar_value=None)),
+    )
+
+    check = monitor_module._agent_heartbeat_check(str(uuid.uuid4()))
+    assert await check() is False
+
+
+@pytest.mark.asyncio
+async def test_agent_heartbeat_check_uses_stale_threshold_and_created_at_fallback(monkeypatch):
+    now = datetime.utcnow()
+
+    with_fresh_heartbeat = SimpleNamespace(
+        last_heartbeat=now - timedelta(seconds=STALE_THRESHOLD_SECONDS - 1),
+        created_at=now,
+    )
+    with_stale_heartbeat = SimpleNamespace(
+        last_heartbeat=now - timedelta(seconds=STALE_THRESHOLD_SECONDS + 1),
+        created_at=now,
+    )
+    with_only_created_at = SimpleNamespace(
+        last_heartbeat=None,
+        created_at=now - timedelta(seconds=STALE_THRESHOLD_SECONDS - 1),
+    )
+    without_timestamps = SimpleNamespace(last_heartbeat=None, created_at=None)
+
+    agent_id = str(uuid.uuid4())
+
+    monkeypatch.setattr(
+        monitor_module.database_module,
+        "async_session_maker",
+        lambda: _fake_session_maker(_FakeExecuteResult(scalar_value=with_fresh_heartbeat)),
+    )
+    check = monitor_module._agent_heartbeat_check(agent_id)
+    assert await check() is True
+
+    monkeypatch.setattr(
+        monitor_module.database_module,
+        "async_session_maker",
+        lambda: _fake_session_maker(_FakeExecuteResult(scalar_value=with_stale_heartbeat)),
+    )
+    check = monitor_module._agent_heartbeat_check(agent_id)
+    assert await check() is False
+
+    monkeypatch.setattr(
+        monitor_module.database_module,
+        "async_session_maker",
+        lambda: _fake_session_maker(_FakeExecuteResult(scalar_value=with_only_created_at)),
+    )
+    check = monitor_module._agent_heartbeat_check(agent_id)
+    assert await check() is True
+
+    monkeypatch.setattr(
+        monitor_module.database_module,
+        "async_session_maker",
+        lambda: _fake_session_maker(_FakeExecuteResult(scalar_value=without_timestamps)),
+    )
+    check = monitor_module._agent_heartbeat_check(agent_id)
+    assert await check() is False
+
+
+@pytest.mark.asyncio
+async def test_sync_self_healing_agents_registers_and_unregisters_delta_agents(monkeypatch):
+    active_agent_ids = [str(uuid.uuid4()) for _ in range(2)]
+    stale_agent_id = str(uuid.uuid4())
+    tracked_agent_ids = {
+        active_agent_ids[1]: object(),
+        stale_agent_id: object(),
+    }
+    query_result = _FakeExecuteResult(
+        scalar_values=[uuid.UUID(agent_id) for agent_id in active_agent_ids],
+    )
+    fake_self_healing = _FakeSelfHealing(tracked_agent_ids)
+    session = _FakeSession(query_result)
+
+    await monitor_module._sync_self_healing_agents(session, fake_self_healing)
+
+    assert [agent_id for agent_id, _ in fake_self_healing.registered] == [active_agent_ids[0]]
+    assert fake_self_healing.unregistered == [stale_agent_id]


### PR DESCRIPTION
## Summary
- Add focused monitor tests around heartbeat freshness and self-healing agent set synchronization.
- Covers `_agent_heartbeat_check` edge cases (unknown agent, stale/fresh heartbeat, created-at fallback).
- Covers `_sync_self_healing_agents` register/unregister deltas.

## Validation
- Ran: `pytest -q tests/api/test_monitor.py` (5 passed)