### PR TITLE
[codex] fix bearer API key auth for automation workflows

### DIFF
--- a/src/api/middleware/auth.py
+++ b/src/api/middleware/auth.py
@@ -10,6 +10,28 @@ from src.api.models.models import User
 from src.api.services.user_service import UserService
 
 
+async def _resolve_user_from_bearer_token(
+    token: str,
+    session: AsyncSession,
+    *,
+    user_service: UserService | None = None,
+) -> Optional[User]:
+    """Resolve an active user from a bearer token (JWT first, then API key fallback)."""
+    service = user_service or UserService(session)
+
+    user_id = verify_access_token(token)
+    if user_id:
+        user = await service.get_user_by_id(user_id)
+        if user and user.is_active:
+            return user
+
+    user = await service.get_user_for_api_key(token)
+    if user and user.is_active:
+        return user
+
+    return None
+
+
 async def get_current_user(
     authorization: Optional[str] = Header(None),
     session: AsyncSession = Depends(get_db),
@@ -30,20 +52,12 @@ async def get_current_user(
         )
 
     token = parts[1]
-    user_id = verify_access_token(token)
-    if not user_id:
+    user_service = UserService(session)
+    user = await _resolve_user_from_bearer_token(token, session, user_service=user_service)
+    if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    user_service = UserService(session)
-    user = await user_service.get_user_by_id(user_id)
-    if not user or not user.is_active:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="User not found or inactive",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
@@ -62,16 +76,8 @@ async def get_current_user_optional(
         return None
 
     token = parts[1]
-    user_id = verify_access_token(token)
-    if not user_id:
-        return None
-
     user_service = UserService(session)
-    user = await user_service.get_user_by_id(user_id)
-    if not user or not user.is_active:
-        return None
-
-    return user
+    return await _resolve_user_from_bearer_token(token, session, user_service=user_service)
 
 
 async def get_api_key_user(
@@ -104,21 +110,19 @@ async def get_current_user_or_api_key(
     session: AsyncSession = Depends(get_db),
 ) -> User:
     """Authenticate using either JWT Bearer token or API key."""
-    # Try JWT first
+    user_service = UserService(session)
+
+    # Try Authorization header first (JWT or API key in Bearer token)
     if authorization:
         parts = authorization.split()
         if len(parts) == 2 and parts[0].lower() == "bearer":
             token = parts[1]
-            user_id = verify_access_token(token)
-            if user_id:
-                user_service = UserService(session)
-                user = await user_service.get_user_by_id(user_id)
-                if user and user.is_active:
-                    return user
+            user = await _resolve_user_from_bearer_token(token, session, user_service=user_service)
+            if user:
+                return user
 
-    # Try API key
+    # Try explicit API key header
     if x_api_key:
-        user_service = UserService(session)
         user = await user_service.get_user_for_api_key(x_api_key)
         if user:
             return user

--- a/tests/api/test_api_keys.py
+++ b/tests/api/test_api_keys.py
@@ -10,6 +10,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.api.auth.jwt import create_access_token
 from src.api.models.models import APIKey
 from src.api.routes.api_keys import MAX_ACTIVE_API_KEYS_PER_USER
 from src.api.services.user_service import verify_api_key
@@ -300,3 +301,41 @@ class TestVerifyAPIKeyCompatibility:
         plain_key = "mutx_live_legacy_example"
         legacy_hash = hashlib.sha256(plain_key.encode()).hexdigest()
         assert verify_api_key(plain_key, legacy_hash)
+
+
+class TestBearerAPIKeyAuth:
+    """Authentication compatibility tests for Bearer API key automation flows."""
+
+    @pytest.mark.asyncio
+    async def test_list_api_keys_with_bearer_managed_api_key(
+        self, client_no_auth: AsyncClient, test_user
+    ):
+        access_token, _ = create_access_token(test_user.id)
+
+        create_response = await client_no_auth.post(
+            "/api/api-keys",
+            json={"name": "automation-key"},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert create_response.status_code == 201
+        created_key = create_response.json()
+
+        list_response = await client_no_auth.get(
+            "/api/api-keys",
+            headers={"Authorization": f"Bearer {created_key['key']}"},
+        )
+        assert list_response.status_code == 200
+        payload = list_response.json()
+        assert payload["total"] == 1
+        assert payload["items"][0]["id"] == created_key["id"]
+
+    @pytest.mark.asyncio
+    async def test_list_api_keys_with_invalid_bearer_api_key_is_unauthorized(
+        self, client_no_auth: AsyncClient
+    ):
+        response = await client_no_auth.get(
+            "/api/api-keys",
+            headers={"Authorization": "Bearer mutx_live_invalid"},
+        )
+
+        assert response.status_code == 401

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -340,6 +340,29 @@ async def test_webhook_delivery_history_supports_managed_api_key_auth(
 
 
 @pytest.mark.asyncio
+async def test_webhook_create_supports_managed_api_key_in_bearer_header(
+    client_no_auth: AsyncClient, test_user
+):
+    access_token, _ = create_access_token(test_user.id)
+    key_response = await client_no_auth.post(
+        "/api/api-keys",
+        json={"name": "webhook-bearer-key"},
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert key_response.status_code == 201
+    managed_api_key = key_response.json()["key"]
+
+    response = await client_no_auth.post(
+        "/api/webhooks/",
+        json={"url": "https://example.com/webhook", "events": ["agent.*"]},
+        headers={"Authorization": f"Bearer {managed_api_key}"},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["url"] == "https://example.com/webhook"
+
+
+@pytest.mark.asyncio
 async def test_webhook_delivery_history_other_user_forbidden(
     client: AsyncClient, other_user_client: AsyncClient, db_session, test_user
 ):


### PR DESCRIPTION
## Summary
This PR advances issue #387 by making managed API keys usable for real automation flows that authenticate via `Authorization: Bearer <api-key>`.

## User impact
Before this change, operators could create/list/revoke API keys, but those keys were not reliably accepted when sent in the same Bearer header shape used by the SDK and most automation clients.

That mismatch meant key management existed, while practical non-browser automation remained brittle.

## Root cause
Auth middleware treated Bearer tokens as JWT-only in core dependencies (`get_current_user`, `get_current_user_optional`), and mixed-auth flows had partial support that still depended on explicit `X-API-Key` headers for API-key auth fallback.

## What changed
- Added a shared bearer-token resolver in `src/api/middleware/auth.py` that:
  - tries JWT validation first
  - falls back to managed/legacy API-key resolution when JWT validation fails
- Updated `get_current_user` and `get_current_user_optional` to use this shared resolver.
- Updated `get_current_user_or_api_key` to accept managed API keys in Bearer auth as well (while preserving `X-API-Key` support).

## Tests
Added/updated API tests to lock in the automation contract:
- `tests/api/test_api_keys.py`
  - managed API key works via `Authorization: Bearer <api-key>` on `/api/api-keys`
  - invalid bearer API key is rejected with `401`
- `tests/api/test_webhooks.py`
  - managed API key in Bearer header can create webhooks (mixed-auth route)

Executed locally:
- `pytest tests/api/test_api_keys.py tests/api/test_webhooks.py tests/api/test_ingest.py -q`
- `pytest tests/api/test_auth.py -q`
- `pytest tests/api/test_leads.py -q`

## Issue linkage
- Closes #387
- Related: #372
