### PR TITLE
[codex] enforce ownership checks on agents and deployments routes

### DIFF
--- a/src/api/auth/ownership.py
+++ b/src/api/auth/ownership.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from src.api.models import Agent, Deployment, User
+
+
+async def get_owned_agent(
+    agent_id: uuid.UUID,
+    db: AsyncSession,
+    current_user: User,
+    *,
+    not_found_detail: str = "Agent not found",
+    forbidden_detail: str = "Not authorized to access this agent",
+    include_deployments: bool = False,
+    include_deployment_events: bool = False,
+) -> Agent:
+    query = select(Agent).where(Agent.id == agent_id)
+    if include_deployments:
+        deployment_loader = selectinload(Agent.deployments)
+        if include_deployment_events:
+            deployment_loader = deployment_loader.selectinload(Deployment.events)
+        query = query.options(deployment_loader)
+
+    result = await db.execute(query)
+    agent = result.scalar_one_or_none()
+    if not agent:
+        raise HTTPException(status_code=404, detail=not_found_detail)
+    if agent.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail=forbidden_detail)
+    return agent
+
+
+async def get_owned_deployment(
+    deployment_id: uuid.UUID,
+    db: AsyncSession,
+    current_user: User,
+    *,
+    not_found_detail: str = "Deployment not found",
+    forbidden_detail: str = "Not authorized to access this deployment",
+    include_events: bool = False,
+) -> Deployment:
+    query = select(Deployment).where(Deployment.id == deployment_id)
+    if include_events:
+        query = query.options(selectinload(Deployment.events))
+
+    result = await db.execute(query)
+    deployment = result.scalar_one_or_none()
+    if not deployment:
+        raise HTTPException(status_code=404, detail=not_found_detail)
+
+    await get_owned_agent(
+        deployment.agent_id,
+        db,
+        current_user,
+        not_found_detail=not_found_detail,
+        forbidden_detail=forbidden_detail,
+    )
+
+    return deployment

--- a/src/api/routes/agents.py
+++ b/src/api/routes/agents.py
@@ -7,8 +7,8 @@ import uuid
 import json
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
+from src.api.auth.ownership import get_owned_agent
 from src.api.database import get_db
 from src.api.models import (
     Agent,
@@ -169,17 +169,13 @@ async def get_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    result = await db.execute(
-        select(Agent)
-        .options(selectinload(Agent.deployments).selectinload(Deployment.events))
-        .where(Agent.id == agent_id)
+    agent = await get_owned_agent(
+        agent_id,
+        db,
+        current_user,
+        include_deployments=True,
+        include_deployment_events=True,
     )
-    agent = result.scalar_one_or_none()
-    if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    # Ownership check
-    if agent.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to access this agent")
     return _serialize_agent(agent, include_deployments=True)
 
 
@@ -189,13 +185,12 @@ async def delete_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    result = await db.execute(select(Agent).where(Agent.id == agent_id))
-    agent = result.scalar_one_or_none()
-    if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    # Ownership check
-    if agent.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to delete this agent")
+    agent = await get_owned_agent(
+        agent_id,
+        db,
+        current_user,
+        forbidden_detail="Not authorized to delete this agent",
+    )
 
     agent.status = AgentStatus.DELETING.value
     await db.delete(agent)
@@ -209,13 +204,12 @@ async def deploy_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    result = await db.execute(select(Agent).where(Agent.id == agent_id))
-    agent = result.scalar_one_or_none()
-    if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    # Ownership check
-    if agent.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to deploy this agent")
+    agent = await get_owned_agent(
+        agent_id,
+        db,
+        current_user,
+        forbidden_detail="Not authorized to deploy this agent",
+    )
 
     deployment = Deployment(
         agent_id=agent_id,
@@ -247,13 +241,12 @@ async def stop_agent(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    result = await db.execute(select(Agent).where(Agent.id == agent_id))
-    agent = result.scalar_one_or_none()
-    if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    # Ownership check
-    if agent.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to stop this agent")
+    agent = await get_owned_agent(
+        agent_id,
+        db,
+        current_user,
+        forbidden_detail="Not authorized to stop this agent",
+    )
 
     result = await db.execute(
         select(Deployment).where(
@@ -288,13 +281,12 @@ async def get_agent_logs(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    # Ownership check - verify agent belongs to current user
-    agent_result = await db.execute(select(Agent).where(Agent.id == agent_id))
-    agent = agent_result.scalar_one_or_none()
-    if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    if agent.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to access this agent's logs")
+    await get_owned_agent(
+        agent_id,
+        db,
+        current_user,
+        forbidden_detail="Not authorized to access this agent's logs",
+    )
 
     query = select(AgentLog).where(AgentLog.agent_id == agent_id).offset(skip).limit(limit)
     if level:
@@ -313,13 +305,12 @@ async def get_agent_metrics(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    # Ownership check - verify agent belongs to current user
-    agent_result = await db.execute(select(Agent).where(Agent.id == agent_id))
-    agent = agent_result.scalar_one_or_none()
-    if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    if agent.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to access this agent's metrics")
+    await get_owned_agent(
+        agent_id,
+        db,
+        current_user,
+        forbidden_detail="Not authorized to access this agent's metrics",
+    )
 
     query = (
         select(AgentMetric)

--- a/src/api/routes/deployments.py
+++ b/src/api/routes/deployments.py
@@ -9,6 +9,7 @@ import uuid
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.api.auth.ownership import get_owned_agent, get_owned_deployment
 from src.api.database import get_db
 from src.api.models import (
     Deployment,
@@ -34,49 +35,6 @@ from src.api.middleware.auth import get_current_user
 
 router = APIRouter(prefix="/deployments", tags=["deployments"])
 logger = logging.getLogger(__name__)
-
-
-async def _get_owned_agent(
-    agent_id: uuid.UUID,
-    db: AsyncSession,
-    current_user: User,
-    *,
-    not_found_detail: str,
-    forbidden_detail: str,
-) -> Agent:
-    result = await db.execute(select(Agent).where(Agent.id == agent_id))
-    agent = result.scalar_one_or_none()
-    if not agent:
-        raise HTTPException(status_code=404, detail=not_found_detail)
-    if agent.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail=forbidden_detail)
-    return agent
-
-
-async def _get_deployment_with_ownership(
-    deployment_id: uuid.UUID,
-    db: AsyncSession,
-    current_user: User,
-) -> Deployment:
-    """Get deployment and verify ownership through the agent."""
-    result = await db.execute(
-        select(Deployment)
-        .options(selectinload(Deployment.events))
-        .where(Deployment.id == deployment_id)
-    )
-    deployment = result.scalar_one_or_none()
-    if not deployment:
-        raise HTTPException(status_code=404, detail="Deployment not found")
-
-    await _get_owned_agent(
-        deployment.agent_id,
-        db,
-        current_user,
-        not_found_detail="Deployment not found",
-        forbidden_detail="Not authorized to access this deployment",
-    )
-
-    return deployment
 
 
 def _serialize_deployment(deployment: Deployment):
@@ -140,7 +98,7 @@ async def list_deployments(
         .limit(limit)
     )
     if agent_id:
-        await _get_owned_agent(
+        await get_owned_agent(
             agent_id,
             db,
             current_user,
@@ -161,7 +119,12 @@ async def get_deployment(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+    deployment = await get_owned_deployment(
+        deployment_id,
+        db,
+        current_user,
+        include_events=True,
+    )
     return _serialize_deployment(deployment)
 
 
@@ -176,7 +139,7 @@ async def get_deployment_events(
     current_user: User = Depends(get_current_user),
 ):
     """Get paginated lifecycle events for a specific deployment."""
-    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+    deployment = await get_owned_deployment(deployment_id, db, current_user)
 
     filters = [DeploymentEventModel.deployment_id == deployment.id]
     if event_type:
@@ -218,7 +181,7 @@ async def scale_deployment(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+    deployment = await get_owned_deployment(deployment_id, db, current_user)
 
     if deployment.status not in ["running", "ready"]:
         raise HTTPException(status_code=400, detail="Can only scale running deployments")
@@ -236,7 +199,12 @@ async def scale_deployment(
 
     await db.commit()
     # Re-fetch to ensure events are loaded and attributes are fresh
-    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+    deployment = await get_owned_deployment(
+        deployment_id,
+        db,
+        current_user,
+        include_events=True,
+    )
     logger.info(f"Scaled deployment {deployment_id} to {scale_data.replicas} replicas")
     return _serialize_deployment(deployment)
 
@@ -247,7 +215,7 @@ async def kill_deployment(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+    deployment = await get_owned_deployment(deployment_id, db, current_user)
 
     deployment.status = "killed"
     deployment.ended_at = datetime.now(timezone.utc)
@@ -276,7 +244,7 @@ async def create_deployment(
     current_user: User = Depends(get_current_user),
 ):
     """Create a new deployment for an agent."""
-    agent = await _get_owned_agent(
+    agent = await get_owned_agent(
         deployment_data.agent_id,
         db,
         current_user,
@@ -315,7 +283,12 @@ async def create_deployment(
 
     await db.commit()
     # Re-fetch to ensure events are loaded and attributes are fresh
-    deployment = await _get_deployment_with_ownership(deployment.id, db, current_user)
+    deployment = await get_owned_deployment(
+        deployment.id,
+        db,
+        current_user,
+        include_events=True,
+    )
     logger.info(f"Created deployment {deployment.id} for agent {deployment_data.agent_id}")
     return _serialize_deployment(deployment)
 
@@ -327,7 +300,7 @@ async def restart_deployment(
     current_user: User = Depends(get_current_user),
 ):
     """Restart an existing deployment."""
-    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+    deployment = await get_owned_deployment(deployment_id, db, current_user)
 
     # Can only restart deployments that are stopped, failed, or killed
     if deployment.status not in ["stopped", "failed", "killed"]:
@@ -358,7 +331,12 @@ async def restart_deployment(
 
     await db.commit()
     # Re-fetch to ensure events are loaded and attributes are fresh
-    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+    deployment = await get_owned_deployment(
+        deployment_id,
+        db,
+        current_user,
+        include_events=True,
+    )
     logger.info(f"Restarted deployment: {deployment_id}")
     return _serialize_deployment(deployment)
 
@@ -373,7 +351,7 @@ async def get_deployment_logs(
     current_user: User = Depends(get_current_user),
 ):
     """Get logs for a specific deployment."""
-    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+    deployment = await get_owned_deployment(deployment_id, db, current_user)
 
     # Query logs for the deployment's agent
     query = (
@@ -397,7 +375,7 @@ async def get_deployment_metrics(
     current_user: User = Depends(get_current_user),
 ):
     """Get metrics for a specific deployment."""
-    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+    deployment = await get_owned_deployment(deployment_id, db, current_user)
 
     # Query metrics for the deployment's agent
     query = (
@@ -420,7 +398,7 @@ async def get_deployment_versions(
     current_user: User = Depends(get_current_user),
 ):
     """Get version history for a specific deployment."""
-    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+    deployment = await get_owned_deployment(deployment_id, db, current_user)
 
     query = (
         select(DeploymentVersion)
@@ -446,7 +424,7 @@ async def rollback_deployment(
     current_user: User = Depends(get_current_user),
 ):
     """Rollback a deployment to a specific version."""
-    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+    deployment = await get_owned_deployment(deployment_id, db, current_user)
 
     if deployment.status not in ["running", "ready", "stopped", "failed"]:
         raise HTTPException(
@@ -489,6 +467,11 @@ async def rollback_deployment(
 
     await db.commit()
 
-    deployment = await _get_deployment_with_ownership(deployment_id, db, current_user)
+    deployment = await get_owned_deployment(
+        deployment_id,
+        db,
+        current_user,
+        include_events=True,
+    )
     logger.info(f"Rolled back deployment {deployment_id} to version {rollback_data.version}")
     return _serialize_deployment(deployment)

--- a/tests/api/test_agents.py
+++ b/tests/api/test_agents.py
@@ -246,6 +246,14 @@ class TestStopAgent:
         response = await client.post("/api/agents/00000000-0000-0000-0000-999999999999/stop")
         assert response.status_code == 404
 
+    @pytest.mark.asyncio
+    async def test_stop_agent_other_user_forbidden(
+        self, other_user_client: AsyncClient, test_agent
+    ):
+        """Test that users cannot stop other users' agents."""
+        response = await other_user_client.post(f"/api/agents/{test_agent.id}/stop")
+        assert response.status_code == 403
+
 
 class TestAgentLogs:
     """Tests for GET /agents/{agent_id}/logs endpoint."""
@@ -281,3 +289,17 @@ class TestAgentMetrics:
         response = await client.get(f"/api/agents/{test_agent.id}/metrics")
         assert response.status_code == 200
         assert isinstance(response.json(), list)
+
+    @pytest.mark.asyncio
+    async def test_get_agent_metrics_not_found(self, client: AsyncClient):
+        """Test getting metrics for non-existent agent returns 404."""
+        response = await client.get("/api/agents/00000000-0000-0000-0000-999999999999/metrics")
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_agent_metrics_other_user_forbidden(
+        self, other_user_client: AsyncClient, test_agent
+    ):
+        """Test that users cannot access other users' agent metrics."""
+        response = await other_user_client.get(f"/api/agents/{test_agent.id}/metrics")
+        assert response.status_code == 403

--- a/tests/api/test_deployments.py
+++ b/tests/api/test_deployments.py
@@ -575,3 +575,30 @@ class TestRestartDeployment:
 
         response = await other_user_client.post(f"/api/deployments/{test_deployment.id}/restart")
         assert response.status_code == 403
+
+
+class TestDeploymentVersions:
+    """Tests for GET /deployments/{deployment_id}/versions endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_deployment_versions_other_user_forbidden(
+        self, other_user_client: AsyncClient, test_deployment
+    ):
+        """Test other users cannot read version history for deployments they do not own."""
+        response = await other_user_client.get(f"/api/deployments/{test_deployment.id}/versions")
+        assert response.status_code == 403
+
+
+class TestRollbackDeployment:
+    """Tests for POST /deployments/{deployment_id}/rollback endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_rollback_deployment_other_user_forbidden(
+        self, other_user_client: AsyncClient, test_deployment
+    ):
+        """Test other users cannot rollback deployments they do not own."""
+        response = await other_user_client.post(
+            f"/api/deployments/{test_deployment.id}/rollback",
+            json={"version": 1},
+        )
+        assert response.status_code == 403


### PR DESCRIPTION
## Summary
This PR enforces authenticated ownership on all `/agents` and `/deployments` API routes for issue #303 (area:auth, P0).

Previously, ownership checks were implemented inline in route handlers with duplicated logic and uneven test coverage for a few resource endpoints. That left authorization behavior harder to reason about and easier to drift as endpoints were added.

## Root Cause
Ownership validation for agent- and deployment-scoped resources lived in route-local helper code or repeated handler-level checks. The logic was not centralized, so behavior consistency depended on each endpoint implementing the same checks manually.

## What Changed
- Added a shared ownership helper module at `src/api/auth/ownership.py`.
  - `get_owned_agent(...)` fetches an agent and enforces owner match against `current_user`.
  - `get_owned_deployment(...)` fetches a deployment, then enforces ownership through its parent agent.
  - Both helpers return `404` for missing resources and `403` for cross-tenant access.
- Refactored `src/api/routes/agents.py` to use shared ownership helpers on all resource-specific endpoints:
  - `GET /agents/{agent_id}`
  - `DELETE /agents/{agent_id}`
  - `POST /agents/{agent_id}/deploy`
  - `POST /agents/{agent_id}/stop`
  - `GET /agents/{agent_id}/logs`
  - `GET /agents/{agent_id}/metrics`
- Refactored `src/api/routes/deployments.py` to use shared ownership helpers for all deployment/agent ownership gates while preserving existing route semantics and response details.
- Expanded tests for ownership enforcement gaps:
  - `tests/api/test_agents.py`
    - other-user forbidden for `POST /agents/{agent_id}/stop`
    - not-found + other-user forbidden for `GET /agents/{agent_id}/metrics`
  - `tests/api/test_deployments.py`
    - other-user forbidden for `GET /deployments/{deployment_id}/versions`
    - other-user forbidden for `POST /deployments/{deployment_id}/rollback`

## User Impact
Users can only access, mutate, deploy, stop, or inspect agents/deployments they own. Cross-tenant access attempts on these routes now consistently fail with `403` (or `404` when the resource does not exist).

## Validation
- `./.venv/bin/pytest -q tests/api/test_agents.py tests/api/test_deployments.py`
  - Result: `59 passed`
