### PR TITLE
fix(api): stop exposing deprecated newsletter backend route

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -16,7 +16,6 @@ from src.api.routes import (
     auth,
     clawhub,
     api_keys,
-    newsletter,
     agent_runtime,
     ingest,
     leads,
@@ -136,7 +135,6 @@ app.include_router(webhooks.router, prefix="/api")
 app.include_router(auth.router, prefix="/api")
 app.include_router(clawhub.router, prefix="/api")
 app.include_router(api_keys.router, prefix="/api")
-app.include_router(newsletter.router, prefix="/api")
 app.include_router(leads.router, prefix="/api")
 app.include_router(agent_runtime.router, prefix="/api")
 app.include_router(ingest.router, prefix="/api")


### PR DESCRIPTION
### Motivation
- Prevent the deprecated backend waitlist endpoint from being reachable at `/api/newsletter`, which bypasses the Next.js Turnstile/honeypot protections when nginx proxies `/api/` to the backend.

### Description
- Removed the deprecated `newsletter` router import and the `app.include_router(newsletter.router, prefix="/api")` mount from `src/api/main.py` so the backend no longer exposes the unprotected `/api/newsletter` endpoint while preserving other `/api/*` routes.

### Testing
- Verified endpoint registration with a small runtime check using `python - <<'PY' ...` which confirmed `'/api/newsletter'` is not present (printed `False`) and `'/api/leads'` remains registered (printed `True`), and these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c15ce918832a99868b827c2a36a5)