### PR TITLE
Require auth and ownership on ClawHub install/uninstall endpoints

### DIFF
--- a/src/api/routes/clawhub.py
+++ b/src/api/routes/clawhub.py
@@ -7,7 +7,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.database import get_db
-from src.api.models import Agent, AgentLog
+from src.api.middleware.auth import get_current_user
+from src.api.models import Agent, AgentLog, User
 
 router = APIRouter(prefix="/clawhub", tags=["clawhub"])
 
@@ -89,13 +90,19 @@ async def list_available_skills():
 
 
 @router.post("/install")
-async def install_skill(request: InstallSkillRequest, db: AsyncSession = Depends(get_db)):
+async def install_skill(
+    request: InstallSkillRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     """Installs a skill to an agent's configuration."""
     result = await db.execute(select(Agent).where(Agent.id == request.agent_id))
     agent = result.scalar_one_or_none()
 
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to modify this agent")
 
     # Simple JSON-based config management for the demo
     import json
@@ -125,13 +132,19 @@ async def install_skill(request: InstallSkillRequest, db: AsyncSession = Depends
 
 
 @router.post("/uninstall")
-async def uninstall_skill(request: InstallSkillRequest, db: AsyncSession = Depends(get_db)):
+async def uninstall_skill(
+    request: InstallSkillRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     """Removes a skill from an agent's configuration."""
     result = await db.execute(select(Agent).where(Agent.id == request.agent_id))
     agent = result.scalar_one_or_none()
 
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to modify this agent")
 
     import json
 

--- a/tests/api/test_clawhub.py
+++ b/tests/api/test_clawhub.py
@@ -1,0 +1,43 @@
+"""Tests for /clawhub endpoints."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.models.models import Agent, AgentStatus
+
+
+class TestClawHubSkillManagement:
+    @pytest.mark.asyncio
+    async def test_install_skill_requires_auth(self, client_no_auth: AsyncClient, test_agent):
+        response = await client_no_auth.post(
+            "/clawhub/install",
+            json={"agent_id": str(test_agent.id), "skill_id": "web_search"},
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_install_skill_other_user_forbidden(
+        self,
+        other_user_client: AsyncClient,
+        db_session: AsyncSession,
+        test_user,
+    ):
+        agent = Agent(
+            name="owned-by-test-user",
+            description="for clawhub auth test",
+            config="{}",
+            user_id=test_user.id,
+            status=AgentStatus.CREATING,
+        )
+        db_session.add(agent)
+        await db_session.commit()
+        await db_session.refresh(agent)
+
+        response = await other_user_client.post(
+            "/clawhub/install",
+            json={"agent_id": str(agent.id), "skill_id": "web_search"},
+        )
+
+        assert response.status_code == 403


### PR DESCRIPTION
### Motivation
- The `/clawhub/install` and `/clawhub/uninstall` handlers previously mutated agent configuration based only on a supplied `agent_id` with no authentication or ownership checks, allowing unauthenticated or cross-tenant changes.
- The change aims to prevent unauthorized modification of agent configs while preserving existing install/uninstall behavior for legitimate owners.

### Description
- Require authentication by adding `Depends(get_current_user)` to both `POST /clawhub/install` and `POST /clawhub/uninstall` handlers in `src/api/routes/clawhub.py`.
- Enforce ownership by checking `agent.user_id == current_user.id` before performing any config mutation and returning `403` otherwise.
- Import the `get_current_user` dependency and the `User` model in `src/api/routes/clawhub.py` to enable dependency injection and ownership checks.
- Add focused API tests in `tests/api/test_clawhub.py` that assert unauthenticated install attempts return `401` and cross-user install attempts return `403`.

### Testing
- `python -m compileall src/api/routes/clawhub.py tests/api/test_clawhub.py` completed successfully.
- Running `pytest -q tests/api/test_clawhub.py tests/test_sdk_clawhub_contract.py` failed in this environment due to a missing test dependency (`ModuleNotFoundError: No module named 'pytest_asyncio'`).
- The new tests were added and validated syntactically and via test fixtures in `tests/conftest.py`, and behavior is covered by the added assertions; full CI should be run to validate with all test dependencies present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b344e364832a8b3b61c342ff3cae)