### PR TITLE
fix(monitor): avoid deprecated utcnow in heartbeat flow

### DIFF
--- a/src/api/services/monitor.py
+++ b/src/api/services/monitor.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select
 
@@ -26,7 +26,7 @@ def _agent_heartbeat_check(agent_id: str):
             if not last_heartbeat:
                 return False
 
-            return (datetime.utcnow() - last_heartbeat) <= timedelta(
+            return (datetime.now(timezone.utc).replace(tzinfo=None) - last_heartbeat) <= timedelta(
                 seconds=STALE_THRESHOLD_SECONDS,
             )
 
@@ -43,13 +43,13 @@ async def _recover_agent_to_running(agent_id: str, metadata):
 
         previous_status = agent.status
         agent.status = AgentStatus.RUNNING.value
-        agent.last_heartbeat = datetime.utcnow()
+        agent.last_heartbeat = datetime.now(timezone.utc).replace(tzinfo=None)
         session.add(
             AgentLog(
                 agent_id=agent.id,
                 level="warning",
                 message="Self-healing recovery handler restored agent status to RUNNING",
-                timestamp=datetime.utcnow(),
+                timestamp=datetime.now(timezone.utc).replace(tzinfo=None),
             )
         )
         await session.commit()

--- a/tests/api/test_monitor.py
+++ b/tests/api/test_monitor.py
@@ -1,6 +1,6 @@
 import asyncio
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -161,7 +161,7 @@ async def test_agent_heartbeat_check_returns_false_for_unknown_agent(monkeypatch
 
 @pytest.mark.asyncio
 async def test_agent_heartbeat_check_uses_stale_threshold_and_created_at_fallback(monkeypatch):
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
 
     with_fresh_heartbeat = SimpleNamespace(
         last_heartbeat=now - timedelta(seconds=STALE_THRESHOLD_SECONDS - 1),


### PR DESCRIPTION
## Summary
- Replace `datetime.utcnow()` usages in monitor service with timezone-safe UTC-now replacement.
- Keep timestamps timezone-naive for existing DB column compatibility while avoiding `DeprecationWarning` on Python 3.13+.
- Update monitor heartbeat test to mirror the same helper.

## Validation
- Ran: `uv run pytest -q tests/api/test_monitor.py` (5 passed)
