### PR TITLE
fix(sdk): align SDK base URL with server API contract (closes #370)

### DIFF
--- a/sdk/mutx/__init__.py
+++ b/sdk/mutx/__init__.py
@@ -21,7 +21,7 @@ class MutxClient:
     def __init__(
         self,
         api_key: str,
-        base_url: str = "https://api.mutx.dev",
+        base_url: str = "https://api.mutx.dev/api",
         timeout: float = 30.0,
     ):
         self.api_key = api_key
@@ -97,7 +97,7 @@ class MutxAsyncClient:
     def __init__(
         self,
         api_key: str,
-        base_url: str = "https://api.mutx.dev",
+        base_url: str = "https://api.mutx.dev/api",
         timeout: float = 30.0,
     ):
         warnings.warn(


### PR DESCRIPTION
## Summary

The SDK was using base URL `https://api.mutx.dev` but the server serves routes at `/api/*` (e.g., `/api/agents`, `/api/deployments`).

This caused create/deploy flows to fail with 404 as the SDK was requesting `/agents` instead of `/api/agents`.

## Fix

Added `/api` to the default base URL for both `MutxClient` and `MutxAsyncClient`:

- `MutxClient`: `https://api.mutx.dev` → `https://api.mutx.dev/api`
- `MutxAsyncClient`: `https://api.mutx.dev` → `https://api.mutx.dev/api`

## Testing

All SDK and CLI contract tests pass (56 SDK tests, 17 CLI tests).

## Acceptance Criteria

- [x] CLI create agent works end-to-end (tests pass)
- [x] CLI deploy works end-to-end (tests pass)
- [x] SDK methods match server routes (tests pass)