### PR TITLE
Harden /auth routes to require JWT bearer tokens

### DIFF
--- a/src/api/middleware/auth.py
+++ b/src/api/middleware/auth.py
@@ -15,8 +15,9 @@ async def _resolve_user_from_bearer_token(
     session: AsyncSession,
     *,
     user_service: UserService | None = None,
+    allow_api_key_fallback: bool = True,
 ) -> Optional[User]:
-    """Resolve an active user from a bearer token (JWT first, then API key fallback)."""
+    """Resolve an active user from a bearer token."""
     service = user_service or UserService(session)
 
     user_id = verify_access_token(token)
@@ -25,9 +26,10 @@ async def _resolve_user_from_bearer_token(
         if user and user.is_active:
             return user
 
-    user = await service.get_user_for_api_key(token)
-    if user and user.is_active:
-        return user
+    if allow_api_key_fallback:
+        user = await service.get_user_for_api_key(token)
+        if user and user.is_active:
+            return user
 
     return None
 
@@ -53,7 +55,49 @@ async def get_current_user(
 
     token = parts[1]
     user_service = UserService(session)
-    user = await _resolve_user_from_bearer_token(token, session, user_service=user_service)
+    user = await _resolve_user_from_bearer_token(
+        token,
+        session,
+        user_service=user_service,
+        allow_api_key_fallback=True,
+    )
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return user
+
+
+async def get_current_user_jwt_only(
+    authorization: Optional[str] = Header(None),
+    session: AsyncSession = Depends(get_db),
+) -> User:
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing authorization header",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    parts = authorization.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authorization header format",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token = parts[1]
+    user_service = UserService(session)
+    user = await _resolve_user_from_bearer_token(
+        token,
+        session,
+        user_service=user_service,
+        allow_api_key_fallback=False,
+    )
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -117,7 +161,12 @@ async def get_current_user_or_api_key(
         parts = authorization.split()
         if len(parts) == 2 and parts[0].lower() == "bearer":
             token = parts[1]
-            user = await _resolve_user_from_bearer_token(token, session, user_service=user_service)
+            user = await _resolve_user_from_bearer_token(
+                token,
+                session,
+                user_service=user_service,
+                allow_api_key_fallback=True,
+            )
             if user:
                 return user
 

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.api.database import get_db
 from src.api.models.models import User
 from src.api.services.user_service import UserService
-from src.api.middleware.auth import get_current_user
+from src.api.middleware.auth import get_current_user_jwt_only
 from src.api.auth.jwt import (
     create_access_token,
     create_refresh_token,
@@ -148,12 +148,12 @@ async def refresh(request: RefreshRequest, session: AsyncSession = Depends(get_d
 
 
 @router.post("/logout")
-async def logout(current_user: User = Depends(get_current_user)):
+async def logout(current_user: User = Depends(get_current_user_jwt_only)):
     return {"message": "Successfully logged out"}
 
 
 @router.get("/me", response_model=UserResponse)
-async def get_me(current_user: User = Depends(get_current_user)):
+async def get_me(current_user: User = Depends(get_current_user_jwt_only)):
     return UserResponse(
         id=str(current_user.id),
         email=current_user.email,

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -65,6 +65,25 @@ class TestAuthEndpoints:
         assert data["email"] == test_user.email
         assert data["id"] == str(test_user.id)
 
+
+    @pytest.mark.asyncio
+    async def test_me_endpoint_rejects_bearer_api_key(
+        self, client: AsyncClient, client_no_auth: AsyncClient
+    ):
+        """Test /me endpoint only accepts JWT bearer tokens, not API keys."""
+        key_response = await client.post(
+            "/api/api-keys",
+            json={"name": "auth-me-key"},
+        )
+        assert key_response.status_code == 201
+        managed_api_key = key_response.json()["key"]
+
+        response = await client_no_auth.get(
+            "/api/auth/me",
+            headers={"Authorization": f"Bearer {managed_api_key}"},
+        )
+        assert response.status_code == 401
+
     @pytest.mark.asyncio
     async def test_register_duplicate_email(self, client_no_auth: AsyncClient, db_session: AsyncSession):
         """Test registering with an existing email fails."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,7 +138,11 @@ async def db_session(test_engine) -> AsyncGenerator[AsyncSession, None]:
 async def client(db_session: AsyncSession, test_user):
     """Create test client with database and auth overrides."""
     from src.api.database import get_db
-    from src.api.middleware.auth import get_current_user, get_current_user_or_api_key
+    from src.api.middleware.auth import (
+        get_current_user,
+        get_current_user_jwt_only,
+        get_current_user_or_api_key,
+    )
     from src.api.routes.webhooks import get_webhook_auth
     from src.api.routes.ingest import get_ingest_auth
     
@@ -156,6 +160,9 @@ async def client(db_session: AsyncSession, test_user):
     async def override_get_current_user_or_api_key():
         return test_user
 
+    async def override_get_current_user_jwt_only():
+        return test_user
+
     async def override_get_webhook_auth():
         return test_user
 
@@ -165,6 +172,7 @@ async def client(db_session: AsyncSession, test_user):
     # Override dependencies
     test_app.dependency_overrides[get_db] = override_get_db
     test_app.dependency_overrides[get_current_user] = override_get_current_user
+    test_app.dependency_overrides[get_current_user_jwt_only] = override_get_current_user_jwt_only
     test_app.dependency_overrides[get_current_user_or_api_key] = override_get_current_user_or_api_key
     test_app.dependency_overrides[get_webhook_auth] = override_get_webhook_auth
     test_app.dependency_overrides[get_ingest_auth] = override_get_ingest_auth
@@ -205,7 +213,11 @@ async def client_no_auth(db_session: AsyncSession):
 async def other_user_client(db_session: AsyncSession, other_user):
     """Create test client authenticated as other_user."""
     from src.api.database import get_db
-    from src.api.middleware.auth import get_current_user, get_current_user_or_api_key
+    from src.api.middleware.auth import (
+        get_current_user,
+        get_current_user_jwt_only,
+        get_current_user_or_api_key,
+    )
     from src.api.routes.webhooks import get_webhook_auth
     from src.api.routes.ingest import get_ingest_auth
     
@@ -220,6 +232,9 @@ async def other_user_client(db_session: AsyncSession, other_user):
     async def override_get_current_user_or_api_key():
         return other_user
 
+    async def override_get_current_user_jwt_only():
+        return other_user
+
     async def override_get_webhook_auth():
         return other_user
 
@@ -228,6 +243,7 @@ async def other_user_client(db_session: AsyncSession, other_user):
     
     test_app.dependency_overrides[get_db] = override_get_db
     test_app.dependency_overrides[get_current_user] = override_get_current_user
+    test_app.dependency_overrides[get_current_user_jwt_only] = override_get_current_user_jwt_only
     test_app.dependency_overrides[get_current_user_or_api_key] = override_get_current_user_or_api_key
     test_app.dependency_overrides[get_webhook_auth] = override_get_webhook_auth
     test_app.dependency_overrides[get_ingest_auth] = override_get_ingest_auth


### PR DESCRIPTION
### Motivation
- A recent change allowed API-key fallback when resolving Bearer tokens, which made JWT-only endpoints (e.g., `/api/auth/me`) accept managed API keys and could leak the user's legacy `api_key`.
- The goal is to prevent API keys from authenticating on JWT-only `/api/auth/*` routes while preserving API-key automation workflows for non-auth routes.

### Description
- Added an `allow_api_key_fallback: bool` parameter to `_resolve_user_from_bearer_token` and defaulted it to allow fallback while making it configurable (`src/api/middleware/auth.py`).
- Implemented a new JWT-only dependency `get_current_user_jwt_only` that calls `_resolve_user_from_bearer_token(..., allow_api_key_fallback=False)` and used it for `/api/auth/logout` and `/api/auth/me` to enforce JWT-only auth (`src/api/routes/auth.py`).
- Preserved existing API-key compatibility for automation flows by keeping fallback enabled in `get_current_user` and `get_current_user_or_api_key` used by API key and webhook endpoints (`src/api/middleware/auth.py`, `src/api/routes/webhooks.py` usage unchanged).
- Added a regression test ensuring `/api/auth/me` rejects a managed API key presented as `Authorization: Bearer ...` and updated test dependency overrides to wire the new JWT-only dependency (`tests/api/test_auth.py`, `tests/conftest.py`).

### Testing
- Installed test dependency with `pip install pytest-asyncio -q` to enable async tests which initially failed to load.
- Ran `pytest -q tests/api/test_api_keys.py::TestBearerAPIKeyAuth::test_list_api_keys_with_bearer_managed_api_key tests/api/test_auth.py::TestAuthEndpoints::test_me_endpoint_rejects_bearer_api_key tests/api/test_auth.py::TestAuthEndpoints::test_me_endpoint` and all three tests passed.
- Ran `pytest -q tests/api/test_webhooks.py::test_webhook_create_supports_managed_api_key_in_bearer_header` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6dfe377b4832aaa7550e44f7f7e10)