### PR TITLE
fix: guard JSON.parse in LogsViewer metadata rendering

### DIFF
--- a/components/app/Observability/LogsViewer.tsx
+++ b/components/app/Observability/LogsViewer.tsx
@@ -56,6 +56,14 @@ function formatTimestamp(timestamp?: string | null) {
   }
 }
 
+function formatMetadata(metadata: string): string {
+  try {
+    return JSON.stringify(JSON.parse(metadata), null, 2);
+  } catch {
+    return metadata;
+  }
+}
+
 async function fetchLogs<T>(url: string): Promise<T[]> {
   const response = await fetch(url, { cache: "no-store" });
   if (!response.ok) {
@@ -284,7 +292,7 @@ export function LogsViewer({
                           Metadata
                         </p>
                         <pre className="text-xs text-slate-400 overflow-x-auto">
-                          {JSON.stringify(JSON.parse(log.extra_data), null, 2)}
+                          {formatMetadata(log.extra_data)}
                         </pre>
                       </div>
                     )}


### PR DESCRIPTION
Prevents client-side crash when log.extra_data contains non-JSON strings (e.g., "node_id: ..." from ingest routes).

## Bug
- **Finding**: a9b99d0e32f081918b30f57193e58afa
- LogsViewer crashes when expanding log entries with non-JSON extra_data
- Backend writes `extra_data` as plain strings like `f"node_id: {status_data.node_id}"`

## Fix
- Add `formatMetadata()` helper that wraps JSON.parse in try/catch
- Falls back to returning raw string if parsing fails

## Testing
- Static code analysis confirms the fix guards against the crash path