### PR TITLE
fix(frontend): use /api/agents endpoint for agents list - issue #307

### DIFF
--- a/components/app/AgentsPageClient.tsx
+++ b/components/app/AgentsPageClient.tsx
@@ -469,7 +469,7 @@ export function AgentsPageClient() {
 
   async function loadAgents() {
     try {
-      const data = await readJson<{ agents?: Agent[] } | Agent[]>("/api/dashboard/agents");
+      const data = await readJson<{ agents?: Agent[] } | Agent[]>("/api/agents");
       
       let agentsData: Agent[];
       if (Array.isArray(data)) {


### PR DESCRIPTION
Fixes the agents list page to use the correct API endpoint /api/agents instead of /api/dashboard/agents.