### PR TITLE
fix(db): enforce TLS certificate verification for Postgres client

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,12 +1,9 @@
 import postgres from 'postgres'
 
-// Railway provides the complete DATABASE_URL in the environment
-// We are forcing ssl off entirely to avoid TLS handshakes over the internal proxy.
+// Railway provides the complete DATABASE_URL in the environment.
+// Keep TLS enabled so certificate validation is enforced by default.
 const sql = process.env.DATABASE_URL
-  ? postgres(process.env.DATABASE_URL + '?sslmode=disable', {
-      ssl: false,
-    })
+  ? postgres(process.env.DATABASE_URL)
   : null
 
 export default sql
-


### PR DESCRIPTION
### Motivation
- A previous change disabled TLS certificate validation for the Postgres client, which allows network attackers to perform MITM on DB traffic and is a high-severity security issue. 
- Restore secure defaults so database connections validate server certificates by default.

### Description
- Modified `lib/db.ts` to remove the `?sslmode=disable` query and the explicit `ssl: false` option so the `postgres` client uses its default TLS behavior. 
- Updated inline comments to reflect that TLS is kept enabled and certificate validation is enforced. 
- The change is minimal and preserves existing functionality while removing the insecure override.

### Testing
- Ran the unit test suite with `npm run -s test:app` and all automated tests passed. 
- Test results: 4 test suites passed and 37 tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b3aa3520832a8895d2591cd8ec8d)