### PR TITLE
fix: replace datetime.utcnow() with datetime.now(timezone.utc) in openclaw provider

### DIFF
--- a/src/api/integrations/openclaw/provider.py
+++ b/src/api/integrations/openclaw/provider.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 
 from src.api.models import Agent, AgentStatus, AgentLog
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -54,7 +54,7 @@ class OpenClawProvider:
             agent_id=self.agent.id,
             level=level,
             message=f"[OpenClaw] {message}",
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
         )
         session.add(log)
         await session.commit()


### PR DESCRIPTION
Replaces deprecated datetime.utcnow() with timezone-aware datetime.now(timezone.utc) in the OpenClaw provider to fix Python 3.12+ deprecation warning.

## Changes
- src/api/integrations/openclaw/provider.py: Replace datetime.utcnow() with datetime.now(timezone.utc)

## Testing
- Local tests pass (250 passed)

## Edge cases
1. Other files in codebase still use utcnow() - out of scope for this fix
2. Timestamp comparisons with naive datetimes may need review in other files
3. Default factory patterns in models may need separate fixes