### PR TITLE
feat(frontend): add loading and error states (#316)

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Global error boundary:", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[400px] flex-col items-center justify-center rounded-xl border border-rose-400/20 bg-rose-400/5 p-8 text-center m-6">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-rose-400/10 text-rose-400">
+        <AlertTriangle className="h-8 w-8" />
+      </div>
+      <h2 className="mt-6 text-lg font-semibold text-white">Something went wrong</h2>
+      <p className="mt-2 max-w-md text-sm text-slate-400">
+        {error.message || "An unexpected error occurred. Please try again."}
+      </p>
+      {error.digest && (
+        <p className="mt-2 text-xs text-slate-500">
+          Error ID: {error.digest}
+        </p>
+      )}
+      <button
+        onClick={reset}
+        className="mt-6 inline-flex items-center gap-2 rounded-lg bg-rose-500 px-4 py-2 text-sm font-medium text-white hover:bg-rose-600"
+      >
+        <RefreshCw className="h-4 w-4" />
+        Try Again
+      </button>
+    </div>
+  );
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,12 @@
+import { Loader2 } from "lucide-react";
+
+export default function Loading() {
+  return (
+    <div className="flex min-h-[400px] items-center justify-center">
+      <div className="flex flex-col items-center gap-4">
+        <Loader2 className="h-8 w-8 animate-spin text-cyan-400" />
+        <p className="text-sm text-slate-400">Loading...</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds global error boundary and loading states for better UX.

## Changes
- `app/error.tsx`: Global error boundary component (40 lines)
- `app/loading.tsx`: Global loading state component (12 lines)

## Test
- Build passes: `npm run build` ✓

Closes #316