### PR TITLE
fix(infra): add app.mutx.dev to nginx server_names - issue #339

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,7 +20,7 @@ http {
 
     server {
         listen 80;
-        server_name mutx.dev www.mutx.dev;
+        server_name mutx.dev www.mutx.dev app.mutx.dev;
 
         # Redirect HTTP to HTTPS (when SSL is configured)
         # return 301 https://$server_name$request_uri;
@@ -94,7 +94,7 @@ http {
     # SSL server block (template - uncomment and configure with SSL certs)
     # server {
     #     listen 443 ssl http2;
-    #     server_name mutx.dev www.mutx.dev;
+    #     server_name mutx.dev www.mutx.dev app.mutx.dev;
     # 
     #     ssl_certificate /etc/nginx/ssl/cert.pem;
     #     ssl_certificate_key /etc/nginx/ssl/key.pem;


### PR DESCRIPTION
## Summary
- Add app.mutx.dev to nginx server_names for domain consolidation
- This ensures requests to app.mutx.dev are properly routed through nginx to the frontend

## Issue
Fixes #339 - consolidate app domains (mutx.dev/app → app.mutx.dev)