### PR TITLE
fix(api): resolve datetime.utcnow deprecation in api_keys.py

### DIFF
--- a/src/api/routes/api_keys.py
+++ b/src/api/routes/api_keys.py
@@ -1,6 +1,6 @@
 import secrets
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -68,7 +68,7 @@ async def create_api_key(
 
     expires_at = None
     if key_data.expires_in_days:
-        expires_at = datetime.utcnow() + timedelta(days=key_data.expires_in_days)
+        expires_at = datetime.now(timezone.utc) + timedelta(days=key_data.expires_in_days)
 
     api_key = APIKey(
         id=uuid.uuid4(),


### PR DESCRIPTION
Resolves Python 3.14+ deprecation warning in api_keys.py.

## Changes
- Replace datetime.utcnow() with datetime.now(timezone.utc) in src/api/routes/api_keys.py

## Validation
- 14 API key tests pass