### PR TITLE
Require verified emails for internal lead access

### DIFF
--- a/src/api/routes/leads.py
+++ b/src/api/routes/leads.py
@@ -15,6 +15,9 @@ router = APIRouter(prefix="/leads", tags=["leads"])
 
 def _assert_internal_user(current_user: User) -> None:
     """Restrict internal lead access to configured internal email domains."""
+    if not current_user.is_email_verified:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
     settings = get_settings()
     allowed_domains = {
         domain.strip().lower()

--- a/tests/api/test_leads.py
+++ b/tests/api/test_leads.py
@@ -66,6 +66,29 @@ async def test_list_leads_unauthorized(client_no_auth: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_list_leads_internal_unverified_forbidden(client_no_auth: AsyncClient):
+    """Test listing leads is forbidden for internal-domain users without verified email."""
+    import uuid
+
+    from src.api.middleware.auth import get_current_user
+    from src.api.models.models import User
+
+    async def override_get_current_user():
+        return User(
+            id=uuid.uuid4(),
+            email="attacker@mutx.dev",
+            password_hash="hashedpassword",
+            is_active=True,
+            is_email_verified=False,
+            name="Attacker",
+        )
+
+    client_no_auth.app.dependency_overrides[get_current_user] = override_get_current_user
+    response = await client_no_auth.get("/leads")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_get_lead_internal_user(client: AsyncClient, db_session: AsyncSession):
     """Test fetching a single lead when internal/authenticated."""
     lead = Lead(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,6 +224,7 @@ async def test_user(db_session: AsyncSession):
         email="test@mutx.dev",
         password_hash="hashedpassword",
         is_active=True,
+        is_email_verified=True,
         name="Test User",
     )
     db_session.add(user)


### PR DESCRIPTION
### Motivation
- The lead listing and retrieval guard previously allowed access based only on email domain, which is bypassable because registration/login can issue tokens before email ownership is verified.
- The intent of the change is to require verified email ownership in addition to an allowlisted domain so internal-only endpoints are not accessible to unverified accounts.

### Description
- Add a verification check in the internal authorization guard by requiring `current_user.is_email_verified` before proceeding with the domain allowlist check in `src/api/routes/leads.py`.
- Update the `test_user` fixture in `tests/conftest.py` to set `is_email_verified=True` so existing internal-user tests continue to represent a valid verified internal user.
- Add a regression test `test_list_leads_internal_unverified_forbidden` in `tests/api/test_leads.py` that asserts an unverified `@mutx.dev` user is denied access (HTTP 403).
- Changes are minimal and preserve existing functionality for verified internal users while closing the domain-only bypass.

### Testing
- Successfully type-checked/compiled the modified files with `python -m py_compile src/api/routes/leads.py tests/api/test_leads.py tests/conftest.py` which passed.
- Attempted to run the test suite with `pytest -q tests/api/test_leads.py` but it failed in this environment due to a missing test dependency (`ModuleNotFoundError: No module named 'pytest_asyncio'`).
- All edits were committed to the branch (`Require verified internal emails for lead access`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c02cba0c832aafbcd100ffce4a7a)