### PR TITLE
fix(api): replace deprecated datetime.utcnow() in main.py

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,6 +1,6 @@
 import asyncio
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 
 from fastapi import FastAPI, Request, Response, status
@@ -167,7 +167,7 @@ async def health_check(request: Request):
 
     return HealthResponse(
         status="healthy" if database_ready else "degraded",
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
         database="ready" if database_ready else "unavailable" if database_error else "initializing",
         error=database_error,
     )
@@ -186,7 +186,7 @@ async def readiness_check(request: Request, response: Response):
 
     return {
         "status": "ready" if database_ready else "not_ready",
-        "timestamp": datetime.utcnow(),
+        "timestamp": datetime.now(timezone.utc),
         "database": database_status,
         "error": database_error,
     }


### PR DESCRIPTION
Replaces deprecated datetime.utcnow() with datetime.now(timezone.utc) in src/api/main.py to fix Python 3.12+ deprecation warning.

## Changes
- src/api/main.py: health_check and readiness_check endpoints

## Edge cases not handled
- None - this is a straightforward replacement, the HealthResponse schema accepts datetime objects