### PR TITLE
[codex] fix(cli-sdk): normalize legacy API base URLs

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -1,8 +1,39 @@
-import os
 import json
+import os
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
+
 import httpx
+
+
+_LEGACY_API_SUFFIXES = ("/api/v1", "/v1", "/api")
+
+
+def _strip_legacy_suffix(path: str) -> str:
+    normalized_path = path.rstrip("/")
+
+    for suffix in _LEGACY_API_SUFFIXES:
+        if normalized_path == suffix:
+            return ""
+        if normalized_path.endswith(suffix):
+            return normalized_path[: -len(suffix)] or ""
+
+    return normalized_path
+
+
+def normalize_api_url(value: str) -> str:
+    normalized_value = value.strip().rstrip("/")
+    if not normalized_value:
+        return normalized_value
+
+    # urlsplit mis-parses values like localhost:8000 without a scheme.
+    if "://" not in normalized_value:
+        return _strip_legacy_suffix(normalized_value)
+
+    parsed = urlsplit(normalized_value)
+    normalized_path = _strip_legacy_suffix(parsed.path)
+    return urlunsplit(parsed._replace(path=normalized_path))
 
 
 class CLIConfig:
@@ -16,14 +47,18 @@ class CLIConfig:
         if self.config_path.exists():
             try:
                 with open(self.config_path) as f:
-                    return json.load(f)
+                    loaded = json.load(f)
+                    api_url = loaded.get("api_url")
+                    if isinstance(api_url, str):
+                        loaded["api_url"] = normalize_api_url(api_url)
+                    return loaded
             except (json.JSONDecodeError, IOError):
                 pass
         return self._default_config()
 
     def _default_config(self) -> dict:
         return {
-            "api_url": os.getenv("MUTX_API_URL", "http://localhost:8000"),
+            "api_url": normalize_api_url(os.getenv("MUTX_API_URL", "http://localhost:8000")),
             "api_key": None,
             "refresh_token": None,
         }
@@ -35,15 +70,14 @@ class CLIConfig:
 
     @property
     def api_url(self) -> str:
-        return self._config.get("api_url", "http://localhost:8000")
+        stored_api_url = self._config.get("api_url", "http://localhost:8000")
+        if isinstance(stored_api_url, str):
+            return normalize_api_url(stored_api_url)
+        return "http://localhost:8000"
 
     @api_url.setter
     def api_url(self, value: str):
-        # Strip trailing /api to avoid double-path issues
-        # since CLI commands explicitly add /api prefix
-        if value.endswith("/api"):
-            value = value[:-4]
-        self._config["api_url"] = value
+        self._config["api_url"] = normalize_api_url(value)
         self.save()
 
     @property

--- a/sdk/mutx/__init__.py
+++ b/sdk/mutx/__init__.py
@@ -15,6 +15,7 @@ from mutx.api_keys import APIKeys
 from mutx.clawhub import ClawHub
 from mutx.deployments import Deployments
 from mutx.webhooks import Webhooks
+from mutx._url import normalize_api_base_url
 
 
 class MutxClient:
@@ -25,7 +26,7 @@ class MutxClient:
         timeout: float = 30.0,
     ):
         self.api_key = api_key
-        self.base_url = base_url.rstrip("/")
+        self.base_url = normalize_api_base_url(base_url)
         self.timeout = timeout
 
         self._client = httpx.Client(
@@ -107,7 +108,7 @@ class MutxAsyncClient:
             stacklevel=2,
         )
         self.api_key = api_key
-        self.base_url = base_url.rstrip("/")
+        self.base_url = normalize_api_base_url(base_url)
         self.timeout = timeout
 
         self._client = httpx.AsyncClient(

--- a/sdk/mutx/_url.py
+++ b/sdk/mutx/_url.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from urllib.parse import urlsplit, urlunsplit
+
+_LEGACY_API_SUFFIXES = ("/api/v1", "/v1", "/api")
+
+
+def _strip_legacy_suffix(path: str) -> str:
+    normalized_path = path.rstrip("/")
+
+    for suffix in _LEGACY_API_SUFFIXES:
+        if normalized_path == suffix:
+            return ""
+        if normalized_path.endswith(suffix):
+            return normalized_path[: -len(suffix)] or ""
+
+    return normalized_path
+
+
+def normalize_api_base_url(value: str) -> str:
+    normalized_value = value.strip().rstrip("/")
+    if not normalized_value:
+        return normalized_value
+
+    # urlsplit mis-parses values like localhost:8000 without a scheme.
+    if "://" not in normalized_value:
+        return _strip_legacy_suffix(normalized_value)
+
+    parsed = urlsplit(normalized_value)
+    normalized_path = _strip_legacy_suffix(parsed.path)
+    return urlunsplit(parsed._replace(path=normalized_path))

--- a/sdk/mutx/agent_runtime.py
+++ b/sdk/mutx/agent_runtime.py
@@ -19,6 +19,8 @@ from typing import Any, Callable, Optional
 
 import httpx
 
+from mutx._url import normalize_api_base_url
+
 logger = logging.getLogger(__name__)
 
 
@@ -88,7 +90,7 @@ class MutxAgentClient:
         agent_id: Optional[str] = None,
         timeout: float = 30.0,
     ):
-        self.mutx_url = mutx_url.rstrip("/")
+        self.mutx_url = normalize_api_base_url(mutx_url)
         self.api_key = api_key
         self.agent_id = agent_id
         self.timeout = timeout
@@ -531,7 +533,7 @@ class MutxAgentSyncClient:
         agent_id: Optional[str] = None,
         timeout: float = 30.0,
     ):
-        self.mutx_url = mutx_url.rstrip("/")
+        self.mutx_url = normalize_api_base_url(mutx_url)
         self.api_key = api_key
         self.agent_id = agent_id
         self.timeout = timeout

--- a/tests/test_cli_config_contract.py
+++ b/tests/test_cli_config_contract.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cli.config import CLIConfig, get_client, normalize_api_url
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("https://app.mutx.dev/v1", "https://app.mutx.dev"),
+        ("https://app.mutx.dev/api", "https://app.mutx.dev"),
+        ("https://app.mutx.dev/api/v1", "https://app.mutx.dev"),
+        ("https://gateway.test/control/api/v1", "https://gateway.test/control"),
+        ("http://localhost:8000/v1/", "http://localhost:8000"),
+        ("localhost:8000/api/v1", "localhost:8000"),
+    ],
+)
+def test_normalize_api_url_strips_legacy_suffixes(raw: str, expected: str) -> None:
+    assert normalize_api_url(raw) == expected
+
+
+def test_cli_config_load_normalizes_stale_saved_api_url(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "api_url": "https://app.mutx.dev/api/v1",
+                "api_key": None,
+                "refresh_token": None,
+            }
+        )
+    )
+
+    config = CLIConfig(config_path=config_path)
+
+    assert config.api_url == "https://app.mutx.dev"
+
+
+def test_cli_config_setter_persists_normalized_api_url(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config = CLIConfig(config_path=config_path)
+
+    config.api_url = "https://app.mutx.dev/api/v1/"
+
+    persisted = json.loads(config_path.read_text())
+    assert persisted["api_url"] == "https://app.mutx.dev"
+
+
+def test_cli_default_config_normalizes_mutx_api_url_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MUTX_API_URL", "https://app.mutx.dev/api/v1")
+
+    config = CLIConfig(config_path=tmp_path / "config.json")
+
+    assert config.api_url == "https://app.mutx.dev"
+
+
+def test_get_client_uses_normalized_base_url(tmp_path: Path) -> None:
+    config = CLIConfig(config_path=tmp_path / "config.json")
+    config.api_url = "https://app.mutx.dev/api/v1"
+
+    client = get_client(config)
+    try:
+        assert str(client.base_url).rstrip("/") == "https://app.mutx.dev"
+    finally:
+        client.close()

--- a/tests/test_sdk_base_url_contract.py
+++ b/tests/test_sdk_base_url_contract.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sdk"))
+
+from mutx import MutxAsyncClient, MutxClient
+from mutx._url import normalize_api_base_url
+from mutx.agent_runtime import MutxAgentClient, MutxAgentSyncClient
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("https://app.mutx.dev/v1", "https://app.mutx.dev"),
+        ("https://app.mutx.dev/api", "https://app.mutx.dev"),
+        ("https://app.mutx.dev/api/v1", "https://app.mutx.dev"),
+        ("https://gateway.test/control/api/v1", "https://gateway.test/control"),
+        ("http://localhost:8000/v1/", "http://localhost:8000"),
+        ("localhost:8000/api/v1", "localhost:8000"),
+    ],
+)
+def test_normalize_api_base_url_strips_legacy_suffixes(raw: str, expected: str) -> None:
+    assert normalize_api_base_url(raw) == expected
+
+
+def test_mutx_client_normalizes_legacy_base_url() -> None:
+    client = MutxClient(api_key="test-key", base_url="https://app.mutx.dev/api/v1")
+    try:
+        assert client.base_url == "https://app.mutx.dev"
+        assert str(client._client.base_url).rstrip("/") == "https://app.mutx.dev"
+    finally:
+        client.close()
+
+
+def test_mutx_async_client_normalizes_legacy_base_url() -> None:
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        client = MutxAsyncClient(api_key="test-key", base_url="https://app.mutx.dev/v1")
+
+    try:
+        assert client.base_url == "https://app.mutx.dev"
+        assert str(client._client.base_url).rstrip("/") == "https://app.mutx.dev"
+    finally:
+        asyncio.run(client.aclose())
+
+
+def test_mutx_agent_clients_normalize_legacy_base_url() -> None:
+    async_client = MutxAgentClient(mutx_url="https://app.mutx.dev/api/v1")
+    sync_client = MutxAgentSyncClient(mutx_url="https://app.mutx.dev/v1")
+
+    assert async_client.mutx_url == "https://app.mutx.dev"
+    assert sync_client.mutx_url == "https://app.mutx.dev"


### PR DESCRIPTION
## Summary
This PR closes a remaining CLI/SDK compatibility gap from the #388 contract-alignment work by normalizing stale base URL suffixes before client requests are built.

## User Impact (Cause -> Effect)
Users with legacy config values such as:
- `https://app.mutx.dev/v1`
- `https://app.mutx.dev/api`
- `https://app.mutx.dev/api/v1`

could generate invalid request paths after recent route shifts (for example duplicated version/prefix segments). In practice this breaks create/deploy and other CLI/SDK flows even when the host is correct.

## Root Cause
CLI and SDK clients accepted `api_url`/`base_url` as-is. As route prefixes evolved (`/v1` and `/api` compatibility), stale stored URLs were not canonicalized, so request paths could be composed with duplicate legacy segments.

## Fix
- Added deterministic URL normalization helpers that strip trailing legacy suffixes: `/api/v1`, `/v1`, and `/api`.
- Applied normalization in:
  - `cli/config.py` load/default/getter/setter paths.
  - `MutxClient` and `MutxAsyncClient` constructors.
  - `MutxAgentClient` and `MutxAgentSyncClient` constructors.
- Added contract tests for both CLI and SDK normalization behavior, including scheme-less host inputs and nested path prefixes.

## Validation
Executed:
- `pytest -q tests/test_cli_config_contract.py tests/test_sdk_base_url_contract.py`
- `pytest -q tests/test_cli_config_contract.py tests/test_sdk_base_url_contract.py tests/test_cli_agents_contract.py tests/test_cli_deploy_contract.py tests/test_cli_webhooks_contract.py tests/test_sdk_async_client_contract.py`

Both runs passed.

## Issue Sweep Notes
- Priority issue `#388` is already closed/merged via PR `#473`.
- Current open issue scan for labels `area:cli-sdk` and `area:sdk` returned no open issues at the time of implementation.
- This PR is a follow-up hardening patch for legacy config compatibility.
