### PR TITLE
fix: re-enable secure TLS defaults for Postgres waitlist client

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,12 +1,8 @@
 import postgres from 'postgres'
 
 // Railway provides the complete DATABASE_URL in the environment
-// We are forcing ssl off entirely to avoid TLS handshakes over the internal proxy.
 const sql = process.env.DATABASE_URL
-  ? postgres(process.env.DATABASE_URL + '?sslmode=disable', {
-      ssl: false,
-    })
+  ? postgres(process.env.DATABASE_URL)
   : null
 
 export default sql
-


### PR DESCRIPTION
### Motivation
- The Postgres client in `lib/db.ts` previously disabled TLS verification (`?sslmode=disable` and `ssl: false`), which allows man-in-the-middle attacks on database traffic and exposes waitlist data.

### Description
- Removed the `?sslmode=disable` query parameter from the connection URL in `lib/db.ts` so the driver receives the raw `DATABASE_URL`.
- Removed the explicit `ssl: false` client option so the `postgres` driver uses its secure default TLS behavior and validates certificates.
- The change is minimal and preserves existing functionality by returning `postgres(process.env.DATABASE_URL)` when `DATABASE_URL` is present and `null` otherwise.

### Testing
- Ran the unit test suite with `npm run test:app`, and all tests passed (4 test suites, 37 tests).
- No other automated tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b3fca000832a81ce662c09a3271b)