### PR TITLE
[codex] fix(ci): guard incompatible pydantic dependency pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Validate dependency compatibility pins
+        run: python scripts/check_requirements_compat.py
+
       - name: Install dependencies
         run: |
           npm ci

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 fastapi==0.109.0
 uvicorn[standard]==0.27.0
 pydantic==2.5.3
+# keep pydantic-settings <2.7.0 while pydantic remains <2.7.0
 pydantic-settings==2.1.0
 
 # Database

--- a/scripts/check_requirements_compat.py
+++ b/scripts/check_requirements_compat.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Fail fast on known incompatible pinned dependency combinations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+
+PIN_PATTERN = re.compile(r"^\s*([A-Za-z0-9_.-]+)==([0-9][A-Za-z0-9_.-]*)\s*$")
+
+
+def parse_pinned_versions(requirements_path: Path) -> dict[str, str]:
+    versions: dict[str, str] = {}
+    for raw_line in requirements_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        match = PIN_PATTERN.match(line)
+        if not match:
+            continue
+        package, version = match.groups()
+        versions[package.lower()] = version
+    return versions
+
+
+def version_tuple(version: str) -> tuple[int, ...]:
+    parts = []
+    for part in version.split("."):
+        if not part.isdigit():
+            break
+        parts.append(int(part))
+    return tuple(parts)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    requirements_path = repo_root / "requirements.txt"
+    versions = parse_pinned_versions(requirements_path)
+
+    pydantic = versions.get("pydantic")
+    pydantic_settings = versions.get("pydantic-settings")
+
+    if pydantic and pydantic_settings:
+        pydantic_version = version_tuple(pydantic)
+        pydantic_settings_version = version_tuple(pydantic_settings)
+        if pydantic_settings_version >= (2, 7, 0) and pydantic_version < (2, 7, 0):
+            print(
+                "ERROR: Incompatible requirements pinning detected.\n"
+                f"- pydantic=={pydantic}\n"
+                f"- pydantic-settings=={pydantic_settings}\n"
+                "pydantic-settings>=2.7.0 requires pydantic>=2.7.0.\n"
+                "Either lower pydantic-settings below 2.7.0 or upgrade pydantic in lockstep."
+            )
+            return 1
+
+    print("Dependency compatibility checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -25,6 +25,9 @@ if [ -z "$PYTHON_BIN" ]; then
   exit 1
 fi
 
+echo "Checking pinned dependency compatibility..."
+"$PYTHON_BIN" scripts/check_requirements_compat.py
+
 if [ -x ".venv/bin/ruff" ]; then
   RUFF_BIN=".venv/bin/ruff"
 else


### PR DESCRIPTION
## Summary
This PR hardens CI against a known dependency-pin mismatch that previously broke the validation job before test execution.

Closes #319.

## Problem
A recent failed CI run (`23101002639` on 2026-03-15) showed dependency installation failing with:
- `pydantic==2.5.3`
- `pydantic-settings==2.7.0`

That combination is incompatible (`pydantic-settings>=2.7.0` requires `pydantic>=2.7.0`), so the pipeline failed during `pip install` and no downstream checks (tests/lint/build) could run.

## Root Cause
Dependency pin updates were not explicitly guarded for cross-package compatibility, so an incompatible pair could be committed and only fail at install time with a generic resolver error.

## Fix
- Added `scripts/check_requirements_compat.py` to enforce known pinned compatibility invariants from `requirements.txt`.
- Wired that check into CI (`.github/workflows/ci.yml`) before dependency installation to fail fast with a clear actionable error.
- Wired the same check into `scripts/test.sh` so local validation mirrors CI behavior.
- Documented the pydantic/pydantic-settings coupling inline in `requirements.txt`.

## Validation
Executed locally in the branch:
- `NEXT_PUBLIC_TURNSTILE_SITE_KEY=ci-test-site-key TURNSTILE_SECRET_KEY=ci-test-secret-key MUTX_SKIP_PLAYWRIGHT=1 bash scripts/test.sh`

Results:
- Dependency compatibility check: passed
- Python lint/format: passed
- Python compile check: passed
- API tests: `147 passed`
- Frontend unit tests: passed
- Frontend lint: passed (existing warnings only)
- Frontend build: passed

This keeps the CI lane green and prevents recurrence of the specific dependency regression that blocked validation.
