### PR TITLE
fix(frontend): degrade health endpoint on timeout

### DIFF
--- a/app/api/dashboard/health/route.ts
+++ b/app/api/dashboard/health/route.ts
@@ -3,7 +3,12 @@ import { NextResponse } from 'next/server'
 import { getApiBaseUrl } from '@/app/api/_lib/controlPlane'
 
 const API_BASE_URL = getApiBaseUrl()
-const HEALTH_TIMEOUT_MS = Number(process.env.DASHBOARD_HEALTH_TIMEOUT_MS ?? '2500')
+const DEFAULT_HEALTH_TIMEOUT_MS = 2500
+const parsedTimeoutMs = Number(process.env.DASHBOARD_HEALTH_TIMEOUT_MS)
+const HEALTH_TIMEOUT_MS =
+  Number.isFinite(parsedTimeoutMs) && parsedTimeoutMs > 0
+    ? Math.max(50, Math.trunc(parsedTimeoutMs))
+    : DEFAULT_HEALTH_TIMEOUT_MS
 
 export const dynamic = 'force-dynamic'
 
@@ -11,7 +16,7 @@ export async function GET() {
   const controller = new AbortController()
   const timeoutId = setTimeout(() => {
     controller.abort()
-  }, Math.max(50, HEALTH_TIMEOUT_MS))
+  }, HEALTH_TIMEOUT_MS)
 
   try {
     const response = await fetch(`${API_BASE_URL}/health`, {
@@ -23,6 +28,9 @@ export async function GET() {
     return NextResponse.json(payload, { status: response.status })
   } catch (error) {
     console.error('Dashboard health proxy error:', error)
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      return NextResponse.json({ status: 'degraded', error: 'Health check timed out' }, { status: 504 })
+    }
     return NextResponse.json({ status: 'unknown', error: 'Failed to connect to API' }, { status: 500 })
   } finally {
     clearTimeout(timeoutId)

--- a/tests/unit/dashboardRoutes.test.ts
+++ b/tests/unit/dashboardRoutes.test.ts
@@ -220,6 +220,26 @@ describe('dashboard route proxies', () => {
     })
   })
 
+  it('returns a degraded status on health timeout', async () => {
+    const timeoutError = new DOMException('The operation was aborted.', 'AbortError')
+    ;(global.fetch as jest.Mock).mockRejectedValue(timeoutError)
+    const { GET } = await import('../../app/api/dashboard/health/route')
+
+    const response = await GET()
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/health',
+      expect.objectContaining({
+        cache: 'no-store',
+      })
+    )
+    expect(response.status).toBe(504)
+    await expect(response.json()).resolves.toEqual({
+      status: 'degraded',
+      error: 'Health check timed out',
+    })
+  })
+
   it('preserves upstream unauthorized responses for api keys proxy', async () => {
     getAuthToken.mockResolvedValue('token')
     ;(global.fetch as jest.Mock).mockResolvedValue({


### PR DESCRIPTION
### Why
Improve frontend dashboard health proxy behavior when upstream API doesn't respond within timeout.

### Change
- normalize timeout env parsing with safe fallback and minimum boundary
- return a 504 + degraded payload when the upstream health check times out
- add unit test coverage for timeout fallback behavior

### Validation
- npm run test:app -- tests/unit/dashboardRoutes.test.ts