### PR TITLE
fix: scope webhook dispatches by tenant user

### DIFF
--- a/src/api/routes/agent_runtime.py
+++ b/src/api/routes/agent_runtime.py
@@ -181,6 +181,7 @@ async def heartbeat(
                 "hostname": request.hostname,
                 "timestamp": heartbeat_timestamp,
             },
+            user_id=agent.user_id,
         )
     except Exception:
         logger.exception(
@@ -202,6 +203,7 @@ async def heartbeat(
                     "hostname": request.hostname,
                     "timestamp": heartbeat_timestamp,
                 },
+                user_id=agent.user_id,
             )
         except Exception:
             logger.exception(

--- a/src/api/routes/ingest.py
+++ b/src/api/routes/ingest.py
@@ -89,7 +89,9 @@ async def agent_status_update(
     await db.commit()
 
     # Trigger webhook
-    await trigger_agent_status_event(db, agent.id, old_status, agent.status, agent.name)
+    await trigger_agent_status_event(
+        db, agent.id, old_status, agent.status, agent.name, user_id=current_user.id
+    )
 
     logger.info(f"Agent {agent.id} status updated to {status_data.status.value}")
     return {"status": "updated"}
@@ -154,7 +156,14 @@ async def deployment_event(
     await db.commit()
 
     # Trigger webhook
-    await trigger_deployment_event(db, deployment.id, agent.id, event_data.event, deployment.status)
+    await trigger_deployment_event(
+        db,
+        deployment.id,
+        agent.id,
+        event_data.event,
+        deployment.status,
+        user_id=current_user.id,
+    )
 
     logger.info(f"Deployment {deployment.id} event: {event_data.event}")
     return {"status": "processed"}
@@ -197,6 +206,7 @@ async def receive_metrics(
             "memory_usage": metrics_data.memory_usage,
             "timestamp": datetime.utcnow().isoformat(),
         },
+        user_id=current_user.id,
     )
 
     logger.debug(f"Received metrics for agent {metrics_data.agent_id}")

--- a/src/api/services/monitoring.py
+++ b/src/api/services/monitoring.py
@@ -58,9 +58,12 @@ async def _emit_agent_status_webhook(
     old_status: str,
     new_status: str,
     agent_name: str,
+    user_id: uuid.UUID,
 ) -> None:
     try:
-        await trigger_agent_status_event(session, agent_id, old_status, new_status, agent_name)
+        await trigger_agent_status_event(
+            session, agent_id, old_status, new_status, agent_name, user_id=user_id
+        )
     except Exception:
         logger.exception(
             "Monitor webhook emission failed for agent.status",
@@ -75,6 +78,7 @@ async def _emit_deployment_webhook(
     agent_id: uuid.UUID,
     event_type: str,
     status: str,
+    user_id: uuid.UUID,
 ) -> None:
     try:
         await trigger_deployment_event(
@@ -83,6 +87,7 @@ async def _emit_deployment_webhook(
             agent_id,
             event_type=event_type,
             status=status,
+            user_id=user_id,
         )
     except Exception:
         logger.exception(
@@ -141,6 +146,7 @@ async def monitor_agent_health(session: AsyncSession):
                     agent_id=agent.id,
                     event_type="monitor_started",
                     status="running",
+                    user_id=agent.user_id,
                 )
 
             await _emit_agent_status_webhook(
@@ -149,6 +155,7 @@ async def monitor_agent_health(session: AsyncSession):
                 old_status=old_status,
                 new_status=agent.status,
                 agent_name=agent.name,
+                user_id=agent.user_id,
             )
 
             logger.info(f"Monitor: Agent {agent.name} ({agent.id}) promoted to RUNNING")
@@ -199,6 +206,7 @@ async def monitor_agent_health(session: AsyncSession):
                     agent_id=agent.id,
                     event_type="monitor_failed",
                     status="failed",
+                    user_id=agent.user_id,
                 )
 
             await _emit_agent_status_webhook(
@@ -207,6 +215,7 @@ async def monitor_agent_health(session: AsyncSession):
                 old_status=old_status,
                 new_status=agent.status,
                 agent_name=agent.name,
+                user_id=agent.user_id,
             )
 
     # 3. Auto-Heal Failed Agents
@@ -258,6 +267,7 @@ async def monitor_agent_health(session: AsyncSession):
                     agent_id=agent.id,
                     event_type="monitor_restarted",
                     status="running",
+                    user_id=agent.user_id,
                 )
 
             await _emit_agent_status_webhook(
@@ -266,6 +276,7 @@ async def monitor_agent_health(session: AsyncSession):
                 old_status=old_status,
                 new_status=agent.status,
                 agent_name=agent.name,
+                user_id=agent.user_id,
             )
 
     await session.commit()

--- a/src/api/services/webhook_service.py
+++ b/src/api/services/webhook_service.py
@@ -173,6 +173,7 @@ async def trigger_webhook_event(
     db: AsyncSession,
     event: str,
     payload: dict,
+    user_id: Optional[uuid.UUID] = None,
 ) -> int:
     """
     Trigger a webhook event to all active webhooks subscribed to the event.
@@ -180,8 +181,13 @@ async def trigger_webhook_event(
     Returns:
         Number of successful deliveries
     """
-    # Get all active webhooks that subscribe to this event
-    result = await db.execute(select(Webhook).where(Webhook.is_active))
+    # Get active webhooks that subscribe to this event.
+    # Scope by user when provided to avoid cross-tenant dispatch.
+    query = select(Webhook).where(Webhook.is_active)
+    if user_id is not None:
+        query = query.where(Webhook.user_id == user_id)
+
+    result = await db.execute(query)
     webhooks = result.scalars().all()
 
     # Filter webhooks by event subscription
@@ -237,6 +243,7 @@ async def trigger_agent_status_event(
     old_status: str,
     new_status: str,
     agent_name: str,
+    user_id: Optional[uuid.UUID] = None,
 ):
     """Trigger agent.status event."""
     await trigger_webhook_event(
@@ -248,6 +255,7 @@ async def trigger_agent_status_event(
             "old_status": old_status,
             "new_status": new_status,
         },
+        user_id=user_id,
     )
 
 
@@ -257,6 +265,7 @@ async def trigger_deployment_event(
     agent_id: uuid.UUID,
     event_type: str,
     status: Optional[str] = None,
+    user_id: Optional[uuid.UUID] = None,
 ):
     """Trigger deployment event."""
     await trigger_webhook_event(
@@ -268,4 +277,5 @@ async def trigger_deployment_event(
             "event_type": event_type,
             "status": status,
         },
+        user_id=user_id,
     )

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -4,7 +4,8 @@ import uuid
 from datetime import datetime, timedelta
 
 from src.api.auth.jwt import create_access_token
-from src.api.models.models import WebhookDeliveryLog
+from src.api.models.models import Webhook, WebhookDeliveryLog
+from src.api.services.webhook_service import trigger_webhook_event
 
 
 @pytest.mark.asyncio
@@ -149,6 +150,46 @@ async def test_webhook_test_trigger(client: AsyncClient, test_user, monkeypatch)
     response = await client.post(f"/webhooks/{webhook_id}/test")
     assert response.status_code == 200
     assert response.json()["status"] == "test_delivered"
+
+
+@pytest.mark.asyncio
+async def test_trigger_webhook_event_scopes_delivery_to_user(
+    db_session, test_user, other_user, monkeypatch
+):
+    import src.api.services.webhook_service as webhook_service
+
+    test_user_webhook = Webhook(
+        user_id=test_user.id,
+        url="https://example.com/test-user",
+        events=["agent.status"],
+        is_active=True,
+    )
+    other_user_webhook = Webhook(
+        user_id=other_user.id,
+        url="https://example.com/other-user",
+        events=["agent.status"],
+        is_active=True,
+    )
+    db_session.add_all([test_user_webhook, other_user_webhook])
+    await db_session.commit()
+
+    delivered_user_ids: list[uuid.UUID] = []
+
+    async def mock_deliver(_session, _db, webhook, _event, _payload):
+        delivered_user_ids.append(webhook.user_id)
+        return True
+
+    monkeypatch.setattr(webhook_service, "deliver_webhook_with_retry", mock_deliver)
+
+    success_count = await trigger_webhook_event(
+        db_session,
+        "agent.status",
+        {"agent_id": "33333333-3333-4333-a333-333333333333"},
+        user_id=test_user.id,
+    )
+
+    assert success_count == 1
+    assert delivered_user_ids == [test_user.id]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- A recent change started triggering webhooks from ingest/runtime/monitoring paths but `trigger_webhook_event` selected all active webhooks globally, allowing cross-tenant disclosure of agent/deployment/metrics events.
- Webhook records include a `user_id` and webhook management enforces per-user access, so dispatch should be scoped per owning tenant to preserve isolation.

### Description
- Add an optional `user_id` parameter to `trigger_webhook_event` and apply it to the DB query so webhook selection is restricted to `Webhook.user_id` when provided (`src/api/services/webhook_service.py`).
- Thread the `user_id` argument through helper wrappers `trigger_agent_status_event` and `trigger_deployment_event` so callers can forward the tenant id (`src/api/services/webhook_service.py`).
- Update ingest endpoints to pass the authenticated `current_user.id` when emitting status, deployment, and metrics webhooks (`src/api/routes/ingest.py`).
- Update runtime heartbeat/status emitters and the monitoring service to pass the owning `user_id` for monitor-generated events, preserving tenant scoping (`src/api/routes/agent_runtime.py`, `src/api/services/monitoring.py`).
- Add a regression test `test_trigger_webhook_event_scopes_delivery_to_user` that inserts two webhooks for different users and monkeypatches delivery to assert only the targeted user’s webhook is invoked (`tests/api/test_webhooks.py`).

### Testing
- Compiled the modified modules using `python -m compileall` for `src/api/services/webhook_service.py`, `src/api/routes/ingest.py`, `src/api/routes/agent_runtime.py`, `src/api/services/monitoring.py`, and `tests/api/test_webhooks.py`, which succeeded.
- Attempted to run a targeted pytest session for the new webhook test and related ingest/runtime tests using `pytest -q ...`, but the run failed due to missing test dependency `pytest_asyncio` in the local environment (ModuleNotFoundError).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ae3882ec832a9c2b24e2d52e3cbe)