### PR TITLE
fix: replace datetime.utcnow() with datetime.now(timezone.utc) in openclaw provider

### DIFF
--- a/src/api/integrations/openclaw/provider.py
+++ b/src/api/integrations/openclaw/provider.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 
 from src.api.models import Agent, AgentStatus, AgentLog
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -54,7 +54,7 @@ class OpenClawProvider:
             agent_id=self.agent.id,
             level=level,
             message=f"[OpenClaw] {message}",
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
         )
         session.add(log)
         await session.commit()


### PR DESCRIPTION
Fixes Python 3.14 deprecation warning for datetime.utcnow()

## Changes
- Replace deprecated datetime.utcnow() with datetime.now(timezone.utc) in src/api/integrations/openclaw/provider.py
- Update import to include timezone from datetime module

## Edge cases not handled
1. Other files in codebase still use datetime.utcnow() (models.py, routes, services, etc.)
2. SQLAlchemy default=datetime.utcnow in models.py requires different fix approach
3. Pydantic default_factory=datetime.utcnow needs lambda or wrapper function

This is a single-file fix as per backend-worker rules.