### PR TITLE
fix: replace datetime.utcnow() in openclaw provider

### DIFF
--- a/src/api/integrations/openclaw/provider.py
+++ b/src/api/integrations/openclaw/provider.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 
 from src.api.models import Agent, AgentStatus, AgentLog
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -54,7 +54,7 @@ class OpenClawProvider:
             agent_id=self.agent.id,
             level=level,
             message=f"[OpenClaw] {message}",
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
         )
         session.add(log)
         await session.commit()


### PR DESCRIPTION
## Summary

Fixes Python 3.14 deprecation warning for datetime.utcnow() in the OpenClaw provider integration.

## Changes

- Replace datetime.utcnow() with datetime.now(timezone.utc) in src/api/integrations/openclaw/provider.py

## Testing

- All tests pass (65 tests in agents and deployments)

## Edge cases

- None - this is a simple deprecation fix with no functional change