### PR TITLE
fix(webhooks): align Next.js webhook proxy with client contract

### DIFF
--- a/app/api/webhooks/[id]/route.ts
+++ b/app/api/webhooks/[id]/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getApiBaseUrl, getAuthToken } from "@/app/api/_lib/controlPlane";
+
+const API_BASE_URL = getApiBaseUrl();
+
+export const dynamic = "force-dynamic";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const token = await getAuthToken(request);
+
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const { url, events } = body;
+
+    if (!url) {
+      return NextResponse.json({ error: "URL is required" }, { status: 400 });
+    }
+
+    const response = await fetch(`${API_BASE_URL}/webhooks/${id}`, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ url, events: events || [] }),
+      cache: "no-store"
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      return NextResponse.json({ error: error.detail || "Failed to update webhook" }, { status: response.status });
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Webhooks PATCH error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const token = await getAuthToken(request);
+
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { id } = await params;
+
+    const response = await fetch(`${API_BASE_URL}/webhooks/${id}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json"
+      },
+      cache: "no-store"
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      return NextResponse.json({ error: error.detail || "Failed to delete webhook" }, { status: response.status });
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error("Webhooks DELETE error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/webhooks/[id]/test/route.ts
+++ b/app/api/webhooks/[id]/test/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getApiBaseUrl, getAuthToken } from "@/app/api/_lib/controlPlane";
+
+const API_BASE_URL = getApiBaseUrl();
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const token = await getAuthToken(request);
+
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { id } = await params;
+
+    const response = await fetch(`${API_BASE_URL}/webhooks/${id}/test`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json"
+      },
+      cache: "no-store"
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      return NextResponse.json({ error: error.detail || "Failed to test webhook" }, { status: response.status });
+    }
+
+    const data = await response.json().catch(() => ({}));
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Webhooks test POST error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/webhooks/route.ts
+++ b/app/api/webhooks/route.ts
@@ -27,7 +27,8 @@ export async function GET(request: NextRequest) {
     }
     
     const data = await response.json();
-    return NextResponse.json(data);
+    const webhooks = Array.isArray(data) ? data : data?.webhooks ?? [];
+    return NextResponse.json({ webhooks });
   } catch (error) {
     console.error("Webhooks GET error:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });


### PR DESCRIPTION
### Motivation
- The webhooks UI expects a `{ webhooks: [...] }` response but the proxy returned the control-plane list (an array), causing the UI to render an empty list.
- The UI issues `PATCH`/`DELETE` to `/api/webhooks/{id}` and `POST` to `/api/webhooks/{id}/test`, but the proxy only implemented `GET`/`POST` for `/api/webhooks`, causing edit/delete/test actions to 404.

### Description
- Normalize `GET /api/webhooks` to always return `{ webhooks: [...] }`, accepting either an upstream array or an already-wrapped payload and returning a consistent shape (`app/api/webhooks/route.ts`).
- Add a dynamic route proxy `app/api/webhooks/[id]/route.ts` that implements `PATCH` for updates and `DELETE` for removals, forwarding requests to the control plane.
- Add a nested proxy `app/api/webhooks/[id]/test/route.ts` that implements `POST` to forward webhook test requests to the control plane.
- Keep changes minimal and backward-compatible with the client contract so existing UI behavior is preserved.

### Testing
- Ran `npm run test:app`, and all unit tests passed (4 test suites, 37 tests) with no failures.
- Ran `npx eslint` against the modified files and it completed without lint errors on the changed files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b604d42a6c832aa7f201887ef5d5d7)