### PR TITLE
fix(webhooks): scope agent heartbeat webhooks to agent owner

### DIFF
--- a/src/api/routes/agent_runtime.py
+++ b/src/api/routes/agent_runtime.py
@@ -181,6 +181,7 @@ async def heartbeat(
                 "hostname": request.hostname,
                 "timestamp": heartbeat_timestamp,
             },
+            user_id=agent.user_id,
         )
     except Exception:
         logger.exception(
@@ -202,6 +203,7 @@ async def heartbeat(
                     "hostname": request.hostname,
                     "timestamp": heartbeat_timestamp,
                 },
+                user_id=agent.user_id,
             )
         except Exception:
             logger.exception(

--- a/src/api/services/webhook_service.py
+++ b/src/api/services/webhook_service.py
@@ -173,6 +173,7 @@ async def trigger_webhook_event(
     db: AsyncSession,
     event: str,
     payload: dict,
+    user_id: Optional[uuid.UUID] = None,
 ) -> int:
     """
     Trigger a webhook event to all active webhooks subscribed to the event.
@@ -180,8 +181,13 @@ async def trigger_webhook_event(
     Returns:
         Number of successful deliveries
     """
-    # Get all active webhooks that subscribe to this event
-    result = await db.execute(select(Webhook).where(Webhook.is_active))
+    # Get active webhooks that subscribe to this event.
+    # If a user_id is provided, only deliver within that tenant.
+    query = select(Webhook).where(Webhook.is_active)
+    if user_id is not None:
+        query = query.where(Webhook.user_id == user_id)
+
+    result = await db.execute(query)
     webhooks = result.scalars().all()
 
     # Filter webhooks by event subscription

--- a/tests/api/test_ingest.py
+++ b/tests/api/test_ingest.py
@@ -101,7 +101,7 @@ async def test_agent_runtime_heartbeat_triggers_heartbeat_webhook_without_status
 
     delivered: list[tuple[str, dict]] = []
 
-    async def mock_trigger_webhook_event(db, event, payload):
+    async def mock_trigger_webhook_event(db, event, payload, user_id=None):
         delivered.append((event, payload))
         return 1
 
@@ -149,7 +149,7 @@ async def test_agent_runtime_heartbeat_emits_status_webhook_on_status_change(
 
     delivered: list[tuple[str, dict]] = []
 
-    async def mock_trigger_webhook_event(db, event, payload):
+    async def mock_trigger_webhook_event(db, event, payload, user_id=None):
         delivered.append((event, payload))
         return 1
 
@@ -186,7 +186,7 @@ async def test_agent_runtime_heartbeat_returns_ok_when_webhook_dispatch_fails(
 
     emitted_events: list[str] = []
 
-    async def mock_trigger_webhook_event(db, event, payload):
+    async def mock_trigger_webhook_event(db, event, payload, user_id=None):
         emitted_events.append(event)
         raise RuntimeError("webhook dispatch unavailable")
 


### PR DESCRIPTION
### Motivation
- Agent heartbeat handlers called a global `trigger_webhook_event` which selected all active webhooks without tenant scoping, allowing any agent-authenticated heartbeat to be broadcast to every tenant's webhook subscriptions.
- Webhooks are stored per-user (`Webhook.user_id`), so deliveries should be scoped to the agent owner's tenant to avoid cross-tenant information disclosure and DoS amplification.

### Description
- Added an optional `user_id: Optional[uuid.UUID]` parameter to `trigger_webhook_event` and applied a `WHERE Webhook.user_id == user_id` filter when `user_id` is provided in `src/api/services/webhook_service.py`.
- Updated the agent runtime heartbeat emissions in `src/api/routes/agent_runtime.py` to pass `user_id=agent.user_id` for both `agent.heartbeat` and `agent.status` events so heartbeats are delivered only to the owning tenant's webhooks.
- Adjusted affected tests (`tests/api/test_ingest.py`) to accept the new optional `user_id` parameter in monkeypatched `trigger_webhook_event` helpers.
- Change is minimal and preserves existing webhook subscription filtering logic and delivery behavior within a tenant.

### Testing
- Ran `python -m compileall src/api/routes/agent_runtime.py src/api/services/webhook_service.py tests/api/test_ingest.py` which completed successfully.
- Attempted to run targeted pytest cases for heartbeat webhook behavior, but `pytest` failed to load due to missing test dependency `pytest_asyncio` (`ModuleNotFoundError: No module named 'pytest_asyncio'`).
- Static sanity checks and targeted edits were validated by compiling and updating the affected unit tests to match the new function signature.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ae08bfac832aa49a489de58f267f)