### PR TITLE
fix(tests): update SDK contract test paths to use /api prefix

### DIFF
--- a/tests/test_sdk_agent_config_contract.py
+++ b/tests/test_sdk_agent_config_contract.py
@@ -56,7 +56,7 @@ def test_agents_create_accepts_dict_config_and_sends_backend_json_string_contrac
         config={"model": "gpt-4o", "temperature": 0.1},
     )
 
-    assert captured["path"] == "/agents"
+    assert captured["path"] == "/api/agents"
     assert isinstance(captured["json"]["config"], dict)
     assert captured["json"]["config"]["model"] == "gpt-4o"
 

--- a/tests/test_sdk_api_keys_contract.py
+++ b/tests/test_sdk_api_keys_contract.py
@@ -60,7 +60,7 @@ def test_api_keys_list_hits_contract_route() -> None:
 
     api_keys.list()
 
-    assert captured["path"] == "/api-keys"
+    assert captured["path"] == "/api/api-keys"
     assert captured["method"] == "GET"
 
 
@@ -78,7 +78,7 @@ def test_api_keys_alist_hits_contract_route() -> None:
     import asyncio
     asyncio.run(api_keys.alist())
 
-    assert captured["path"] == "/api-keys"
+    assert captured["path"] == "/api/api-keys"
     assert captured["method"] == "GET"
 
 
@@ -96,7 +96,7 @@ def test_api_keys_create_hits_contract_route_and_maps_payload() -> None:
 
     api_keys.create(name="my-key", expires_in_days=30)
 
-    assert captured["path"] == "/api-keys"
+    assert captured["path"] == "/api/api-keys"
     assert captured["method"] == "POST"
     assert captured["json"]["name"] == "my-key"
     assert captured["json"]["expires_in_days"] == 30
@@ -132,7 +132,7 @@ def test_api_keys_acreate_hits_contract_route() -> None:
     import asyncio
     asyncio.run(api_keys.acreate(name="async-key"))
 
-    assert captured["path"] == "/api-keys"
+    assert captured["path"] == "/api/api-keys"
     assert captured["method"] == "POST"
 
 
@@ -150,7 +150,7 @@ def test_api_keys_revoke_hits_contract_route() -> None:
 
     api_keys.revoke(key_id)
 
-    assert captured["path"] == f"/api-keys/{key_id}"
+    assert captured["path"] == f"/api/api-keys/{key_id}"
     assert captured["method"] == "DELETE"
 
 
@@ -169,7 +169,7 @@ def test_api_keys_arevoke_hits_contract_route() -> None:
     import asyncio
     asyncio.run(api_keys.arevoke(key_id))
 
-    assert captured["path"] == f"/api-keys/{key_id}"
+    assert captured["path"] == f"/api/api-keys/{key_id}"
     assert captured["method"] == "DELETE"
 
 
@@ -187,7 +187,7 @@ def test_api_keys_rotate_hits_contract_route() -> None:
 
     result = api_keys.rotate(key_id)
 
-    assert captured["path"] == f"/api-keys/{key_id}/rotate"
+    assert captured["path"] == f"/api/api-keys/{key_id}/rotate"
     assert captured["method"] == "POST"
     assert isinstance(result, APIKeyWithSecret)
 
@@ -207,7 +207,7 @@ def test_api_keys_arotate_hits_contract_route() -> None:
     import asyncio
     result = asyncio.run(api_keys.arotate(key_id))
 
-    assert captured["path"] == f"/api-keys/{key_id}/rotate"
+    assert captured["path"] == f"/api/api-keys/{key_id}/rotate"
     assert captured["method"] == "POST"
     assert isinstance(result, APIKeyWithSecret)
 

--- a/tests/test_sdk_async_resources_contract.py
+++ b/tests/test_sdk_async_resources_contract.py
@@ -89,7 +89,7 @@ async def test_agents_async_methods_are_awaited_with_async_client() -> None:
         agents = Agents(client)
         agent = await agents.acreate(name="async-agent", config={"model": "gpt-4o"})
 
-    assert captured["path"] == "/agents"
+    assert captured["path"] == "/api/agents"
     assert captured["json"]["name"] == "async-agent"
     assert captured["json"]["config"]["model"] == "gpt-4o"
     assert agent.name == "async-agent"
@@ -123,7 +123,7 @@ async def test_deployments_async_methods_are_awaited_with_async_client() -> None
         deployments = Deployments(client)
         deployment = await deployments.acreate(str(uuid.uuid4()), replicas=2)
 
-    assert captured["path"] == "/deployments"
+    assert captured["path"] == "/api/deployments"
     assert deployment.status in {"running", "pending", "creating"}
 
 
@@ -142,7 +142,7 @@ async def test_api_keys_async_methods_are_awaited_with_async_client() -> None:
         api_keys = APIKeys(client)
         key = await api_keys.acreate("test-key")
 
-    assert captured["path"] == "/api-keys"
+    assert captured["path"] == "/api/api-keys"
     assert key.name == "ci-key"
     assert key.key == "mutx_test_key"
 
@@ -162,6 +162,6 @@ async def test_webhooks_async_methods_are_awaited_with_async_client() -> None:
         webhooks = Webhooks(client)
         webhook = await webhooks.acreate(url="https://example.com/hook", events=["agent.started"])
 
-    assert captured["path"] == "/webhooks/"
+    assert captured["path"] == "/api/webhooks/"
     assert webhook.url == "https://example.com/webhook"
     assert webhook.events == ["agent.started", "agent.stopped"]

--- a/tests/test_sdk_clawhub_contract.py
+++ b/tests/test_sdk_clawhub_contract.py
@@ -30,7 +30,7 @@ def _skill_payload(**overrides: Any) -> dict[str, Any]:
 
 def test_clawhub_list_skills_parses_sync_skill_payloads() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == "/clawhub/skills"
+        assert request.url.path == "/api/clawhub/skills"
         return httpx.Response(200, json=[_skill_payload()])
 
     client = httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler))
@@ -46,7 +46,7 @@ def test_clawhub_list_skills_parses_sync_skill_payloads() -> None:
 @pytest.mark.asyncio
 async def test_clawhub_alist_skills_parses_async_skill_payloads() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == "/clawhub/skills"
+        assert request.url.path == "/api/clawhub/skills"
         return httpx.Response(200, json=[_skill_payload(name="async-skill")])
 
     async with httpx.AsyncClient(
@@ -79,7 +79,7 @@ async def test_clawhub_ainstall_skill_returns_json_without_awaiting_plain_dict()
 
         result = await clawhub.ainstall_skill(agent_id=uuid.uuid4(), skill_id="skill-demo")
 
-    assert captured["path"] == "/clawhub/install"
+    assert captured["path"] == "/api/clawhub/install"
     assert captured["json"]["skill_id"] == "skill-demo"
     assert result["ok"] is True
 
@@ -101,6 +101,6 @@ async def test_clawhub_auninstall_skill_returns_json_without_awaiting_plain_dict
 
         result = await clawhub.auninstall_skill(agent_id=uuid.uuid4(), skill_id="skill-demo")
 
-    assert captured["path"] == "/clawhub/uninstall"
+    assert captured["path"] == "/api/clawhub/uninstall"
     assert captured["json"]["skill_id"] == "skill-demo"
     assert result["ok"] is True

--- a/tests/test_sdk_deployments_contract.py
+++ b/tests/test_sdk_deployments_contract.py
@@ -81,7 +81,7 @@ def test_deployments_create_hits_canonical_route_and_maps_payload() -> None:
     with httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler)) as client:
         deployment = Deployments(client).create(agent_id, replicas=3)
 
-    assert captured["path"] == "/deployments"
+    assert captured["path"] == "/api/deployments"
     assert json.loads(captured["body"]) == {"agent_id": str(agent_id), "replicas": 3}
     assert deployment.agent_id == agent_id
     assert deployment.status == "pending"
@@ -107,7 +107,7 @@ async def test_deployments_acreate_hits_canonical_route_and_maps_payload() -> No
     ) as client:
         deployment = await Deployments(client).acreate(agent_id, replicas=2)
 
-    assert captured["path"] == "/deployments"
+    assert captured["path"] == "/api/deployments"
     assert json.loads(captured["body"]) == {"agent_id": str(agent_id), "replicas": 2}
     assert deployment.agent_id == agent_id
     assert deployment.status == "pending"
@@ -126,7 +126,7 @@ def test_deployments_restart_hits_contract_route_and_maps_payload() -> None:
     with httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler)) as client:
         deployment = Deployments(client).restart(deployment_id)
 
-    assert captured["path"] == f"/deployments/{deployment_id}/restart"
+    assert captured["path"] == f"/api/deployments/{deployment_id}/restart"
     assert captured["body"] == ""
     assert deployment.id == deployment_id
     assert deployment.status == "pending"
@@ -148,7 +148,7 @@ async def test_deployments_arestart_hits_contract_route_and_maps_payload() -> No
     ) as client:
         deployment = await Deployments(client).arestart(deployment_id)
 
-    assert captured["path"] == f"/deployments/{deployment_id}/restart"
+    assert captured["path"] == f"/api/deployments/{deployment_id}/restart"
     assert captured["body"] == ""
     assert deployment.id == deployment_id
     assert deployment.status == "pending"
@@ -180,7 +180,7 @@ def test_deployments_events_hits_contract_route_and_maps_payload() -> None:
             status="failed",
         )
 
-    assert captured["path"] == f"/deployments/{deployment_id}/events"
+    assert captured["path"] == f"/api/deployments/{deployment_id}/events"
     assert captured["query"] == {
         "skip": "3",
         "limit": "25",
@@ -209,7 +209,7 @@ async def test_deployments_aevents_hits_contract_route_and_maps_payload() -> Non
     ) as client:
         history = await Deployments(client).aevents(deployment_id, skip=1, limit=10)
 
-    assert captured["path"] == f"/deployments/{deployment_id}/events"
+    assert captured["path"] == f"/api/deployments/{deployment_id}/events"
     assert captured["query"] == {"skip": "1", "limit": "10"}
     assert history.deployment_id == deployment_id
     assert history.items[0].status == "running"
@@ -281,7 +281,7 @@ def test_deployments_logs_support_level_filter_param() -> None:
         payload = Deployments(client).logs(deployment_id, skip=2, limit=50, level="ERROR")
 
     assert payload == []
-    assert captured["path"] == f"/deployments/{deployment_id}/logs"
+    assert captured["path"] == f"/api/deployments/{deployment_id}/logs"
     assert captured["query"] == {"skip": "2", "limit": "50", "level": "ERROR"}
 
 
@@ -302,7 +302,7 @@ async def test_deployments_alogs_support_level_filter_param() -> None:
         payload = await Deployments(client).alogs(deployment_id, skip=4, limit=75, level="INFO")
 
     assert payload == []
-    assert captured["path"] == f"/deployments/{deployment_id}/logs"
+    assert captured["path"] == f"/api/deployments/{deployment_id}/logs"
     assert captured["query"] == {"skip": "4", "limit": "75", "level": "INFO"}
 
 
@@ -318,7 +318,7 @@ def test_deployments_metrics_hits_contract_route_and_query_params() -> None:
     with httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler)) as client:
         payload = Deployments(client).metrics(deployment_id, skip=5, limit=15)
 
-    assert captured["path"] == f"/deployments/{deployment_id}/metrics"
+    assert captured["path"] == f"/api/deployments/{deployment_id}/metrics"
     assert captured["query"] == {"skip": "5", "limit": "15"}
     assert payload[0]["cpu_usage"] == 0.61
     assert payload[0]["memory_usage"] == 0.44
@@ -340,6 +340,6 @@ async def test_deployments_ametrics_hits_contract_route_and_query_params() -> No
     ) as client:
         payload = await Deployments(client).ametrics(deployment_id, skip=6, limit=12)
 
-    assert captured["path"] == f"/deployments/{deployment_id}/metrics"
+    assert captured["path"] == f"/api/deployments/{deployment_id}/metrics"
     assert captured["query"] == {"skip": "6", "limit": "12"}
     assert payload[0]["cpu_usage"] == 0.61

--- a/tests/test_sdk_webhooks_contract.py
+++ b/tests/test_sdk_webhooks_contract.py
@@ -51,7 +51,7 @@ def test_webhooks_create_uses_trailing_slash_route_and_is_active_contract_field(
         is_active=False,
     )
 
-    assert captured["path"] == "/webhooks/"
+    assert captured["path"] == "/api/webhooks/"
     assert captured["json"]["is_active"] is False
     assert "active" not in captured["json"]
 
@@ -112,7 +112,7 @@ def test_webhooks_get_deliveries_uses_live_backend_route_and_filters() -> None:
         webhook_id, limit=10, skip=5, event="agent.status", success=False
     )
 
-    assert captured["path"] == f"/webhooks/{webhook_id}/deliveries"
+    assert captured["path"] == f"/api/webhooks/{webhook_id}/deliveries"
     assert captured["params"] == {
         "skip": "5",
         "limit": "10",


### PR DESCRIPTION
## Summary
Fixes failing SDK contract tests that expected legacy API paths without the  prefix.

## Changes
Updated test expectations in 6 test files to match the actual SDK routes:
- 
- 
- 
- 
- 
- 

The SDK uses  prefix for all routes (e.g., , , ).

## Validation
```
pytest -q tests/
253 passed, 2 warnings
```

## Edge Cases
- CLI contract tests still use `/v1/` prefix (correct - CLI and SDK have different base paths)
- Backend API routes use `/api/` prefix (correct)
- Tests for async methods also updated (paired with sync methods)