### PR TITLE
feat(api): CORS config parsing and security tests - issue #306

### DIFF
--- a/src/api/config.py
+++ b/src/api/config.py
@@ -1,8 +1,17 @@
+import json
 from functools import lru_cache
 import secrets
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+DEFAULT_CORS_ORIGINS = [
+    "http://localhost:3000",
+    "http://app.localhost:3000",
+    "https://mutx.dev",
+    "https://app.mutx.dev",
+]
 
 
 class Settings(BaseSettings):
@@ -21,12 +30,25 @@ class Settings(BaseSettings):
         default=8000,
         validation_alias=AliasChoices("API_PORT", "PORT"),
     )
-    cors_origins: list[str] = [
-        "http://localhost:3000",
-        "http://app.localhost:3000",
-        "https://mutx.dev",
-        "https://app.mutx.dev",
-    ]
+    cors_origins: list[str] = Field(default=DEFAULT_CORS_ORIGINS)
+
+    @field_validator("cors_origins", mode="before")
+    @classmethod
+    def parse_cors_origins(cls, v: str | list[str] | None) -> list[str]:
+        if v is None:
+            return DEFAULT_CORS_ORIGINS
+        if isinstance(v, str):
+            # Try JSON array first, then comma-separated
+            try:
+                parsed = json.loads(v)
+                if isinstance(parsed, list):
+                    return parsed
+            except json.JSONDecodeError:
+                pass
+            # Comma-separated
+            return [origin.strip() for origin in v.split(",") if origin.strip()]
+        return v
+
     log_level: str = "INFO"
     jwt_secret: str = Field(default_factory=lambda: secrets.token_urlsafe(32))
     access_token_expire_minutes: int = 30

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -1,0 +1,23 @@
+from src.api.config import Settings
+
+
+def test_cors_origins_accepts_comma_separated_string() -> None:
+    settings = Settings.model_validate(
+        {"cors_origins": "http://localhost:3000, https://app.mutx.dev"},
+    )
+
+    assert settings.cors_origins == [
+        "http://localhost:3000",
+        "https://app.mutx.dev",
+    ]
+
+
+def test_cors_origins_accepts_json_array_string() -> None:
+    settings = Settings.model_validate(
+        {"cors_origins": '["http://localhost:3000", "https://app.mutx.dev"]'},
+    )
+
+    assert settings.cors_origins == [
+        "http://localhost:3000",
+        "https://app.mutx.dev",
+    ]


### PR DESCRIPTION
## Summary

- Add field validator for  to support comma-separated and JSON array strings in env vars
- Add  for CORS origin parsing validation
- Existing  tests CORS/security middleware (5 tests)

## Tests

All 7 tests pass:
- test_cors_origins_accepts_comma_separated_string
- test_cors_origins_accepts_json_array_string  
- test_cors_preflight_allows_configured_origin
- test_cors_preflight_rejects_disallowed_origin
- test_security_headers_are_applied_to_responses
- test_csrf_rejects_state_change_with_disallowed_origin
- test_csrf_allows_state_change_with_configured_origin

## Related

- Issue #306