### PR TITLE
fix: harden middleware rate limiter against spoofing and map growth

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,18 +4,41 @@ import { NextResponse } from 'next/server'
 // Rate limiting configuration
 const RATE_LIMIT = 100 // requests per window
 const RATE_LIMIT_WINDOW = 60 * 1000 // 1 minute in ms
+const MAX_RATE_LIMIT_ENTRIES = 10_000
 const rateLimitMap = new Map<string, { count: number; resetTime: number }>()
 
 function getClientIp(request: NextRequest): string {
-  return request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-         request.headers.get('x-real-ip') ||
-         request.ip ||
-         'unknown'
+  return request.ip || 'unknown'
+}
+
+function pruneRateLimitMap(now: number) {
+  for (const [ip, record] of rateLimitMap.entries()) {
+    if (now > record.resetTime) {
+      rateLimitMap.delete(ip)
+    }
+  }
+
+  if (rateLimitMap.size < MAX_RATE_LIMIT_ENTRIES) {
+    return
+  }
+
+  const overflow = rateLimitMap.size - MAX_RATE_LIMIT_ENTRIES + 1
+  let removed = 0
+
+  for (const ip of rateLimitMap.keys()) {
+    rateLimitMap.delete(ip)
+    removed++
+
+    if (removed >= overflow) {
+      break
+    }
+  }
 }
 
 function checkRateLimit(request: NextRequest): { allowed: boolean; remaining: number; resetTime: number } {
   const ip = getClientIp(request)
   const now = Date.now()
+  pruneRateLimitMap(now)
   const record = rateLimitMap.get(ip)
 
   if (!record || now > record.resetTime) {


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory growth and rate-limit bypass caused by keying the in-memory rate limiter on untrusted headers (`x-forwarded-for`/`x-real-ip`) and never evicting old entries.
- Ensure the rate limiter remains effective for real clients while bounding process memory usage and preserving existing middleware behavior and headers.

### Description
- Stop trusting header-based client identity and use `request.ip` for rate-limit keys instead of `x-forwarded-for`/`x-real-ip`.
- Add `MAX_RATE_LIMIT_ENTRIES = 10000` and implement `pruneRateLimitMap(now)` to remove expired entries and evict oldest keys when the map exceeds the cap.
- Call `pruneRateLimitMap()` at the start of `checkRateLimit()` so stale records are removed before lookup and updates.
- Preserve existing response behavior and rate-limit headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`) for `/api/*` routes.

### Testing
- Ran `npm run test:app` which executed unit tests and reported `Test Suites: 5 passed, 5 total` and `Tests: 59 passed, 59 total`, so all unit tests passed.
- Ran `npm run lint` which completed with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6f5d7ad7c832abca94d24c5321ebb)