### PR TITLE
fix(web): keep auth cookies host-only

### DIFF
--- a/app/api/_lib/controlPlane.ts
+++ b/app/api/_lib/controlPlane.ts
@@ -21,12 +21,8 @@ export function shouldUseSecureCookies(request: NextRequest) {
 }
 
 export function getCookieDomain(request: NextRequest) {
-  const hostname = request.nextUrl.hostname.toLowerCase()
-
-  if (hostname === 'app.mutx.dev' || hostname === 'mutx.dev') {
-    return '.mutx.dev'
-  }
-
+  // Keep auth cookies host-only to avoid exposing tokens across subdomains.
+  void request
   return undefined
 }
 

--- a/tests/unit/controlPlane.test.ts
+++ b/tests/unit/controlPlane.test.ts
@@ -14,9 +14,9 @@ function mockRequest(url: string, forwardedProto?: string) {
 }
 
 describe('dashboard auth cookie policy helpers', () => {
-  it('shares auth cookies across mutx.dev subdomains', () => {
-    expect(getCookieDomain(mockRequest('https://app.mutx.dev/api/auth/login'))).toBe('.mutx.dev')
-    expect(getCookieDomain(mockRequest('https://mutx.dev/api/auth/login'))).toBe('.mutx.dev')
+  it('does not force a shared domain for production hosts', () => {
+    expect(getCookieDomain(mockRequest('https://app.mutx.dev/api/auth/login'))).toBeUndefined()
+    expect(getCookieDomain(mockRequest('https://mutx.dev/api/auth/login'))).toBeUndefined()
   })
 
   it('does not force a domain on localhost-style environments', () => {


### PR DESCRIPTION
### Motivation

- The prior change added `getCookieDomain()` that returned `.mutx.dev` for production hosts to share auth cookies across subdomains, which broadened the attack surface by exposing non-HttpOnly tokens to any `*.mutx.dev` subdomain. 
- The intent of the fix is to remove cross-subdomain cookie scoping so auth tokens remain host-only and are not readable by JavaScript on other subdomains.

### Description

- Changed `getCookieDomain()` in `app/api/_lib/controlPlane.ts` to always return `undefined`, keeping auth cookies host-only and avoiding setting a shared `.mutx.dev` domain. 
- Updated `tests/unit/controlPlane.test.ts` to assert the production hosts no longer receive a forced shared cookie domain while retaining localhost expectations. 
- Preserved existing `shouldUseSecureCookies()` behavior and other cookie attributes so secure-cookie logic remains unchanged. 

### Testing

- Ran the unit tests for the application with `npm run test:app -- tests/unit/controlPlane.test.ts` and verified all affected suites pass. 
- Test summary: Test Suites: 4 passed, Tests: 37 passed, all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5aeb75530832aac46eb527093e3de)