### PR TITLE
Fix timezone-aware created_at crash in monitor heartbeat check

### DIFF
--- a/src/api/services/monitor.py
+++ b/src/api/services/monitor.py
@@ -26,7 +26,10 @@ def _agent_heartbeat_check(agent_id: str):
             if not last_heartbeat:
                 return False
 
-            return (datetime.now(timezone.utc).replace(tzinfo=None) - last_heartbeat) <= timedelta(
+            if last_heartbeat.tzinfo is None:
+                last_heartbeat = last_heartbeat.replace(tzinfo=timezone.utc)
+
+            return (datetime.now(timezone.utc) - last_heartbeat) <= timedelta(
                 seconds=STALE_THRESHOLD_SECONDS,
             )
 

--- a/tests/api/test_monitor.py
+++ b/tests/api/test_monitor.py
@@ -175,6 +175,10 @@ async def test_agent_heartbeat_check_uses_stale_threshold_and_created_at_fallbac
         last_heartbeat=None,
         created_at=now - timedelta(seconds=STALE_THRESHOLD_SECONDS - 1),
     )
+    with_only_created_at_timezone_aware = SimpleNamespace(
+        last_heartbeat=None,
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=STALE_THRESHOLD_SECONDS - 1),
+    )
     without_timestamps = SimpleNamespace(last_heartbeat=None, created_at=None)
 
     agent_id = str(uuid.uuid4())
@@ -199,6 +203,16 @@ async def test_agent_heartbeat_check_uses_stale_threshold_and_created_at_fallbac
         monitor_module.database_module,
         "async_session_maker",
         lambda: _fake_session_maker(_FakeExecuteResult(scalar_value=with_only_created_at)),
+    )
+    check = monitor_module._agent_heartbeat_check(agent_id)
+    assert await check() is True
+
+    monkeypatch.setattr(
+        monitor_module.database_module,
+        "async_session_maker",
+        lambda: _fake_session_maker(
+            _FakeExecuteResult(scalar_value=with_only_created_at_timezone_aware)
+        ),
     )
     check = monitor_module._agent_heartbeat_check(agent_id)
     assert await check() is True


### PR DESCRIPTION
### Motivation
- The background self-healing heartbeat check mixed naive and timezone-aware datetimes when `Agent.created_at` became timezone-aware, causing a `TypeError` for agents without a `last_heartbeat` and breaking health checks.

### Description
- Normalize the timestamp used for age comparison by converting a naive `last_heartbeat` (or `created_at` fallback) to UTC-aware before subtraction in `src/api/services/monitor.py` inside `_agent_heartbeat_check`.
- Compare directly against `datetime.now(timezone.utc)` instead of stripping tzinfo to avoid naive/aware mixing and exceptions.
- Add a regression case to `tests/api/test_monitor.py` that covers the fallback path where `last_heartbeat` is `None` and `created_at` is timezone-aware to ensure the check handles aware datetimes.

### Testing
- Ran `python -m py_compile src/api/services/monitor.py tests/api/test_monitor.py` which succeeded to validate syntax.
- Attempted `pytest -q tests/api/test_monitor.py` but it failed in this environment due to a missing test dependency (`ModuleNotFoundError: No module named 'pytest_asyncio'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6dc110130832aa519c2a1c6c0e81b)