### PR TITLE
[codex] feat(auth): add ownership enforcement on /agents and /deployments routes

### DIFF
--- a/tests/api/test_agents.py
+++ b/tests/api/test_agents.py
@@ -124,6 +124,22 @@ class TestListAgents:
         assert response.json() == []
 
 
+class TestAgentAuthorization:
+    """Authorization guardrails for /agents endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_list_agents_requires_authentication(self, client_no_auth: AsyncClient):
+        response = await client_no_auth.get("/api/agents")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_get_agent_requires_authentication(
+        self, client_no_auth: AsyncClient, test_agent
+    ):
+        response = await client_no_auth.get(f"/api/agents/{test_agent.id}")
+        assert response.status_code == 401
+
+
 class TestGetAgent:
     """Tests for GET /agents/{agent_id} endpoint."""
 

--- a/tests/api/test_deployments.py
+++ b/tests/api/test_deployments.py
@@ -96,6 +96,28 @@ class TestListDeployments:
         """Test filtering by another user's agent is forbidden."""
         response = await other_user_client.get(f"/api/deployments?agent_id={test_agent.id}")
         assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_list_deployments_scoped_to_authenticated_user(
+        self, client: AsyncClient, other_user_client: AsyncClient, test_deployment
+    ):
+        """Deployment list must not include resources owned by other users."""
+        response = await client.get("/api/deployments")
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+
+        response = await other_user_client.get("/api/deployments")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @pytest.mark.asyncio
+    async def test_list_deployments_ignores_client_supplied_user_id(
+        self, other_user_client: AsyncClient, test_agent
+    ):
+        """Client-supplied user filters must never expand ownership scope."""
+        response = await other_user_client.get(f"/api/deployments?user_id={test_agent.user_id}")
+        assert response.status_code == 200
+        assert response.json() == []
     
     @pytest.mark.asyncio
     async def test_list_deployments_by_status(
@@ -148,6 +170,22 @@ class TestGetDeployment:
         """Test other users cannot read deployments they do not own."""
         response = await other_user_client.get(f"/api/deployments/{test_deployment.id}")
         assert response.status_code == 403
+
+
+class TestDeploymentAuthorization:
+    """Authorization guardrails for /deployments endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_list_deployments_requires_authentication(self, client_no_auth: AsyncClient):
+        response = await client_no_auth.get("/api/deployments")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_get_deployment_requires_authentication(
+        self, client_no_auth: AsyncClient, test_deployment
+    ):
+        response = await client_no_auth.get(f"/api/deployments/{test_deployment.id}")
+        assert response.status_code == 401
 
 
 class TestScaleDeployment:


### PR DESCRIPTION
## Summary
This PR closes the remaining gap for issue #303 by hardening the ownership enforcement contract on `/api/agents` and `/api/deployments` with explicit regression tests.

The backend routes already derive ownership from the authenticated user and reject cross-tenant access. The missing piece was stronger route-level regression coverage to prevent future regressions in ownership scope and auth status handling.

## Problem and User Impact
Issue #303 calls out a critical auth requirement: ownership must always come from the authenticated identity, never from client-supplied `user_id` values.

Without explicit tests on list/read paths for these route groups, future refactors could accidentally reintroduce data exposure across users. That would let users see or manage resources they do not own.

## Root Cause
Ownership checks existed in route implementations, but the automated test contract did not fully lock:
- list scoping behavior for `/deployments` across different authenticated users
- resistance to client-supplied `user_id` query parameters on `/deployments`
- unauthenticated `401` responses on representative `/agents` and `/deployments` endpoints

## Fix
Added targeted API tests that enforce ownership and auth semantics:

### `tests/api/test_agents.py`
- Added `TestAgentAuthorization.test_list_agents_requires_authentication`
- Added `TestAgentAuthorization.test_get_agent_requires_authentication`

### `tests/api/test_deployments.py`
- Added `TestListDeployments.test_list_deployments_scoped_to_authenticated_user`
- Added `TestListDeployments.test_list_deployments_ignores_client_supplied_user_id`
- Added `TestDeploymentAuthorization.test_list_deployments_requires_authentication`
- Added `TestDeploymentAuthorization.test_get_deployment_requires_authentication`

These tests guarantee:
- users can only see their own agents/deployments
- client-supplied identity hints do not widen access scope
- `401` is returned for unauthenticated requests and `403` for authenticated cross-user access

## Validation
Executed and passed:

- `uv run pytest -q tests/api/test_agents.py -k 'authorization or scoped_to_authenticated_user'`
- `uv run pytest -q tests/api/test_deployments.py -k 'Authorization or scoped_to_authenticated_user or client_supplied_user_id'`
- `uv run pytest -q tests/api/test_agents.py`
- `uv run pytest -q tests/api/test_deployments.py`

Issue: Closes #303
