### PR TITLE
fix(api): protect ClawHub install/uninstall with auth + ownership checks

### DIFF
--- a/src/api/routes/clawhub.py
+++ b/src/api/routes/clawhub.py
@@ -8,6 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.database import get_db
 from src.api.models import Agent, AgentLog
+from src.api.middleware.auth import get_current_user
+from src.api.models.models import User
 
 router = APIRouter(prefix="/clawhub", tags=["clawhub"])
 
@@ -89,13 +91,19 @@ async def list_available_skills():
 
 
 @router.post("/install")
-async def install_skill(request: InstallSkillRequest, db: AsyncSession = Depends(get_db)):
+async def install_skill(
+    request: InstallSkillRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     """Installs a skill to an agent's configuration."""
     result = await db.execute(select(Agent).where(Agent.id == request.agent_id))
     agent = result.scalar_one_or_none()
 
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to modify this agent")
 
     # Simple JSON-based config management for the demo
     import json
@@ -125,13 +133,19 @@ async def install_skill(request: InstallSkillRequest, db: AsyncSession = Depends
 
 
 @router.post("/uninstall")
-async def uninstall_skill(request: InstallSkillRequest, db: AsyncSession = Depends(get_db)):
+async def uninstall_skill(
+    request: InstallSkillRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     """Removes a skill from an agent's configuration."""
     result = await db.execute(select(Agent).where(Agent.id == request.agent_id))
     agent = result.scalar_one_or_none()
 
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to modify this agent")
 
     import json
 

--- a/tests/api/test_clawhub.py
+++ b/tests/api/test_clawhub.py
@@ -1,0 +1,41 @@
+"""Tests for /clawhub endpoints."""
+
+import pytest
+from httpx import AsyncClient
+
+
+class TestClawHubSkillManagementAuthz:
+    """Authorization checks for install/uninstall operations."""
+
+    @pytest.mark.asyncio
+    async def test_install_skill_requires_authentication(
+        self, client_no_auth: AsyncClient, test_agent
+    ):
+        response = await client_no_auth.post(
+            "/clawhub/install",
+            json={"agent_id": str(test_agent.id), "skill_id": "skill-demo"},
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_install_skill_for_other_user_agent_forbidden(
+        self, other_user_client: AsyncClient, test_agent
+    ):
+        response = await other_user_client.post(
+            "/clawhub/install",
+            json={"agent_id": str(test_agent.id), "skill_id": "skill-demo"},
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_uninstall_skill_for_other_user_agent_forbidden(
+        self, other_user_client: AsyncClient, test_agent
+    ):
+        response = await other_user_client.post(
+            "/clawhub/uninstall",
+            json={"agent_id": str(test_agent.id), "skill_id": "skill-demo"},
+        )
+
+        assert response.status_code == 403


### PR DESCRIPTION
### Motivation
- The `/clawhub/install` and `/clawhub/uninstall` endpoints previously accepted an `agent_id` and mutated `Agent.config` and `AgentLog` with no authentication or ownership checks, allowing unauthenticated cross-tenant tampering.

### Description
- Require an authenticated user on `POST /clawhub/install` and `POST /clawhub/uninstall` by adding `current_user: User = Depends(get_current_user)` to both endpoints and importing `get_current_user` and `User`.
- Enforce agent ownership by checking `agent.user_id == current_user.id` and returning `403 Not authorized to modify this agent` before any config or log mutation.
- Add focused API tests in `tests/api/test_clawhub.py` that assert unauthenticated install attempts return `401` and cross-tenant install/uninstall attempts return `403`.

### Testing
- Installed test dependency with `python -m pip install pytest-asyncio` successfully. 
- Ran `pytest -q tests/api/test_clawhub.py tests/test_sdk_clawhub_contract.py` and observed all tests pass (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b5a88b10832abd2feafa7a089c6d)