### PR TITLE
fix(test-api): quote auth JSON payloads correctly

### DIFF
--- a/scripts/test-api.sh
+++ b/scripts/test-api.sh
@@ -83,8 +83,11 @@ test_endpoint() {
 do_register() {
     print_header "Register Test User"
     
+    local payload
+    payload=$(printf '{"email":"%s","name":"%s","password":"%s"}' "$TEST_EMAIL" "Test User" "$TEST_PASSWORD")
+
     local response
-    response=$(curl -sf -X POST "$API_URL/auth/register"         -H "Content-Type: application/json"         -d "{"email":"$TEST_EMAIL","name":"Test User","password":"$TEST_PASSWORD"}" 2>&1) || true
+    response=$(curl -sf -X POST "$API_URL/auth/register"         -H "Content-Type: application/json"         -d "$payload" 2>&1) || true
     
     if echo "$response" | grep -q "Email already registered"; then
         echo -e "${YELLOW}User already exists, trying login...${NC}"
@@ -103,8 +106,11 @@ do_register() {
 do_login() {
     print_header "Login"
     
+    local payload
+    payload=$(printf '{"email":"%s","password":"%s"}' "$TEST_EMAIL" "$TEST_PASSWORD")
+
     local response
-    response=$(curl -sf -X POST "$API_URL/auth/login"         -H "Content-Type: application/json"         -d "{"email":"$TEST_EMAIL","password":"$TEST_PASSWORD"}" 2>&1) || true
+    response=$(curl -sf -X POST "$API_URL/auth/login"         -H "Content-Type: application/json"         -d "$payload" 2>&1) || true
     
     if echo "$response" | grep -q "access_token"; then
         ACCESS_TOKEN=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null || echo "")


### PR DESCRIPTION
### Motivation
- The `do_register` and `do_login` helpers built JSON bodies with embedded double quotes which allowed shell word-splitting and produced malformed JSON when values contained spaces (e.g., "Test User").
- The change ensures `curl -d` receives a single, well-formed JSON argument so registration/login flows in the test script work reliably.

### Description
- Construct the JSON request bodies with `printf` into a `payload` variable to avoid embedded-quote parsing issues in `scripts/test-api.sh` for both `do_register` and `do_login`.
- Pass the `payload` variable as the single `-d` argument to `curl` in both helpers, preserving headers and response handling.
- No change to external behavior or outputs other than fixing malformed payloads caused by shell quoting.

### Testing
- Ran `bash -n scripts/test-api.sh` to verify the script has valid syntax and it succeeded.
- Ran `./scripts/test-api.sh --help | head -20` to validate the script runs and prints usage, and it produced the expected help output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b65ef72a3c832a95b845b2ca1e87fb)