### PR TITLE
Require TLS for Postgres connections

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,12 +1,10 @@
 import postgres from 'postgres'
 
 // Railway provides the complete DATABASE_URL in the environment
-// We are forcing ssl off entirely to avoid TLS handshakes over the internal proxy.
 const sql = process.env.DATABASE_URL
-  ? postgres(process.env.DATABASE_URL + '?sslmode=disable', {
-      ssl: false,
+  ? postgres(process.env.DATABASE_URL, {
+      ssl: 'require',
     })
   : null
 
 export default sql
-


### PR DESCRIPTION
### Motivation
- Fix a security regression in `lib/db.ts` that disabled TLS for Postgres connections (previously using `?sslmode=disable` and `ssl: false`), which exposed credentials and data in transit.

### Description
- Updated `lib/db.ts` to remove the `?sslmode=disable` URL override and replace `ssl: false` with `ssl: 'require'`, while preserving the existing behavior of returning `null` when `DATABASE_URL` is unset.

### Testing
- Ran `npm run lint` which completed with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b3d63f5c832a98d43fdc047be1ad)