### PR TITLE
fix(auth): always set Secure on auth cookies

### DIFF
--- a/app/api/_lib/controlPlane.ts
+++ b/app/api/_lib/controlPlane.ts
@@ -17,7 +17,8 @@ export function getApiBaseUrl() {
 }
 
 export function shouldUseSecureCookies(request: NextRequest) {
-  return request.nextUrl.protocol === 'https:' || request.headers.get('x-forwarded-proto') === 'https'
+  void request
+  return true
 }
 
 export function getCookieDomain(request: NextRequest) {

--- a/tests/unit/controlPlane.test.ts
+++ b/tests/unit/controlPlane.test.ts
@@ -24,9 +24,9 @@ describe('dashboard auth cookie policy helpers', () => {
     expect(getCookieDomain(mockRequest('http://localhost:3000/api/auth/login'))).toBeUndefined()
   })
 
-  it('marks cookies secure for direct https and forwarded https requests', () => {
+  it('always marks auth cookies as secure', () => {
     expect(shouldUseSecureCookies(mockRequest('https://app.mutx.dev/api/auth/login'))).toBe(true)
     expect(shouldUseSecureCookies(mockRequest('http://app.mutx.dev/api/auth/login', 'https'))).toBe(true)
-    expect(shouldUseSecureCookies(mockRequest('http://localhost:3000/api/auth/login'))).toBe(false)
+    expect(shouldUseSecureCookies(mockRequest('http://localhost:3000/api/auth/login'))).toBe(true)
   })
 })


### PR DESCRIPTION
### Motivation
- Prevent a security regression where auth cookies could be issued without the `Secure` attribute when the inbound request appeared as HTTP or `x-forwarded-proto` was missing, which can expose tokens to on-path attackers.

### Description
- Make `shouldUseSecureCookies` always return `true` in `app/api/_lib/controlPlane.ts` so access/refresh cookies are always set with `Secure`.
- Update the unit test in `tests/unit/controlPlane.test.ts` to reflect the hardened policy and to assert secure cookies are always enabled.
- Leave route handlers unchanged; they continue to rely on the shared helper for cookie security.

### Testing
- Ran `npm run test:app`, which executed the unit test suite and completed successfully with all tests passing (4 test suites, 37 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ac6f5238832abb9ab135659ab40e)