### PR TITLE
docs(api): clarify ownership enforcement (fixes #369)

### DIFF
--- a/src/api/routes/agents.py
+++ b/src/api/routes/agents.py
@@ -251,6 +251,9 @@ async def list_agents(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    # Ownership enforcement: always filter by authenticated user's ID.
+    # Client-supplied user_id query params are ignored - ownership is derived
+    # from the auth token via current_user, not from client input.
     query = select(Agent).order_by(Agent.created_at.desc()).offset(skip).limit(limit)
     query = query.where(Agent.user_id == current_user.id)
     result = await db.execute(query)

--- a/src/api/routes/deployments.py
+++ b/src/api/routes/deployments.py
@@ -87,6 +87,9 @@ async def list_deployments(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    # Ownership enforcement: always filter by authenticated user's agent ownership.
+    # Client-supplied user_id query params are ignored - ownership is derived
+    # from the auth token via current_user, not from client input.
     # Filter deployments by agents owned by the current user
     query = (
         select(Deployment)


### PR DESCRIPTION
## Summary

Adds explicit documentation comments to clarify that ownership enforcement is already implemented in the `/agents` and `/deployments` routes:

- `/agents` only returns resources owned by the authenticated user
- `/deployments` only returns resources owned by the authenticated user  
- Ownership is derived from the auth token (`current_user.id`), not from client-supplied input

## Changes

- Added clarifying comments to `list_agents` in `src/api/routes/agents.py`
- Added clarifying comments to `list_deployments` in `src/api/routes/deployments.py`

## Verification

All 65 existing tests pass:

```
tests/api/test_agents.py ................................                [ 49%]
tests/api/test_deployments.py .................................          [100%]
======================== 65 passed in 3.86s =========================
```

## Acceptance Criteria

- [x] `/agents` only returns resources owned by the authenticated user
- [x] `/deployments` only returns resources owned by the authenticated user
- [x] Ownership derived from auth token, not client input