### PR TITLE
fix: replace datetime.utcnow with datetime.nowtimezone.utc

### DIFF
--- a/src/api/integrations/openclaw/provider.py
+++ b/src/api/integrations/openclaw/provider.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 
 from src.api.models import Agent, AgentStatus, AgentLog
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -54,7 +54,7 @@ class OpenClawProvider:
             agent_id=self.agent.id,
             level=level,
             message=f"[OpenClaw] {message}",
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
         )
         session.add(log)
         await session.commit()


### PR DESCRIPTION
Fixes Python 3.14 deprecation warning for datetime.utcnow in openclaw provider.

## Changes
- Replace deprecated datetime.utcnow with datetime.nowtimezone.utc in src/api/integrations/openclaw/provider.py

## Edge cases not handled
- None - this is a straightforward deprecation fix with no runtime behavior change