### PR TITLE
fix(observability): avoid metadata parse crash in logs viewer

### DIFF
--- a/components/app/Observability/LogsViewer.tsx
+++ b/components/app/Observability/LogsViewer.tsx
@@ -56,6 +56,14 @@ function formatTimestamp(timestamp?: string | null) {
   }
 }
 
+function formatMetadata(metadata: string): string {
+  try {
+    return JSON.stringify(JSON.parse(metadata), null, 2);
+  } catch {
+    return metadata;
+  }
+}
+
 async function fetchLogs<T>(url: string): Promise<T[]> {
   const response = await fetch(url, { cache: "no-store" });
   if (!response.ok) {
@@ -284,7 +292,7 @@ export function LogsViewer({
                           Metadata
                         </p>
                         <pre className="text-xs text-slate-400 overflow-x-auto">
-                          {JSON.stringify(JSON.parse(log.extra_data), null, 2)}
+                          {formatMetadata(log.extra_data)}
                         </pre>
                       </div>
                     )}


### PR DESCRIPTION
### Motivation
- The logs viewer unguardedly called `JSON.parse(log.extra_data)` during render which throws for plain-text metadata (for example `"node_id: ..."`) and can crash the observability UI when expanding a log entry.

### Description
- Add a `formatMetadata(metadata: string)` helper that attempts to parse and pretty-print JSON and falls back to returning the original string if parsing fails.
- Replace the unsafe inline `JSON.stringify(JSON.parse(log.extra_data), null, 2)` call with `formatMetadata(log.extra_data)` in `components/app/Observability/LogsViewer.tsx` so non-JSON metadata no longer crashes the component.

### Testing
- Ran `npm run lint -- --file components/app/Observability/LogsViewer.tsx` which completed successfully and only reported pre-existing React hook dependency warnings in the file.
- No unit tests were modified or added as part of this fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5cf056898832abb8f8624ee47cf45)