### PR TITLE
fix(security): remove fixed PYTHONHASHSEED in production Dockerfile

### DIFF
--- a/infrastructure/docker/Dockerfile.api.production
+++ b/infrastructure/docker/Dockerfile.api.production
@@ -50,7 +50,6 @@ COPY --chown=appuser:appuser pyproject.toml /app/
 # Environment variables for production
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONHASHSEED=0 \
     ENVIRONMENT=production \
     LOG_LEVEL=INFO
 


### PR DESCRIPTION
### Motivation
- Remove the insecure `PYTHONHASHSEED=0` setting from the production image because it disables Python's hash randomization and increases exposure to hash‑collision DoS attacks. 

### Description
- Deleted the `PYTHONHASHSEED=0` entry from the `ENV` block in `infrastructure/docker/Dockerfile.api.production` so production containers use Python's default randomized hashing, with no other functional changes. 

### Testing
- Confirmed the change by inspecting the Dockerfile with `sed -n '1,140p' infrastructure/docker/Dockerfile.api.production`, searching with `rg -n "PYTHONHASHSEED" infrastructure/docker/Dockerfile.api.production` which returned no matches, and viewing the environment block with `nl -ba infrastructure/docker/Dockerfile.api.production | sed -n '46,60p'`, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b63aa92910832a9e32d8893351aa9d)