### PR TITLE
fix(auth): mark token cookies as HttpOnly

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
 
     const nextResponse = NextResponse.json(payload)
     nextResponse.cookies.set('access_token', payload.access_token, {
-      httpOnly: false,
+      httpOnly: true,
       sameSite: 'lax',
       secure: secureCookies,
       domain: cookieDomain,
@@ -35,7 +35,7 @@ export async function POST(request: NextRequest) {
       maxAge: payload.expires_in || 1800,
     })
     nextResponse.cookies.set('refresh_token', payload.refresh_token, {
-      httpOnly: false,
+      httpOnly: true,
       sameSite: 'lax',
       secure: secureCookies,
       domain: cookieDomain,

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
 
     const nextResponse = NextResponse.json(payload)
     nextResponse.cookies.set('access_token', payload.access_token, {
-      httpOnly: false,
+      httpOnly: true,
       sameSite: 'lax',
       secure: secureCookies,
       domain: cookieDomain,
@@ -35,7 +35,7 @@ export async function POST(request: NextRequest) {
       maxAge: payload.expires_in || 1800,
     })
     nextResponse.cookies.set('refresh_token', payload.refresh_token, {
-      httpOnly: false,
+      httpOnly: true,
       sameSite: 'lax',
       secure: secureCookies,
       domain: cookieDomain,


### PR DESCRIPTION
### Motivation
- Fix a high-severity issue where `access_token` and `refresh_token` cookies were being set with `httpOnly: false`, allowing client-side JavaScript (and XSS) to read JWTs and risk session hijacking.

### Description
- Set `httpOnly: true` for `access_token` and `refresh_token` cookies in `app/api/auth/login/route.ts` and `app/api/auth/register/route.ts` while keeping existing cookie attributes (`sameSite`, `secure`, `domain`, `path`, `maxAge`).

### Testing
- Ran unit tests with `npm run test:app` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b4283a94832ab639de7597762c1e)