### PR TITLE
fix(api): normalize naive datetimes in expiry checks

### DIFF
--- a/src/api/services/user_service.py
+++ b/src/api/services/user_service.py
@@ -41,6 +41,13 @@ def verify_api_key(plain_key: str, hashed_key: str) -> bool:
         return False
 
 
+def as_utc_datetime(value: datetime) -> datetime:
+    """Normalize datetimes to timezone-aware UTC for safe comparisons."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
 class UserService:
     def __init__(self, session: AsyncSession):
         self.session = session
@@ -146,7 +153,9 @@ class UserService:
 
         for api_key in api_keys:
             if verify_api_key(plain_key, api_key.key_hash):
-                if api_key.expires_at and api_key.expires_at < datetime.now(timezone.utc):
+                if api_key.expires_at and as_utc_datetime(api_key.expires_at) < datetime.now(
+                    timezone.utc
+                ):
                     return None
                 await self.update_api_key_last_used(api_key.id)
                 return api_key
@@ -277,7 +286,9 @@ class UserService:
             return None
 
         # Check if token is expired
-        if user.password_reset_expires_at and user.password_reset_expires_at < datetime.now(timezone.utc):
+        if user.password_reset_expires_at and as_utc_datetime(
+            user.password_reset_expires_at
+        ) < datetime.now(timezone.utc):
             return None
 
         # Update password and clear reset token

--- a/tests/api/test_api_keys.py
+++ b/tests/api/test_api_keys.py
@@ -4,6 +4,7 @@ Tests for /api-keys endpoints.
 
 import hashlib
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from httpx import AsyncClient
@@ -300,3 +301,28 @@ class TestVerifyAPIKeyCompatibility:
         plain_key = "mutx_live_legacy_example"
         legacy_hash = hashlib.sha256(plain_key.encode()).hexdigest()
         assert verify_api_key(plain_key, legacy_hash)
+
+
+class TestAPIKeyExpirationComparison:
+    """Tests for API key expiration comparisons with naive DB timestamps."""
+
+    @pytest.mark.asyncio
+    async def test_verify_api_key_handles_naive_expiration_datetime(
+        self, db_session: AsyncSession, test_user
+    ):
+        """Naive expires_at values from DB should not crash verification."""
+        from src.api.services.user_service import UserService
+
+        service = UserService(db_session)
+        api_key, plain_key = await service.create_api_key(
+            user_id=test_user.id,
+            name="expiring-key",
+            expires_in_days=1,
+        )
+
+        api_key.expires_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=1)
+        await db_session.commit()
+
+        verified_key = await service.verify_api_key(plain_key, test_user.id)
+
+        assert verified_key is None

--- a/tests/api/test_password_reset.py
+++ b/tests/api/test_password_reset.py
@@ -1,0 +1,28 @@
+"""Tests for password reset token handling."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.services.user_service import UserService
+
+
+class TestPasswordResetExpiration:
+    """Tests for password reset expiration comparisons."""
+
+    @pytest.mark.asyncio
+    async def test_reset_password_handles_naive_expiration_datetime(
+        self, db_session: AsyncSession, test_user
+    ):
+        """Naive expiration timestamps from DB should not crash password reset."""
+        service = UserService(db_session)
+        token = await service.create_password_reset_token(test_user.id)
+
+        test_user.password_reset_token = token
+        test_user.password_reset_expires_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=1)
+        await db_session.commit()
+
+        result = await service.reset_password(token, "new-password")
+
+        assert result is None


### PR DESCRIPTION
### Motivation
- The service started producing timezone-aware expiry values while SQLAlchemy model `DateTime` columns remain naive, causing `TypeError: can't compare offset-naive and offset-aware datetimes` during API key verification and password reset flows. 
- This exception results in 500 errors and breaks authentication/password reset behavior for affected users.

### Description
- Add an `as_utc_datetime(value: datetime) -> datetime` helper in `src/api/services/user_service.py` that converts naive datetimes to UTC-aware datetimes and normalizes aware datetimes to UTC. 
- Use `as_utc_datetime(...)` when comparing `APIKey.expires_at` in `verify_api_key` and when checking `User.password_reset_expires_at` in `reset_password` to avoid naive/aware comparison errors. 
- Add regression tests: `tests/api/test_api_keys.py` includes `TestAPIKeyExpirationComparison::test_verify_api_key_handles_naive_expiration_datetime` and a new `tests/api/test_password_reset.py` with `TestPasswordResetExpiration::test_reset_password_handles_naive_expiration_datetime` to exercise naive DB timestamps.

### Testing
- Compiled modified modules and tests with `python -m compileall src/api/services/user_service.py tests/api/test_api_keys.py tests/api/test_password_reset.py`, which succeeded. 
- Attempted to run targeted pytest tests but the environment lacked `pytest_asyncio`, so `pytest` invocation failed with `ModuleNotFoundError: No module named 'pytest_asyncio'`. 
- Performed a small runtime check of the new helper (`as_utc_datetime`) in an interactive Python run which confirmed naive datetimes are normalized and comparisons against `datetime.now(timezone.utc)` behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b669147924832abc8f34ac3d2f6beb)