### PR TITLE
fix(frontend): preserve agent state on stop response

### DIFF
--- a/components/app/AgentsPageClient.tsx
+++ b/components/app/AgentsPageClient.tsx
@@ -65,8 +65,8 @@ async function deleteAgent(agentId: string): Promise<void> {
   }
 }
 
-async function stopAgent(agentId: string): Promise<Agent> {
-  return readJson<Agent>(`/api/agents/${encodeURIComponent(agentId)}/stop`, {
+async function stopAgent(agentId: string): Promise<{ status: string }> {
+  return readJson<{ status: string }>(`/api/agents/${encodeURIComponent(agentId)}/stop`, {
     method: "POST",
     cache: "no-store",
   });
@@ -565,8 +565,12 @@ export function AgentsPageClient() {
 
     setStoppingId(agentId);
     try {
-      const updated = await stopAgent(agentId);
-      setAgents((prev) => prev.map((a) => (a.id === agentId ? updated : a)));
+      await stopAgent(agentId);
+      setAgents((prev) =>
+        prev.map((agent) =>
+          agent.id === agentId ? { ...agent, status: "stopped" } : agent,
+        ),
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to stop agent");
     } finally {


### PR DESCRIPTION
### Motivation
- The frontend assumed the stop endpoint returned a full `Agent` and replaced the agent in local state with that response, but the backend only returns `{ status: "stopped" }`, which could leave agent entries missing `id`/`name` and break filtering/rendering. 
- The change prevents a functional regression where stopping an agent could corrupt the agents list and trigger the error boundary. 

### Description
- Update `stopAgent` to parse the stop endpoint as `{ status: string }` instead of a full `Agent` by changing its return type and `readJson` invocation in `components/app/AgentsPageClient.tsx`.
- Change `handleStop` to not replace the agent entry with the stop response; instead it updates the existing agent object and sets `status` to `"stopped"` after a successful stop request.
- These changes preserve existing agent fields (like `id`, `name`, `description`) and avoid runtime `TypeError`s during filtering and rendering.

### Testing
- Ran `npm run lint` and the run completed with no ESLint warnings or errors.
- Local static inspection and codeflow review confirm `stopAgent` now expects `{ status: string }` and `handleStop` updates only the `status` field, preventing the previously observed state corruption.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6f89ce4c4832a9ca9bad035a455cb)