### PR TITLE
fix(api): replace datetime.utcnow with timezone-aware datetime.now

### DIFF
--- a/src/api/routes/agents.py
+++ b/src/api/routes/agents.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 import logging
@@ -227,7 +227,7 @@ async def deploy_agent(
         agent_id=agent_id,
         status="deploying",
         replicas=1,
-        started_at=datetime.utcnow(),
+        started_at=datetime.now(timezone.utc),
     )
     db.add(deployment)
     await db.flush()  # Get deployment.id
@@ -269,7 +269,7 @@ async def stop_agent(
     deployments = result.scalars().all()
     for deployment in deployments:
         deployment.status = "stopped"
-        deployment.ended_at = datetime.utcnow()
+        deployment.ended_at = datetime.now(timezone.utc)
 
         # Record stop event
         stop_event = DeploymentEventModel(

--- a/src/api/routes/deployments.py
+++ b/src/api/routes/deployments.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
@@ -230,7 +230,7 @@ async def kill_deployment(
     deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
 
     deployment.status = "killed"
-    deployment.ended_at = datetime.utcnow()
+    deployment.ended_at = datetime.now(timezone.utc)
 
     # Record kill event
     kill_event = DeploymentEventModel(
@@ -273,7 +273,7 @@ async def create_deployment(
         agent_id=deployment_data.agent_id,
         status="pending",
         replicas=deployment_data.replicas,
-        started_at=datetime.utcnow(),
+        started_at=datetime.now(timezone.utc),
     )
     db.add(deployment)
     await db.flush()  # Get deployment.id
@@ -314,7 +314,7 @@ async def restart_deployment(
 
     # Reset deployment status
     deployment.status = "pending"
-    deployment.started_at = datetime.utcnow()
+    deployment.started_at = datetime.now(timezone.utc)
     deployment.ended_at = None
     deployment.error_message = None
 


### PR DESCRIPTION
## Summary

Resolves Python 3.14+ deprecation warnings for `datetime.utcnow()`.

## Changes
- Replace `datetime.utcnow()` with `datetime.now(timezone.utc)` in:
  - `src/api/routes/agents.py`
  - `src/api/routes/deployments.py`

## Validation
- 54 tests passed (test_agents.py + test_deployments.py)
- No breaking changes

## Notes
- Backend APIs for issues #232, #233, #234 are already implemented and merged
- This is a maintenance slice to address deprecation warnings