### PR TITLE
fix: remove trailing whitespace from agents.py to pass lint

### DIFF
--- a/sdk/mutx/agents.py
+++ b/sdk/mutx/agents.py
@@ -159,7 +159,7 @@ class Agents:
         self,
         skip: int = 0,
         limit: int = 50,
-        
+
     ) -> list[Agent]:
         self._require_sync_client()
         response = self._client.get(
@@ -173,7 +173,7 @@ class Agents:
         self,
         skip: int = 0,
         limit: int = 50,
-        
+
     ) -> list[Agent]:
         self._require_async_client()
         response = await self._client.get(


### PR DESCRIPTION
## Summary
- Fix trailing whitespace on lines 162 and 176 in sdk/mutx/agents.py
- Resolves CI lint failure

## Testing
- All 248 tests pass