### PR TITLE
fix: replace datetime.utcnow with datetime.now(timezone.utc) in models

### DIFF
--- a/src/api/models/models.py
+++ b/src/api/models/models.py
@@ -82,9 +82,13 @@ class User(Base):
     password_hash: Mapped[str] = mapped_column(String(255), nullable=True)
     plan: Mapped[Plan] = mapped_column(SQLEnum(Plan), default=Plan.FREE)
     api_key: Mapped[str] = mapped_column(String(64), unique=True, nullable=True, index=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc)
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
     )
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     # Email verification fields
@@ -125,9 +129,13 @@ class Agent(Base):
         String(128), nullable=True, index=True
     )  # Agent API key for self-auth
     last_heartbeat: Mapped[datetime] = mapped_column(DateTime, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc)
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
     )
 
     user: Mapped["User"] = relationship("User", back_populates="agents")
@@ -161,7 +169,9 @@ class Deployment(Base):
     status: Mapped[str] = mapped_column(String(50), default="pending")
     region: Mapped[str] = mapped_column(String(50), nullable=True)
     version: Mapped[str] = mapped_column(String(50), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     replicas: Mapped[int] = mapped_column(Integer, default=1)
     node_id: Mapped[str] = mapped_column(String(255), nullable=True)
     started_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)
@@ -188,7 +198,9 @@ class DeploymentEvent(Base):
     status: Mapped[str] = mapped_column(String(50), nullable=False)
     node_id: Mapped[str] = mapped_column(String(255), nullable=True)
     error_message: Mapped[str] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
 
     deployment: Mapped["Deployment"] = relationship("Deployment", back_populates="events")
 
@@ -203,7 +215,9 @@ class DeploymentVersion(Base):
     version: Mapped[int] = mapped_column(Integer, nullable=False)
     config_snapshot: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String(50), default="current")
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     rolled_back_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)
 
     deployment: Mapped["Deployment"] = relationship("Deployment", back_populates="versions")
@@ -219,7 +233,9 @@ class APIKey(Base):
     key_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     last_used: Mapped[datetime] = mapped_column(DateTime, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
 
@@ -237,7 +253,9 @@ class Webhook(Base):
     events: Mapped[list[str]] = mapped_column(ARRAY(String), default=list)
     secret: Mapped[str] = mapped_column(String(255), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
 
     user: Mapped["User"] = relationship("User", back_populates="webhooks")
 
@@ -253,7 +271,9 @@ class Metrics(Base):
     memory: Mapped[float] = mapped_column(Float, nullable=True)
     requests: Mapped[int] = mapped_column(Integer, default=0)
     latency: Mapped[float] = mapped_column(Float, nullable=True)
-    timestamp: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), index=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
+    )
 
     agent: Mapped["Agent"] = relationship("Agent", back_populates="metrics")
 
@@ -268,7 +288,9 @@ class Alert(Base):
     type: Mapped[AlertType] = mapped_column(SQLEnum(AlertType), nullable=False)
     message: Mapped[str] = mapped_column(Text, nullable=False)
     resolved: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     resolved_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)
 
     agent: Mapped["Agent"] = relationship("Agent", back_populates="alerts")
@@ -285,7 +307,9 @@ class AgentLog(Base):
     message: Mapped[str] = mapped_column(Text, nullable=False)
     extra_data: Mapped[str] = mapped_column(Text, nullable=True)
     meta_data: Mapped[Optional[dict]] = mapped_column(Text, nullable=True)  # Renamed to meta_data
-    timestamp: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), index=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
+    )
 
     agent: Mapped["Agent"] = relationship("Agent", back_populates="logs")
 
@@ -302,7 +326,9 @@ class Command(Base):
     status: Mapped[str] = mapped_column(String(50), default="pending")
     result: Mapped[Optional[dict]] = mapped_column(Text, nullable=True)
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
     agent: Mapped["Agent"] = relationship("Agent")
@@ -317,7 +343,9 @@ class AgentMetric(Base):
     )
     cpu_usage: Mapped[float] = mapped_column(Float, nullable=True)
     memory_usage: Mapped[float] = mapped_column(Float, nullable=True)
-    timestamp: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), index=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
+    )
 
     agent: Mapped["Agent"] = relationship("Agent", back_populates="agent_metrics")
 
@@ -337,9 +365,13 @@ class AgentRun(Base):
     output_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     run_metadata: Mapped[Optional[str]] = mapped_column("metadata", Text, nullable=True)
-    started_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), index=True)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
+    )
     completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
+    )
 
     agent: Mapped["Agent"] = relationship("Agent", back_populates="runs")
     user: Mapped["User"] = relationship("User", back_populates="runs")
@@ -359,7 +391,9 @@ class AgentRunTrace(Base):
     message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     payload: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     sequence: Mapped[int] = mapped_column(Integer, default=0)
-    timestamp: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), index=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
+    )
 
     run: Mapped["AgentRun"] = relationship("AgentRun", back_populates="traces")
 
@@ -380,7 +414,9 @@ class WebhookDeliveryLog(Base):
     success: Mapped[bool] = mapped_column(Boolean, default=False)
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     attempts: Mapped[int] = mapped_column(Integer, default=1)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     delivered_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
     webhook: Mapped["Webhook"] = relationship("Webhook")
@@ -392,7 +428,9 @@ class WaitlistSignup(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     source: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
+    )
 
 
 class Lead(Base):
@@ -404,4 +442,6 @@ class Lead(Base):
     company: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     source: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
+    )

--- a/src/api/routes/agent_runtime.py
+++ b/src/api/routes/agent_runtime.py
@@ -14,7 +14,7 @@ These endpoints are used by agents to connect to MUTX:
 import logging
 import json
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -157,7 +157,7 @@ async def heartbeat(
 
     # Update agent status and last heartbeat
     previous_status = agent.status
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     heartbeat_timestamp = now.isoformat()
     new_status = request.status.value
     agent.status = new_status
@@ -231,7 +231,7 @@ async def report_metrics(
         agent_id=agent.id,
         cpu_usage=request.cpu_usage,
         memory_usage=request.memory_usage,
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
     )
     db.add(metric)
 
@@ -311,7 +311,7 @@ async def acknowledge_command(
     command.status = "completed" if request.success else "failed"
     command.result = request.result
     command.error_message = request.error
-    command.completed_at = datetime.utcnow()
+    command.completed_at = datetime.now(timezone.utc)
 
     await db.commit()
 
@@ -337,7 +337,7 @@ async def submit_log(
         level=request.level,
         message=request.message,
         meta_data=request.metadata,
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
     )
     db.add(log_entry)
 
@@ -366,7 +366,11 @@ async def get_agent_status(
 
     uptime = 0.0
     if current_agent.created_at:
-        uptime = (datetime.utcnow() - current_agent.created_at).total_seconds()
+        # Handle both naive and timezone-aware datetimes
+        created = current_agent.created_at
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=timezone.utc)
+        uptime = (datetime.now(timezone.utc) - created).total_seconds()
 
     return AgentStatusResponse(
         agent_id=str(current_agent.id),

--- a/src/api/services/monitoring.py
+++ b/src/api/services/monitoring.py
@@ -4,7 +4,7 @@ Monitoring and Self-Healing logic for MUTX.
 
 import logging
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -103,14 +103,18 @@ async def monitor_agent_health(session: AsyncSession):
     2. Mark 'running' agents as 'failed' if heartbeat is missing
     3. Auto-heal 'failed' agents back to 'running'
     """
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     # 1. Promote CREATING -> RUNNING
     # This simulates the completion of provisioning
     result = await session.execute(select(Agent).where(Agent.status == "creating"))
     new_agents = result.scalars().all()
     for agent in new_agents:
-        if now - agent.created_at > timedelta(seconds=10):
+        # Handle both naive and timezone-aware datetimes
+        created = agent.created_at
+        if created and created.tzinfo is None:
+            created = created.replace(tzinfo=timezone.utc)
+        if created and now - created > timedelta(seconds=10):
             old_status = agent.status
             agent.status = "running"
             agent.last_heartbeat = now
@@ -159,7 +163,11 @@ async def monitor_agent_health(session: AsyncSession):
 
     for agent in running_agents:
         last_hb = agent.last_heartbeat or agent.created_at
-        if now - last_hb > timedelta(seconds=STALE_THRESHOLD_SECONDS):
+        # Handle both naive and timezone-aware datetimes
+        if last_hb:
+            if last_hb.tzinfo is None:
+                last_hb = last_hb.replace(tzinfo=timezone.utc)
+        if last_hb and now - last_hb > timedelta(seconds=STALE_THRESHOLD_SECONDS):
             logger.warning(f"Monitor: Agent {agent.name} ({agent.id}) is STALE. Marking as FAILED.")
             old_status = agent.status
             agent.status = "failed"
@@ -214,7 +222,11 @@ async def monitor_agent_health(session: AsyncSession):
     failed_agents = result.scalars().all()
 
     for agent in failed_agents:
-        if now - agent.updated_at > timedelta(seconds=HEAL_THRESHOLD_SECONDS):
+        # Handle both naive and timezone-aware datetimes
+        updated = agent.updated_at
+        if updated and updated.tzinfo is None:
+            updated = updated.replace(tzinfo=timezone.utc)
+        if updated and now - updated > timedelta(seconds=HEAL_THRESHOLD_SECONDS):
             logger.info(f"Auto-Healer: Restarting agent {agent.name} ({agent.id})...")
             old_status = agent.status
             agent.status = "running"

--- a/tests/api/test_agent_runtime.py
+++ b/tests/api/test_agent_runtime.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import uuid
 
 import pytest
@@ -16,7 +16,7 @@ async def test_agent_status_requires_agent_auth(client, test_agent):
 async def test_agent_status_returns_authenticated_agent_status(client, db_session, test_agent):
     test_agent.api_key = 'mutx_agent_status_test_key'
     test_agent.status = 'running'
-    test_agent.last_heartbeat = datetime.utcnow()
+    test_agent.last_heartbeat = datetime.now(timezone.utc)
     await db_session.commit()
 
     response = await client.get(
@@ -119,7 +119,7 @@ async def test_runtime_registered_agent_api_key_authenticates_status_and_heartbe
             'agent_id': agent_id,
             'status': 'running',
             'message': 'demo heartbeat',
-            'timestamp': datetime.utcnow().isoformat(),
+            'timestamp': datetime.now(timezone.utc).isoformat(),
         },
     )
 


### PR DESCRIPTION
Replaces deprecated datetime.utcnow() with timezone-aware datetime.now(timezone.utc) in src/api/models/models.py