### PR TITLE
fix: add click to test-requirements.txt for CLI test collection

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,6 +16,9 @@ pydantic-settings>=2.1.0
 sqlalchemy>=2.0.48
 asyncpg>=0.29.0
 
+# CLI testing dependencies
+click>=8.0.0
+
 # Auth dependencies  
 python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4


### PR DESCRIPTION
## Summary

Adds `click>=8.0.0` to test-requirements.txt to fix CLI test collection.

## Problem

CLI tests were failing to collect due to missing `click` dependency:

```
ModuleNotFoundError: No module named 'click'
```

## Solution

Added `click>=8.0.0` to test-requirements.txt under a new `# CLI testing dependencies` section.

## Testing

- All 251 tests now collect successfully (was 231 + 3 errors)
- All 251 tests pass

## Edge Cases

1. Click version is not tightly pinned - works with any 8.x version
2. CLI tests may need additional dependencies to run fully - this fixes collection at minimum

Closes #389