### PR TITLE
[codex] feat(infra): add API error-rate alert and monitoring URLs

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -73,6 +73,13 @@ The monitoring compose file binds UI and exporter ports to localhost by default.
 Stop it with `cd infrastructure && make monitor-down`.
 Prometheus now loads alerting rules from `infrastructure/monitoring/prometheus/alerts.yml` and scrapes the API via `host.docker.internal:8000` (works for local Docker Desktop + Linux host-gateway mapping). Grafana provisioning and dashboard mounts are resolved relative to `infrastructure/docker/docker-compose.monitoring.yml`, so the stack reads from `../monitoring/grafana/...` when launched from `infrastructure/`.
 
+Default monitoring URLs (when using `.env.monitoring.example` defaults):
+
+- Grafana: `http://localhost:3001`
+- Prometheus UI: `http://localhost:9090`
+- Alertmanager UI: `http://localhost:9093`
+- API metrics endpoint: `http://localhost:8000/metrics`
+
 ## CI Drift Detection
 
 A scheduled GitHub Actions workflow now checks Terraform drift daily for both `staging` and `production` using `terraform plan -detailed-exitcode`:

--- a/infrastructure/monitoring/prometheus/alerts.yml
+++ b/infrastructure/monitoring/prometheus/alerts.yml
@@ -19,6 +19,22 @@ groups:
           summary: "High API p95 latency"
           description: "MUTX API p95 latency is above 1s for 10 minutes."
 
+      - alert: HighApiErrorRate
+        expr: |
+          (
+            sum(rate(http_requests_total{job="mutx-api",status=~"5.."}[5m]))
+            /
+            clamp_min(sum(rate(http_requests_total{job="mutx-api"}[5m])), 0.1)
+          ) > 0.05
+          and
+          sum(rate(http_requests_total{job="mutx-api"}[5m])) > 0.2
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High API 5xx error rate"
+          description: "MUTX API 5xx error rate is above 5% for 10 minutes."
+
       - alert: RedisExporterDown
         expr: up{job="redis-exporter"} == 0
         for: 5m


### PR DESCRIPTION
## Summary
This PR implements a small, production-focused slice of `#314` by adding API error-rate alerting and documenting concrete monitoring URLs for operators.

## User impact
Before this change, the monitoring rules covered API availability and latency, but not sustained server-side error rates. That leaves a blind spot where users can see elevated 5xx failures while the service still appears "up."

After this change, operators get a dedicated critical alert when the API returns too many 5xx responses over time, so incidents are detected earlier and triage can start before broad customer impact escalates.

## Root cause
The Prometheus alert set lacked an explicit error-rate rule tied to `http_requests_total` status labels, and docs did not list the default URLs for the monitoring surfaces.

## What changed
- Added `HighApiErrorRate` alert rule in `infrastructure/monitoring/prometheus/alerts.yml`.
- Alert triggers when:
  - 5xx ratio exceeds 5% over 5 minutes,
  - request volume is above a low-traffic floor (`> 0.2 req/s`) to reduce noise,
  - condition persists for 10 minutes.
- Added a monitoring URL reference block to `infrastructure/README.md` for Grafana, Prometheus, Alertmanager, and API `/metrics`.

## Validation
- Attempted: `cd infrastructure && make monitor-validate`
- Result: could not run in this environment because Docker daemon is unavailable (`docker.sock` not present).
- Fallback sanity check performed: parsed `prometheus.yml` and `alerts.yml` with Ruby `YAML.load_file` to confirm valid YAML structure.

## Scope
This is an incremental step toward `#314` and specifically addresses:
- error-rate alerting
- monitoring URL documentation

Partial for #314.
