### PR TITLE
fix(db): restore TLS certificate verification for Postgres connection

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,12 +1,9 @@
 import postgres from 'postgres'
 
-// Railway provides the complete DATABASE_URL in the environment
-// We are forcing ssl off entirely to avoid TLS handshakes over the internal proxy.
+// Railway provides the complete DATABASE_URL in the environment.
+// Keep TLS enabled with certificate validation (do not disable sslmode or verification).
 const sql = process.env.DATABASE_URL
-  ? postgres(process.env.DATABASE_URL + '?sslmode=disable', {
-      ssl: false,
-    })
+  ? postgres(process.env.DATABASE_URL)
   : null
 
 export default sql
-


### PR DESCRIPTION
### Motivation
- The Postgres client was explicitly disabling TLS certificate verification (`sslmode=disable` and `ssl: false`), creating a high-risk MITM exposure for database traffic; this change reinstates verified TLS.

### Description
- Remove the `'?sslmode=disable'` URL mutation and the `ssl: false` client option in `lib/db.ts` and instantiate the `postgres` client directly with `process.env.DATABASE_URL` so certificate validation is not bypassed.

### Testing
- Ran `npm run -s lint` which completed without ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b4453104832a8037f954ce9f3b8f)