### PR TITLE
fix: replace deprecated datetime.utcnow in error_schemas.py

### DIFF
--- a/src/api/models/error_schemas.py
+++ b/src/api/models/error_schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class ErrorDetail(BaseModel):
@@ -23,7 +23,7 @@ class ErrorResponse(BaseModel):
     message: str = Field(description="Human-readable error message")
     details: Optional[list[ErrorDetail]] = Field(None, description="Detailed validation errors")
     request_id: Optional[str] = Field(None, description="Request ID for tracing")
-    timestamp: datetime = Field(default_factory=datetime.utcnow, description="Error timestamp")
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Error timestamp")
 
     model_config = {
         "json_schema_extra": {


### PR DESCRIPTION
Replaces deprecated datetime.utcnow with datetime.now(timezone.utc) in src/api/models/error_schemas.py.

One file, one fix. Tests pass locally.