### PR TITLE
fix(api): add CLI-compatible /api routes for agents and deployments

### DIFF
--- a/app/api/_lib/validation.ts
+++ b/app/api/_lib/validation.ts
@@ -100,7 +100,7 @@ export const schemas = {
   
   // Deployment schemas
   deploymentCreate: z.object({
-    agent_id: z.string().uuid('Invalid agent ID'),
+    agent_id: z.string().uuid('Invalid agent ID'), replicas: z.number().int().positive().max(10, 'Max replicas is 10').optional(),
     environment: z.enum(['development', 'staging', 'production']).optional(),
     config: z.record(z.string(), z.unknown()).optional(),
   }),

--- a/app/api/agents/[id]/deploy/route.ts
+++ b/app/api/agents/[id]/deploy/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
+import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { id } = await params
+    
+    const response = await fetch(`${API_BASE_URL}/api/agents/${id}/deploy`, {
+      method: 'POST',
+      headers: { 
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to deploy agent' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}

--- a/app/api/agents/[id]/logs/route.ts
+++ b/app/api/agents/[id]/logs/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
+import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { id } = await params
+    const { searchParams } = new URL(request.url)
+    const paramsStr = searchParams.toString()
+    
+    const response = await fetch(`${API_BASE_URL}/api/agents/${id}/logs?${paramsStr}`, {
+      headers: { 
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to fetch logs' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}

--- a/app/api/agents/[id]/route.ts
+++ b/app/api/agents/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
+import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { id } = await params
+    
+    const response = await fetch(`${API_BASE_URL}/api/agents/${id}`, {
+      headers: { 
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to fetch agent' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { id } = await params
+    
+    const response = await fetch(`${API_BASE_URL}/api/agents/${id}`, {
+      method: 'DELETE',
+      headers: { 
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    if (response.status === 204) {
+      return new NextResponse(null, { status: 204 })
+    }
+    
+    const payload = await response.json().catch(() => ({ detail: 'Failed to delete agent' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}

--- a/app/api/agents/[id]/stop/route.ts
+++ b/app/api/agents/[id]/stop/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
+import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { id } = await params
+    
+    const response = await fetch(`${API_BASE_URL}/api/agents/${id}/stop`, {
+      method: 'POST',
+      headers: { 
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to stop agent' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}

--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
+import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * CLI-compatible agents endpoint.
+ * Proxies directly to control plane without user filtering.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { searchParams } = new URL(request.url)
+    const params = new URLSearchParams(searchParams)
+    
+    const response = await fetch(`${API_BASE_URL}/api/agents?${params}`, {
+      headers: { 
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to fetch agents' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const body = await req.json()
+    
+    const response = await fetch(`${API_BASE_URL}/api/agents`, {
+      method: 'POST',
+      headers: { 
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to create agent' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}

--- a/app/api/deployments/[id]/events/route.ts
+++ b/app/api/deployments/[id]/events/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
+import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { id } = await params
+    const { searchParams } = new URL(request.url)
+    const paramsStr = searchParams.toString()
+    
+    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}/events?${paramsStr}`, {
+      headers: { 
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to fetch events' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}

--- a/app/api/deployments/[id]/logs/route.ts
+++ b/app/api/deployments/[id]/logs/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
+import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { id } = await params
+    const { searchParams } = new URL(request.url)
+    const paramsStr = searchParams.toString()
+    
+    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}/logs?${paramsStr}`, {
+      headers: { 
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to fetch logs' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}

--- a/app/api/deployments/[id]/metrics/route.ts
+++ b/app/api/deployments/[id]/metrics/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
+import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { id } = await params
+    const { searchParams } = new URL(request.url)
+    const paramsStr = searchParams.toString()
+    
+    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}/metrics?${paramsStr}`, {
+      headers: { 
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to fetch metrics' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}

--- a/app/api/deployments/[id]/restart/route.ts
+++ b/app/api/deployments/[id]/restart/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
+import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { id } = await params
+    
+    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}/restart`, {
+      method: 'POST',
+      headers: { 
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to restart deployment' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}

--- a/app/api/deployments/[id]/route.ts
+++ b/app/api/deployments/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
+import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { id } = await params
+    
+    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}`, {
+      headers: { 
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to fetch deployment' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { id } = await params
+    
+    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}`, {
+      method: 'DELETE',
+      headers: { 
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    if (response.status === 204) {
+      return new NextResponse(null, { status: 204 })
+    }
+    
+    const payload = await response.json().catch(() => ({ detail: 'Failed to delete deployment' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}

--- a/app/api/deployments/[id]/scale/route.ts
+++ b/app/api/deployments/[id]/scale/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
+import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { id } = await params
+    const body = await req.json()
+    
+    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}/scale`, {
+      method: 'POST',
+      headers: { 
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to scale deployment' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}

--- a/app/api/deployments/route.ts
+++ b/app/api/deployments/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
+import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+
+const API_BASE_URL = getApiBaseUrl()
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * CLI-compatible deployments endpoint.
+ * Proxies directly to control plane without user filtering.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const { searchParams } = new URL(request.url)
+    const params = new URLSearchParams(searchParams)
+    
+    // Proxy to control plane
+    const response = await fetch(`${API_BASE_URL}/api/deployments?${params}`, {
+      headers: { 
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to fetch deployments' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return withErrorHandling(async (req: Request) => {
+    const token = await getAuthToken(request)
+    if (!token) {
+      return unauthorized()
+    }
+
+    const body = await req.json()
+    
+    // Proxy to control plane
+    const response = await fetch(`${API_BASE_URL}/api/deployments`, {
+      method: 'POST',
+      headers: { 
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    })
+
+    const payload = await response.json().catch(() => ({ detail: 'Failed to create deployment' }))
+    return NextResponse.json(payload, { status: response.status })
+  })(request)
+}


### PR DESCRIPTION
## Summary

This PR addresses issue #388 by adding CLI-compatible API routes that proxy directly to the control plane, removing the user-filtering logic that was breaking the create/deploy flow.

## Changes

- **New routes**:
  -  - list and create agents (proxies to control plane)
  -  - get and delete individual agent
  -  - deploy an agent
  -  - get agent logs
  -  - stop an agent
  -  - list and create deployments
  -  - get and delete deployment
  -  - scale deployment
  -  - restart deployment
  -  - get deployment events
  -  - get deployment logs
  -  - get deployment metrics

- **Schema update**: Added  field to  validation schema to accept the CLI's create request format

## Why this fixes the issue

The CLI expects to call  and  directly, but the existing routes were only at  and , which include user-filtering logic that doesn't work with CLI's API key authentication. The new routes proxy directly to the control plane without the user filtering.

## Acceptance checklist

- [x] Alias routes at /api/deployments and /api/agents created
- [x] CLI and SDK can now align with actual server contract
- [ ] create/deploy flow works end-to-end (requires integration testing)

## Tests

```
Test Suites: 5 passed, 5 total
Tests:       57 passed, 57 total
```