### PR TITLE
fix(db): stop forcing plaintext postgres connections

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,12 +1,8 @@
 import postgres from 'postgres'
 
-// Railway provides the complete DATABASE_URL in the environment
-// We are forcing ssl off entirely to avoid TLS handshakes over the internal proxy.
+// Use DATABASE_URL as provided so SSL/TLS behavior is controlled by connection settings.
 const sql = process.env.DATABASE_URL
-  ? postgres(process.env.DATABASE_URL + '?sslmode=disable', {
-      ssl: false,
-    })
+  ? postgres(process.env.DATABASE_URL)
   : null
 
 export default sql
-


### PR DESCRIPTION
### Motivation
- Fix a security regression where the Postgres client was forced to plaintext by appending `?sslmode=disable` and passing `{ ssl: false }`, which can expose credentials and query data to network attackers.

### Description
- Update `lib/db.ts` to remove the `?sslmode=disable` mutation and the hardcoded `{ ssl: false }`, and initialize the client with `postgres(process.env.DATABASE_URL)` so SSL is controlled by the connection string/environment.

### Testing
- Ran `npm run test:app` which executes the Jest unit suite and confirmed all tests passed (4 test suites, 37 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b3a27668832aac78f0b8a7467e2f)