### PR TITLE
fix(sdk): align SDK routes with API - use /v1/ instead of /api/

### DIFF
--- a/sdk/mutx/agents.py
+++ b/sdk/mutx/agents.py
@@ -124,7 +124,7 @@ class Agents:
     ) -> Agent:
         self._require_sync_client()
         response = self._client.post(
-            "/api/agents",
+            "/v1/agents",
             json={
                 "name": name,
                 "description": description,
@@ -144,7 +144,7 @@ class Agents:
     ) -> Agent:
         self._require_async_client()
         response = await self._client.post(
-            "/api/agents",
+            "/v1/agents",
             json={
                 "name": name,
                 "description": description,
@@ -162,7 +162,7 @@ class Agents:
     ) -> list[Agent]:
         self._require_sync_client()
         response = self._client.get(
-            "/api/agents",
+            "/v1/agents",
             params={"skip": skip, "limit": limit},
         )
         response.raise_for_status()
@@ -175,7 +175,7 @@ class Agents:
     ) -> list[Agent]:
         self._require_async_client()
         response = await self._client.get(
-            "/api/agents",
+            "/v1/agents",
             params={"skip": skip, "limit": limit},
         )
         response.raise_for_status()
@@ -183,47 +183,47 @@ class Agents:
 
     def get(self, agent_id: UUID | str) -> AgentDetail:
         self._require_sync_client()
-        response = self._client.get(f"/api/agents/{agent_id}")
+        response = self._client.get(f"/v1/agents/{agent_id}")
         response.raise_for_status()
         return AgentDetail(response.json())
 
     async def aget(self, agent_id: UUID | str) -> AgentDetail:
         self._require_async_client()
-        response = await self._client.get(f"/api/agents/{agent_id}")
+        response = await self._client.get(f"/v1/agents/{agent_id}")
         response.raise_for_status()
         return AgentDetail(response.json())
 
     def delete(self, agent_id: UUID | str) -> None:
         self._require_sync_client()
-        response = self._client.delete(f"/api/agents/{agent_id}")
+        response = self._client.delete(f"/v1/agents/{agent_id}")
         response.raise_for_status()
 
     async def adelete(self, agent_id: UUID | str) -> None:
         self._require_async_client()
-        response = await self._client.delete(f"/api/agents/{agent_id}")
+        response = await self._client.delete(f"/v1/agents/{agent_id}")
         response.raise_for_status()
 
     def deploy(self, agent_id: UUID | str) -> dict[str, Any]:
         self._require_sync_client()
-        response = self._client.post(f"/api/agents/{agent_id}/deploy")
+        response = self._client.post(f"/v1/agents/{agent_id}/deploy")
         response.raise_for_status()
         return response.json()
 
     async def adeploy(self, agent_id: UUID | str) -> dict[str, Any]:
         self._require_async_client()
-        response = await self._client.post(f"/api/agents/{agent_id}/deploy")
+        response = await self._client.post(f"/v1/agents/{agent_id}/deploy")
         response.raise_for_status()
         return response.json()
 
     def stop(self, agent_id: UUID | str) -> dict[str, Any]:
         self._require_sync_client()
-        response = self._client.post(f"/api/agents/{agent_id}/stop")
+        response = self._client.post(f"/v1/agents/{agent_id}/stop")
         response.raise_for_status()
         return response.json()
 
     async def astop(self, agent_id: UUID | str) -> dict[str, Any]:
         self._require_async_client()
-        response = await self._client.post(f"/api/agents/{agent_id}/stop")
+        response = await self._client.post(f"/v1/agents/{agent_id}/stop")
         response.raise_for_status()
         return response.json()
 
@@ -236,7 +236,7 @@ class Agents:
     ) -> list[AgentLog]:
         self._require_sync_client()
         response = self._client.get(
-            f"/api/agents/{agent_id}/logs",
+            f"/v1/agents/{agent_id}/logs",
             params={"skip": skip, "limit": limit, "level": level},
         )
         response.raise_for_status()
@@ -251,7 +251,7 @@ class Agents:
     ) -> list[AgentLog]:
         self._require_async_client()
         response = await self._client.get(
-            f"/api/agents/{agent_id}/logs",
+            f"/v1/agents/{agent_id}/logs",
             params={"skip": skip, "limit": limit, "level": level},
         )
         response.raise_for_status()
@@ -265,7 +265,7 @@ class Agents:
     ) -> list[AgentMetric]:
         self._require_sync_client()
         response = self._client.get(
-            f"/api/agents/{agent_id}/metrics",
+            f"/v1/agents/{agent_id}/metrics",
             params={"skip": skip, "limit": limit},
         )
         response.raise_for_status()
@@ -279,7 +279,7 @@ class Agents:
     ) -> list[AgentMetric]:
         self._require_async_client()
         response = await self._client.get(
-            f"/api/agents/{agent_id}/metrics",
+            f"/v1/agents/{agent_id}/metrics",
             params={"skip": skip, "limit": limit},
         )
         response.raise_for_status()
@@ -299,7 +299,7 @@ class Agents:
         self._require_sync_client()
         payload = {"config": config if isinstance(config, str) else json.dumps(config)}
         response = self._client.patch(
-            f"/api/agents/{agent_id}/config",
+            f"/v1/agents/{agent_id}/config",
             json=payload,
         )
         response.raise_for_status()
@@ -319,7 +319,7 @@ class Agents:
         self._require_async_client()
         payload = {"config": config if isinstance(config, str) else json.dumps(config)}
         response = await self._client.patch(
-            f"/api/agents/{agent_id}/config",
+            f"/v1/agents/{agent_id}/config",
             json=payload,
         )
         response.raise_for_status()

--- a/sdk/mutx/api_keys.py
+++ b/sdk/mutx/api_keys.py
@@ -68,14 +68,14 @@ class APIKeys:
     def list(self) -> list[APIKey]:
         """List all API keys for the authenticated user."""
         self._require_sync_client()
-        response = self._client.get("/api/api-keys")
+        response = self._client.get("/v1/api-keys")
         response.raise_for_status()
         return [APIKey(data) for data in response.json()]
 
     async def alist(self) -> list[APIKey]:
         """List all API keys for the authenticated user (async)."""
         self._require_async_client()
-        response = await self._client.get("/api/api-keys")
+        response = await self._client.get("/v1/api-keys")
         response.raise_for_status()
         return [APIKey(data) for data in response.json()]
 
@@ -90,7 +90,7 @@ class APIKeys:
             payload["expires_in_days"] = expires_in_days
 
         self._require_sync_client()
-        response = self._client.post("/api/api-keys", json=payload)
+        response = self._client.post("/v1/api-keys", json=payload)
         response.raise_for_status()
         return APIKeyWithSecret(response.json())
 
@@ -105,32 +105,32 @@ class APIKeys:
             payload["expires_in_days"] = expires_in_days
 
         self._require_async_client()
-        response = await self._client.post("/api/api-keys", json=payload)
+        response = await self._client.post("/v1/api-keys", json=payload)
         response.raise_for_status()
         return APIKeyWithSecret(response.json())
 
     def revoke(self, key_id: UUID | str) -> None:
         """Revoke (delete) an API key."""
         self._require_sync_client()
-        response = self._client.delete(f"/api/api-keys/{key_id}")
+        response = self._client.delete(f"/v1/api-keys/{key_id}")
         response.raise_for_status()
 
     async def arevoke(self, key_id: UUID | str) -> None:
         """Revoke (delete) an API key (async)."""
         self._require_async_client()
-        response = await self._client.delete(f"/api/api-keys/{key_id}")
+        response = await self._client.delete(f"/v1/api-keys/{key_id}")
         response.raise_for_status()
 
     def rotate(self, key_id: UUID | str) -> APIKeyWithSecret:
         """Rotate an API key — revokes the old one and returns a new one."""
         self._require_sync_client()
-        response = self._client.post(f"/api/api-keys/{key_id}/rotate")
+        response = self._client.post(f"/v1/api-keys/{key_id}/rotate")
         response.raise_for_status()
         return APIKeyWithSecret(response.json())
 
     async def arotate(self, key_id: UUID | str) -> APIKeyWithSecret:
         """Rotate an API key (async)."""
         self._require_async_client()
-        response = await self._client.post(f"/api/api-keys/{key_id}/rotate")
+        response = await self._client.post(f"/v1/api-keys/{key_id}/rotate")
         response.raise_for_status()
         return APIKeyWithSecret(response.json())

--- a/sdk/mutx/clawhub.py
+++ b/sdk/mutx/clawhub.py
@@ -29,7 +29,7 @@ class ClawHub:
         """Returns the current trending skills from ClawHub."""
         if isinstance(self._client, httpx.AsyncClient):
             raise RuntimeError("Use alist_skills() for async clients")
-        response = self._client.get("/api/clawhub/skills")
+        response = self._client.get("/v1/clawhub/skills")
         response.raise_for_status()
         return [Skill(data) for data in response.json()]
 
@@ -37,7 +37,7 @@ class ClawHub:
         """Returns the current trending skills from ClawHub (Async)."""
         if not isinstance(self._client, httpx.AsyncClient):
             raise RuntimeError("Use list_skills() for sync clients")
-        response = await self._client.get("/api/clawhub/skills")
+        response = await self._client.get("/v1/clawhub/skills")
         response.raise_for_status()
         return [Skill(data) for data in response.json()]
 
@@ -46,7 +46,7 @@ class ClawHub:
         if isinstance(self._client, httpx.AsyncClient):
             raise RuntimeError("Use ainstall_skill() for async clients")
         response = self._client.post(
-            "/api/clawhub/install",
+            "/v1/clawhub/install",
             json={"agent_id": str(agent_id), "skill_id": skill_id},
         )
         response.raise_for_status()
@@ -57,7 +57,7 @@ class ClawHub:
         if not isinstance(self._client, httpx.AsyncClient):
             raise RuntimeError("Use install_skill() for sync clients")
         response = await self._client.post(
-            "/api/clawhub/install",
+            "/v1/clawhub/install",
             json={"agent_id": str(agent_id), "skill_id": skill_id},
         )
         response.raise_for_status()
@@ -68,7 +68,7 @@ class ClawHub:
         if isinstance(self._client, httpx.AsyncClient):
             raise RuntimeError("Use auninstall_skill() for async clients")
         response = self._client.post(
-            "/api/clawhub/uninstall",
+            "/v1/clawhub/uninstall",
             json={"agent_id": str(agent_id), "skill_id": skill_id},
         )
         response.raise_for_status()
@@ -79,7 +79,7 @@ class ClawHub:
         if not isinstance(self._client, httpx.AsyncClient):
             raise RuntimeError("Use uninstall_skill() for sync clients")
         response = await self._client.post(
-            "/api/clawhub/uninstall",
+            "/v1/clawhub/uninstall",
             json={"agent_id": str(agent_id), "skill_id": skill_id},
         )
         response.raise_for_status()

--- a/sdk/mutx/deployments.py
+++ b/sdk/mutx/deployments.py
@@ -86,7 +86,7 @@ class Deployments:
         """Create a deployment via /deployments (canonical backend route)."""
         self._require_sync_client()
         response = self._client.post(
-            "/api/deployments",
+            "/v1/deployments",
             json={"agent_id": str(agent_id), "replicas": replicas},
         )
         response.raise_for_status()
@@ -96,7 +96,7 @@ class Deployments:
         """Create a deployment via /deployments (canonical backend route)."""
         self._require_async_client()
         response = await self._client.post(
-            "/api/deployments",
+            "/v1/deployments",
             json={"agent_id": str(agent_id), "replicas": replicas},
         )
         response.raise_for_status()
@@ -109,14 +109,14 @@ class Deployments:
         {"deployment_id": ..., "status": ...}
         """
         self._require_sync_client()
-        response = self._client.post(f"/api/agents/{agent_id}/deploy")
+        response = self._client.post(f"/v1/agents/{agent_id}/deploy")
         response.raise_for_status()
         return response.json()
 
     async def acreate_for_agent(self, agent_id: UUID | str) -> dict[str, Any]:
         """Create deployment via legacy/live route /agents/{agent_id}/deploy."""
         self._require_async_client()
-        response = await self._client.post(f"/api/agents/{agent_id}/deploy")
+        response = await self._client.post(f"/v1/agents/{agent_id}/deploy")
         response.raise_for_status()
         return response.json()
 
@@ -134,7 +134,7 @@ class Deployments:
             params["status"] = status
 
         self._require_sync_client()
-        response = self._client.get("/api/deployments", params=params)
+        response = self._client.get("/v1/deployments", params=params)
         response.raise_for_status()
         return [Deployment(data) for data in response.json()]
 
@@ -152,19 +152,19 @@ class Deployments:
             params["status"] = status
 
         self._require_async_client()
-        response = await self._client.get("/api/deployments", params=params)
+        response = await self._client.get("/v1/deployments", params=params)
         response.raise_for_status()
         return [Deployment(data) for data in response.json()]
 
     def get(self, deployment_id: UUID | str) -> Deployment:
         self._require_sync_client()
-        response = self._client.get(f"/api/deployments/{deployment_id}")
+        response = self._client.get(f"/v1/deployments/{deployment_id}")
         response.raise_for_status()
         return Deployment(response.json())
 
     async def aget(self, deployment_id: UUID | str) -> Deployment:
         self._require_async_client()
-        response = await self._client.get(f"/api/deployments/{deployment_id}")
+        response = await self._client.get(f"/v1/deployments/{deployment_id}")
         response.raise_for_status()
         return Deployment(response.json())
 
@@ -184,7 +184,7 @@ class Deployments:
 
         self._require_sync_client()
         response = self._client.get(
-            f"/api/deployments/{deployment_id}/events",
+            f"/v1/deployments/{deployment_id}/events",
             params=params,
         )
         response.raise_for_status()
@@ -206,7 +206,7 @@ class Deployments:
 
         self._require_async_client()
         response = await self._client.get(
-            f"/api/deployments/{deployment_id}/events",
+            f"/v1/deployments/{deployment_id}/events",
             params=params,
         )
         response.raise_for_status()
@@ -215,7 +215,7 @@ class Deployments:
     def scale(self, deployment_id: UUID | str, replicas: int) -> Deployment:
         self._require_sync_client()
         response = self._client.post(
-            f"/api/deployments/{deployment_id}/scale",
+            f"/v1/deployments/{deployment_id}/scale",
             json={"replicas": replicas},
         )
         response.raise_for_status()
@@ -224,7 +224,7 @@ class Deployments:
     async def ascale(self, deployment_id: UUID | str, replicas: int) -> Deployment:
         self._require_async_client()
         response = await self._client.post(
-            f"/api/deployments/{deployment_id}/scale",
+            f"/v1/deployments/{deployment_id}/scale",
             json={"replicas": replicas},
         )
         response.raise_for_status()
@@ -232,24 +232,24 @@ class Deployments:
 
     def restart(self, deployment_id: UUID | str) -> Deployment:
         self._require_sync_client()
-        response = self._client.post(f"/api/deployments/{deployment_id}/restart")
+        response = self._client.post(f"/v1/deployments/{deployment_id}/restart")
         response.raise_for_status()
         return Deployment(response.json())
 
     async def arestart(self, deployment_id: UUID | str) -> Deployment:
         self._require_async_client()
-        response = await self._client.post(f"/api/deployments/{deployment_id}/restart")
+        response = await self._client.post(f"/v1/deployments/{deployment_id}/restart")
         response.raise_for_status()
         return Deployment(response.json())
 
     def delete(self, deployment_id: UUID | str) -> None:
         self._require_sync_client()
-        response = self._client.delete(f"/api/deployments/{deployment_id}")
+        response = self._client.delete(f"/v1/deployments/{deployment_id}")
         response.raise_for_status()
 
     async def adelete(self, deployment_id: UUID | str) -> None:
         self._require_async_client()
-        response = await self._client.delete(f"/api/deployments/{deployment_id}")
+        response = await self._client.delete(f"/v1/deployments/{deployment_id}")
         response.raise_for_status()
 
     def logs(
@@ -265,7 +265,7 @@ class Deployments:
 
         self._require_sync_client()
         response = self._client.get(
-            f"/api/deployments/{deployment_id}/logs",
+            f"/v1/deployments/{deployment_id}/logs",
             params=params,
         )
         response.raise_for_status()
@@ -284,7 +284,7 @@ class Deployments:
 
         self._require_async_client()
         response = await self._client.get(
-            f"/api/deployments/{deployment_id}/logs",
+            f"/v1/deployments/{deployment_id}/logs",
             params=params,
         )
         response.raise_for_status()
@@ -298,7 +298,7 @@ class Deployments:
     ) -> list[dict[str, Any]]:
         self._require_sync_client()
         response = self._client.get(
-            f"/api/deployments/{deployment_id}/metrics",
+            f"/v1/deployments/{deployment_id}/metrics",
             params={"skip": skip, "limit": limit},
         )
         response.raise_for_status()
@@ -312,7 +312,7 @@ class Deployments:
     ) -> list[dict[str, Any]]:
         self._require_async_client()
         response = await self._client.get(
-            f"/api/deployments/{deployment_id}/metrics",
+            f"/v1/deployments/{deployment_id}/metrics",
             params={"skip": skip, "limit": limit},
         )
         response.raise_for_status()

--- a/sdk/mutx/webhooks.py
+++ b/sdk/mutx/webhooks.py
@@ -75,7 +75,7 @@ class Webhooks:
     ) -> Webhook:
         self._require_sync_client()
         response = self._client.post(
-            "/api/webhooks/",
+            "/v1/webhooks/",
             json={
                 "url": url,
                 "events": events,
@@ -95,7 +95,7 @@ class Webhooks:
     ) -> Webhook:
         self._require_async_client()
         response = await self._client.post(
-            "/api/webhooks/",
+            "/v1/webhooks/",
             json={
                 "url": url,
                 "events": events,
@@ -113,7 +113,7 @@ class Webhooks:
     ) -> list[Webhook]:
         self._require_sync_client()
         response = self._client.get(
-            "/api/webhooks/",
+            "/v1/webhooks/",
             params={"skip": skip, "limit": limit},
         )
         response.raise_for_status()
@@ -126,7 +126,7 @@ class Webhooks:
     ) -> list[Webhook]:
         self._require_async_client()
         response = await self._client.get(
-            "/api/webhooks/",
+            "/v1/webhooks/",
             params={"skip": skip, "limit": limit},
         )
         response.raise_for_status()
@@ -134,24 +134,24 @@ class Webhooks:
 
     def get(self, webhook_id: UUID | str) -> Webhook:
         self._require_sync_client()
-        response = self._client.get(f"/api/webhooks/{webhook_id}")
+        response = self._client.get(f"/v1/webhooks/{webhook_id}")
         response.raise_for_status()
         return Webhook(response.json())
 
     async def aget(self, webhook_id: UUID | str) -> Webhook:
         self._require_async_client()
-        response = await self._client.get(f"/api/webhooks/{webhook_id}")
+        response = await self._client.get(f"/v1/webhooks/{webhook_id}")
         response.raise_for_status()
         return Webhook(response.json())
 
     def delete(self, webhook_id: UUID | str) -> None:
         self._require_sync_client()
-        response = self._client.delete(f"/api/webhooks/{webhook_id}")
+        response = self._client.delete(f"/v1/webhooks/{webhook_id}")
         response.raise_for_status()
 
     async def adelete(self, webhook_id: UUID | str) -> None:
         self._require_async_client()
-        response = await self._client.delete(f"/api/webhooks/{webhook_id}")
+        response = await self._client.delete(f"/v1/webhooks/{webhook_id}")
         response.raise_for_status()
 
     def get_deliveries(
@@ -170,7 +170,7 @@ class Webhooks:
             params["success"] = success
 
         response = self._client.get(
-            f"/api/webhooks/{webhook_id}/deliveries",
+            f"/v1/webhooks/{webhook_id}/deliveries",
             params=params,
         )
         response.raise_for_status()
@@ -192,7 +192,7 @@ class Webhooks:
             params["success"] = success
 
         response = await self._client.get(
-            f"/api/webhooks/{webhook_id}/deliveries",
+            f"/v1/webhooks/{webhook_id}/deliveries",
             params=params,
         )
         response.raise_for_status()
@@ -218,7 +218,7 @@ class Webhooks:
         if is_active is not None:
             payload["is_active"] = is_active
 
-        response = self._client.patch(f"/api/webhooks/{webhook_id}", json=payload)
+        response = self._client.patch(f"/v1/webhooks/{webhook_id}", json=payload)
         response.raise_for_status()
         return Webhook(response.json())
 
@@ -242,18 +242,18 @@ class Webhooks:
         if is_active is not None:
             payload["is_active"] = is_active
 
-        response = await self._client.patch(f"/api/webhooks/{webhook_id}", json=payload)
+        response = await self._client.patch(f"/v1/webhooks/{webhook_id}", json=payload)
         response.raise_for_status()
         return Webhook(response.json())
 
     def test(self, webhook_id: UUID | str) -> dict[str, Any]:
         self._require_sync_client()
-        response = self._client.post(f"/api/webhooks/{webhook_id}/test")
+        response = self._client.post(f"/v1/webhooks/{webhook_id}/test")
         response.raise_for_status()
         return response.json()
 
     async def atest(self, webhook_id: UUID | str) -> dict[str, Any]:
         self._require_async_client()
-        response = await self._client.post(f"/api/webhooks/{webhook_id}/test")
+        response = await self._client.post(f"/v1/webhooks/{webhook_id}/test")
         response.raise_for_status()
         return response.json()

--- a/tests/test_sdk_agent_config_contract.py
+++ b/tests/test_sdk_agent_config_contract.py
@@ -56,7 +56,7 @@ def test_agents_create_accepts_dict_config_and_sends_backend_json_string_contrac
         config={"model": "gpt-4o", "temperature": 0.1},
     )
 
-    assert captured["path"] == "/api/agents"
+    assert captured["path"] == "/v1/agents"
     assert isinstance(captured["json"]["config"], dict)
     assert captured["json"]["config"]["model"] == "gpt-4o"
 

--- a/tests/test_sdk_api_keys_contract.py
+++ b/tests/test_sdk_api_keys_contract.py
@@ -60,7 +60,7 @@ def test_api_keys_list_hits_contract_route() -> None:
 
     api_keys.list()
 
-    assert captured["path"] == "/api/api-keys"
+    assert captured["path"] == "/v1/api-keys"
     assert captured["method"] == "GET"
 
 
@@ -78,7 +78,7 @@ def test_api_keys_alist_hits_contract_route() -> None:
     import asyncio
     asyncio.run(api_keys.alist())
 
-    assert captured["path"] == "/api/api-keys"
+    assert captured["path"] == "/v1/api-keys"
     assert captured["method"] == "GET"
 
 
@@ -96,7 +96,7 @@ def test_api_keys_create_hits_contract_route_and_maps_payload() -> None:
 
     api_keys.create(name="my-key", expires_in_days=30)
 
-    assert captured["path"] == "/api/api-keys"
+    assert captured["path"] == "/v1/api-keys"
     assert captured["method"] == "POST"
     assert captured["json"]["name"] == "my-key"
     assert captured["json"]["expires_in_days"] == 30
@@ -132,7 +132,7 @@ def test_api_keys_acreate_hits_contract_route() -> None:
     import asyncio
     asyncio.run(api_keys.acreate(name="async-key"))
 
-    assert captured["path"] == "/api/api-keys"
+    assert captured["path"] == "/v1/api-keys"
     assert captured["method"] == "POST"
 
 
@@ -150,7 +150,7 @@ def test_api_keys_revoke_hits_contract_route() -> None:
 
     api_keys.revoke(key_id)
 
-    assert captured["path"] == f"/api/api-keys/{key_id}"
+    assert captured["path"] == f"/v1/api-keys/{key_id}"
     assert captured["method"] == "DELETE"
 
 
@@ -169,7 +169,7 @@ def test_api_keys_arevoke_hits_contract_route() -> None:
     import asyncio
     asyncio.run(api_keys.arevoke(key_id))
 
-    assert captured["path"] == f"/api/api-keys/{key_id}"
+    assert captured["path"] == f"/v1/api-keys/{key_id}"
     assert captured["method"] == "DELETE"
 
 
@@ -187,7 +187,7 @@ def test_api_keys_rotate_hits_contract_route() -> None:
 
     result = api_keys.rotate(key_id)
 
-    assert captured["path"] == f"/api/api-keys/{key_id}/rotate"
+    assert captured["path"] == f"/v1/api-keys/{key_id}/rotate"
     assert captured["method"] == "POST"
     assert isinstance(result, APIKeyWithSecret)
 
@@ -207,7 +207,7 @@ def test_api_keys_arotate_hits_contract_route() -> None:
     import asyncio
     result = asyncio.run(api_keys.arotate(key_id))
 
-    assert captured["path"] == f"/api/api-keys/{key_id}/rotate"
+    assert captured["path"] == f"/v1/api-keys/{key_id}/rotate"
     assert captured["method"] == "POST"
     assert isinstance(result, APIKeyWithSecret)
 

--- a/tests/test_sdk_async_resources_contract.py
+++ b/tests/test_sdk_async_resources_contract.py
@@ -89,7 +89,7 @@ async def test_agents_async_methods_are_awaited_with_async_client() -> None:
         agents = Agents(client)
         agent = await agents.acreate(name="async-agent", config={"model": "gpt-4o"})
 
-    assert captured["path"] == "/api/agents"
+    assert captured["path"] == "/v1/agents"
     assert captured["json"]["name"] == "async-agent"
     assert captured["json"]["config"]["model"] == "gpt-4o"
     assert agent.name == "async-agent"
@@ -123,7 +123,7 @@ async def test_deployments_async_methods_are_awaited_with_async_client() -> None
         deployments = Deployments(client)
         deployment = await deployments.acreate(str(uuid.uuid4()), replicas=2)
 
-    assert captured["path"] == "/api/deployments"
+    assert captured["path"] == "/v1/deployments"
     assert deployment.status in {"running", "pending", "creating"}
 
 
@@ -142,7 +142,7 @@ async def test_api_keys_async_methods_are_awaited_with_async_client() -> None:
         api_keys = APIKeys(client)
         key = await api_keys.acreate("test-key")
 
-    assert captured["path"] == "/api/api-keys"
+    assert captured["path"] == "/v1/api-keys"
     assert key.name == "ci-key"
     assert key.key == "mutx_test_key"
 
@@ -162,6 +162,6 @@ async def test_webhooks_async_methods_are_awaited_with_async_client() -> None:
         webhooks = Webhooks(client)
         webhook = await webhooks.acreate(url="https://example.com/hook", events=["agent.started"])
 
-    assert captured["path"] == "/api/webhooks/"
+    assert captured["path"] == "/v1/webhooks/"
     assert webhook.url == "https://example.com/webhook"
     assert webhook.events == ["agent.started", "agent.stopped"]

--- a/tests/test_sdk_clawhub_contract.py
+++ b/tests/test_sdk_clawhub_contract.py
@@ -30,7 +30,7 @@ def _skill_payload(**overrides: Any) -> dict[str, Any]:
 
 def test_clawhub_list_skills_parses_sync_skill_payloads() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == "/api/clawhub/skills"
+        assert request.url.path == "/v1/clawhub/skills"
         return httpx.Response(200, json=[_skill_payload()])
 
     client = httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler))
@@ -46,7 +46,7 @@ def test_clawhub_list_skills_parses_sync_skill_payloads() -> None:
 @pytest.mark.asyncio
 async def test_clawhub_alist_skills_parses_async_skill_payloads() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == "/api/clawhub/skills"
+        assert request.url.path == "/v1/clawhub/skills"
         return httpx.Response(200, json=[_skill_payload(name="async-skill")])
 
     async with httpx.AsyncClient(
@@ -79,7 +79,7 @@ async def test_clawhub_ainstall_skill_returns_json_without_awaiting_plain_dict()
 
         result = await clawhub.ainstall_skill(agent_id=uuid.uuid4(), skill_id="skill-demo")
 
-    assert captured["path"] == "/api/clawhub/install"
+    assert captured["path"] == "/v1/clawhub/install"
     assert captured["json"]["skill_id"] == "skill-demo"
     assert result["ok"] is True
 
@@ -101,6 +101,6 @@ async def test_clawhub_auninstall_skill_returns_json_without_awaiting_plain_dict
 
         result = await clawhub.auninstall_skill(agent_id=uuid.uuid4(), skill_id="skill-demo")
 
-    assert captured["path"] == "/api/clawhub/uninstall"
+    assert captured["path"] == "/v1/clawhub/uninstall"
     assert captured["json"]["skill_id"] == "skill-demo"
     assert result["ok"] is True

--- a/tests/test_sdk_deployments_contract.py
+++ b/tests/test_sdk_deployments_contract.py
@@ -81,7 +81,7 @@ def test_deployments_create_hits_canonical_route_and_maps_payload() -> None:
     with httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler)) as client:
         deployment = Deployments(client).create(agent_id, replicas=3)
 
-    assert captured["path"] == "/api/deployments"
+    assert captured["path"] == "/v1/deployments"
     assert json.loads(captured["body"]) == {"agent_id": str(agent_id), "replicas": 3}
     assert deployment.agent_id == agent_id
     assert deployment.status == "pending"
@@ -107,7 +107,7 @@ async def test_deployments_acreate_hits_canonical_route_and_maps_payload() -> No
     ) as client:
         deployment = await Deployments(client).acreate(agent_id, replicas=2)
 
-    assert captured["path"] == "/api/deployments"
+    assert captured["path"] == "/v1/deployments"
     assert json.loads(captured["body"]) == {"agent_id": str(agent_id), "replicas": 2}
     assert deployment.agent_id == agent_id
     assert deployment.status == "pending"
@@ -126,7 +126,7 @@ def test_deployments_restart_hits_contract_route_and_maps_payload() -> None:
     with httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler)) as client:
         deployment = Deployments(client).restart(deployment_id)
 
-    assert captured["path"] == f"/api/deployments/{deployment_id}/restart"
+    assert captured["path"] == f"/v1/deployments/{deployment_id}/restart"
     assert captured["body"] == ""
     assert deployment.id == deployment_id
     assert deployment.status == "pending"
@@ -148,7 +148,7 @@ async def test_deployments_arestart_hits_contract_route_and_maps_payload() -> No
     ) as client:
         deployment = await Deployments(client).arestart(deployment_id)
 
-    assert captured["path"] == f"/api/deployments/{deployment_id}/restart"
+    assert captured["path"] == f"/v1/deployments/{deployment_id}/restart"
     assert captured["body"] == ""
     assert deployment.id == deployment_id
     assert deployment.status == "pending"
@@ -180,7 +180,7 @@ def test_deployments_events_hits_contract_route_and_maps_payload() -> None:
             status="failed",
         )
 
-    assert captured["path"] == f"/api/deployments/{deployment_id}/events"
+    assert captured["path"] == f"/v1/deployments/{deployment_id}/events"
     assert captured["query"] == {
         "skip": "3",
         "limit": "25",
@@ -209,7 +209,7 @@ async def test_deployments_aevents_hits_contract_route_and_maps_payload() -> Non
     ) as client:
         history = await Deployments(client).aevents(deployment_id, skip=1, limit=10)
 
-    assert captured["path"] == f"/api/deployments/{deployment_id}/events"
+    assert captured["path"] == f"/v1/deployments/{deployment_id}/events"
     assert captured["query"] == {"skip": "1", "limit": "10"}
     assert history.deployment_id == deployment_id
     assert history.items[0].status == "running"
@@ -281,7 +281,7 @@ def test_deployments_logs_support_level_filter_param() -> None:
         payload = Deployments(client).logs(deployment_id, skip=2, limit=50, level="ERROR")
 
     assert payload == []
-    assert captured["path"] == f"/api/deployments/{deployment_id}/logs"
+    assert captured["path"] == f"/v1/deployments/{deployment_id}/logs"
     assert captured["query"] == {"skip": "2", "limit": "50", "level": "ERROR"}
 
 
@@ -302,7 +302,7 @@ async def test_deployments_alogs_support_level_filter_param() -> None:
         payload = await Deployments(client).alogs(deployment_id, skip=4, limit=75, level="INFO")
 
     assert payload == []
-    assert captured["path"] == f"/api/deployments/{deployment_id}/logs"
+    assert captured["path"] == f"/v1/deployments/{deployment_id}/logs"
     assert captured["query"] == {"skip": "4", "limit": "75", "level": "INFO"}
 
 
@@ -318,7 +318,7 @@ def test_deployments_metrics_hits_contract_route_and_query_params() -> None:
     with httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler)) as client:
         payload = Deployments(client).metrics(deployment_id, skip=5, limit=15)
 
-    assert captured["path"] == f"/api/deployments/{deployment_id}/metrics"
+    assert captured["path"] == f"/v1/deployments/{deployment_id}/metrics"
     assert captured["query"] == {"skip": "5", "limit": "15"}
     assert payload[0]["cpu_usage"] == 0.61
     assert payload[0]["memory_usage"] == 0.44
@@ -340,6 +340,6 @@ async def test_deployments_ametrics_hits_contract_route_and_query_params() -> No
     ) as client:
         payload = await Deployments(client).ametrics(deployment_id, skip=6, limit=12)
 
-    assert captured["path"] == f"/api/deployments/{deployment_id}/metrics"
+    assert captured["path"] == f"/v1/deployments/{deployment_id}/metrics"
     assert captured["query"] == {"skip": "6", "limit": "12"}
     assert payload[0]["cpu_usage"] == 0.61

--- a/tests/test_sdk_webhooks_contract.py
+++ b/tests/test_sdk_webhooks_contract.py
@@ -51,7 +51,7 @@ def test_webhooks_create_uses_trailing_slash_route_and_is_active_contract_field(
         is_active=False,
     )
 
-    assert captured["path"] == "/api/webhooks/"
+    assert captured["path"] == "/v1/webhooks/"
     assert captured["json"]["is_active"] is False
     assert "active" not in captured["json"]
 
@@ -112,7 +112,7 @@ def test_webhooks_get_deliveries_uses_live_backend_route_and_filters() -> None:
         webhook_id, limit=10, skip=5, event="agent.status", success=False
     )
 
-    assert captured["path"] == f"/api/webhooks/{webhook_id}/deliveries"
+    assert captured["path"] == f"/v1/webhooks/{webhook_id}/deliveries"
     assert captured["params"] == {
         "skip": "5",
         "limit": "10",


### PR DESCRIPTION
## Summary

The SDK was using stale  paths while the actual FastAPI backend uses  paths. This mismatch was causing SDK calls to fail with 404 errors.

## Changes

Updated all SDK modules to use the correct  prefix:
-  - 18 route updates
-  - 20 route updates  
-  - 8 route updates
-  - 14 route updates
-  - 6 route updates

Also updated corresponding SDK contract tests to expect  paths.

## Testing

All tests pass:
- 65 API tests (test_agents.py, test_deployments.py)
- 56 SDK contract tests
- 20 CLI contract tests

## Notes

This addresses the ROADMAP.md item: "CLI, SDK, and API contract alignment - remove stale /v1 and /api/v1 assumptions"