### PR TITLE
fix: re-enable TLS encryption for database client

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,12 +1,11 @@
 import postgres from 'postgres'
 
 // Railway provides the complete DATABASE_URL in the environment
-// We are forcing ssl off entirely to avoid TLS handshakes over the internal proxy.
+// Keep TLS enabled for in-transit encryption of database traffic.
 const sql = process.env.DATABASE_URL
-  ? postgres(process.env.DATABASE_URL + '?sslmode=disable', {
-      ssl: false,
+  ? postgres(process.env.DATABASE_URL, {
+      ssl: { rejectUnauthorized: false },
     })
   : null
 
 export default sql
-


### PR DESCRIPTION
### Motivation
- Address a security regression that explicitly disabled TLS for Postgres connections by removing `?sslmode=disable` and `ssl: false`, which exposed database traffic to interception or tampering.

### Description
- Restore encrypted DB transport by updating `lib/db.ts` to stop mutating the `DATABASE_URL` and to pass `ssl: { rejectUnauthorized: false }` to the Postgres client so TLS remains enabled while preserving prior compatibility behavior.

### Testing
- Ran the unit test suite with `npm run test:app`, and all tests passed (4 test suites, 37 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b322f55c832a8ad22e33dd195780)