### PR TITLE
fix: prevent crash in plan limit check by counting deployments via agent owner

### DIFF
--- a/src/api/services/user_service.py
+++ b/src/api/services/user_service.py
@@ -216,7 +216,10 @@ class UserService:
             current_count = result.scalar() or 0
         elif resource == "deployments":
             result = await self.session.execute(
-                select(func.count()).select_from(Deployment).where(Deployment.user_id == user_id)
+                select(func.count())
+                .select_from(Deployment)
+                .join(Agent, Deployment.agent_id == Agent.id)
+                .where(Agent.user_id == user_id)
             )
             current_count = result.scalar() or 0
         elif resource == "api_keys":


### PR DESCRIPTION
### Motivation
- Fix a runtime `AttributeError` in `UserService.check_plan_limits` where the code queried a non-existent `Deployment.user_id`; the intent is to enforce per-user deployment limits based on agent ownership without causing server errors.

### Description
- Replace the invalid `Deployment.user_id == user_id` filter with a join from `Deployment` to `Agent` and `where(Agent.user_id == user_id)` in `src/api/services/user_service.py` so deployment counts are computed via the agent owner.

### Testing
- Verified the updated SQLAlchemy statement with a small Python snippet (built the `select(func.count())` + `join` query), confirmed the file compiles with `python -m compileall src/api/services/user_service.py`, and attempted `pytest tests/api/test_deployments.py -q` which could not run due to a missing `pytest_asyncio` dependency in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6ad67c38c832ab10b2aa27a24825f)