### PR TITLE
Restrict leads read endpoints to internal users

### DIFF
--- a/src/api/config.py
+++ b/src/api/config.py
@@ -63,6 +63,14 @@ class Settings(BaseSettings):
             "DB_CONNECT_TIMEOUT_SECONDS",
         ),
     )
+    internal_user_email_domains: list[str] = Field(
+        default=["mutx.dev"],
+        validation_alias=AliasChoices(
+            "INTERNAL_USER_EMAIL_DOMAINS",
+            "ADMIN_EMAIL_DOMAINS",
+        ),
+        description="Email domains allowed to access internal-only endpoints.",
+    )
 
 
 @lru_cache()

--- a/src/api/routes/leads.py
+++ b/src/api/routes/leads.py
@@ -4,12 +4,27 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
 import uuid
 
+from src.api.config import get_settings
 from src.api.database import get_db
 from src.api.models.models import Lead, User
 from src.api.models.schemas import LeadCreate, LeadResponse
 from src.api.middleware.auth import get_current_user
 
 router = APIRouter(prefix="/leads", tags=["leads"])
+
+
+def _assert_internal_user(current_user: User) -> None:
+    """Restrict internal lead access to configured internal email domains."""
+    settings = get_settings()
+    allowed_domains = {
+        domain.strip().lower()
+        for domain in settings.internal_user_email_domains
+        if domain and domain.strip()
+    }
+
+    user_domain = current_user.email.rsplit("@", 1)[-1].lower() if "@" in current_user.email else ""
+    if user_domain not in allowed_domains:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
 
 
 @router.post("", response_model=LeadResponse, status_code=status.HTTP_201_CREATED)
@@ -43,9 +58,9 @@ async def list_leads(
 ):
     """
     List captured leads.
-    Restricted to authenticated users (internal/admin use).
+    Restricted to internal/admin users.
     """
-    # In a real app, we might check if user is admin
+    _assert_internal_user(current_user)
     result = await db.execute(
         select(Lead).order_by(Lead.created_at.desc()).offset(skip).limit(limit)
     )
@@ -60,6 +75,7 @@ async def get_lead(
     current_user: User = Depends(get_current_user),
 ):
     """Get a specific lead by ID."""
+    _assert_internal_user(current_user)
     result = await db.execute(select(Lead).where(Lead.id == lead_id))
     lead = result.scalar_one_or_none()
     if not lead:

--- a/tests/api/test_leads.py
+++ b/tests/api/test_leads.py
@@ -44,12 +44,18 @@ async def test_capture_lead_minimal(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_list_leads_authenticated(client: AsyncClient, test_user):
-    """Test listing leads requires authentication."""
-    # This should succeed because 'client' is authenticated (via conftest fixtures usually)
+async def test_list_leads_internal_user(client: AsyncClient, test_user):
+    """Test listing leads for an internal user."""
     response = await client.get("/leads")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
+
+
+@pytest.mark.asyncio
+async def test_list_leads_non_internal_forbidden(other_user_client: AsyncClient):
+    """Test listing leads is forbidden for non-internal users."""
+    response = await other_user_client.get("/leads")
+    assert response.status_code == 403
 
 
 @pytest.mark.asyncio
@@ -60,8 +66,8 @@ async def test_list_leads_unauthorized(client_no_auth: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_get_lead_authenticated(client: AsyncClient, db_session: AsyncSession):
-    """Test fetching a single lead when authenticated."""
+async def test_get_lead_internal_user(client: AsyncClient, db_session: AsyncSession):
+    """Test fetching a single lead when internal/authenticated."""
     lead = Lead(
         email="reader@example.com",
         name="Reader",
@@ -78,6 +84,18 @@ async def test_get_lead_authenticated(client: AsyncClient, db_session: AsyncSess
     data = response.json()
     assert data["id"] == str(lead.id)
     assert data["email"] == "reader@example.com"
+
+
+@pytest.mark.asyncio
+async def test_get_lead_non_internal_forbidden(other_user_client: AsyncClient, db_session: AsyncSession):
+    """Test fetching a lead is forbidden for non-internal users."""
+    lead = Lead(email="private@example.com", source="homepage")
+    db_session.add(lead)
+    await db_session.commit()
+    await db_session.refresh(lead)
+
+    response = await other_user_client.get(f"/leads/{lead.id}")
+    assert response.status_code == 403
 
 
 @pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,7 +221,7 @@ async def test_user(db_session: AsyncSession):
     
     user = User(
         id=uuid.UUID("11111111-1111-4111-a111-111111111111"),
-        email="test@example.com",
+        email="test@mutx.dev",
         password_hash="hashedpassword",
         is_active=True,
         name="Test User",


### PR DESCRIPTION
### Motivation
- The `GET /leads` and `GET /leads/{lead_id}` handlers exposed all captured leads to any authenticated user, leaking contact PII in a multi-tenant environment.
- Provide a minimal, conservative fix that preserves public `POST /leads` behavior while preventing unauthorized read access to lead data.

### Description
- Added a new application setting `internal_user_email_domains` (default `["mutx.dev"]`) to `Settings` for configurable internal-only email domains and environment aliases `INTERNAL_USER_EMAIL_DOMAINS`/`ADMIN_EMAIL_DOMAINS` in `src/api/config.py`.
- Implemented `_assert_internal_user(current_user: User)` in `src/api/routes/leads.py` that checks the current user's email domain against the configured allowlist and raises `HTTPException(403)` when not allowed.
- Applied the internal-user guard to `list_leads` and `get_lead` so read endpoints now return `403 Forbidden` for non-internal authenticated users while leaving `capture_lead` public.
- Updated tests in `tests/api/test_leads.py` to assert internal access behavior and added a negative test for non-internal authenticated users, and adjusted the default `test_user` fixture email to an internal domain in `tests/conftest.py`.

### Testing
- Ran the focused test suite with `pytest tests/api/test_leads.py -q` after installing `pytest-asyncio` and all tests passed.
- Result: `9 passed` for the lead tests with expected authorization behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ae19d278832aa6952516f5e661ff)