### PR TITLE
fix: consolidate app domains (mutx.dev/app to app.mutx.dev) - issue #339

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -9,9 +9,23 @@ function isAppHost(hostname: string) {
   return hostname === 'app.mutx.dev' || hostname === 'app.localhost'
 }
 
+function isPrimaryWebHost(hostname: string) {
+  return hostname === 'mutx.dev' || hostname === 'www.mutx.dev'
+}
+
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
   const hostname = getHostname(request)
+
+  // Keep app.mutx.dev as the canonical operator surface in production.
+  if (isPrimaryWebHost(hostname) && (pathname === '/app' || pathname.startsWith('/app/'))) {
+    const redirectUrl = request.nextUrl.clone()
+    redirectUrl.hostname = 'app.mutx.dev'
+    redirectUrl.protocol = 'https'
+    redirectUrl.port = ''
+    redirectUrl.pathname = pathname.replace(/^\/app/, '') || '/'
+    return NextResponse.redirect(redirectUrl, 308)
+  }
 
   if (!isAppHost(hostname)) {
     return NextResponse.next()


### PR DESCRIPTION
## Summary
- Adds redirect from mutx.dev/app to app.mutx.dev via middleware
- Ensures app.mutx.dev is the canonical domain for the operator dashboard
- Touches ONE file: middleware.ts