### PR TITLE
feat(dashboard): add deploy action for agents

### DIFF
--- a/app/api/dashboard/agents/[agentId]/route.ts
+++ b/app/api/dashboard/agents/[agentId]/route.ts
@@ -94,6 +94,17 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       return NextResponse.json(payload, { status: response.status })
     }
 
+    if (action === 'deploy') {
+      const response = await fetch(`${API_BASE_URL}/agents/${agentId}/deploy`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        cache: 'no-store',
+      })
+
+      const payload = await response.json().catch(() => ({ detail: 'Failed to deploy agent' }))
+      return NextResponse.json(payload, { status: response.status })
+    }
+
     return badRequest('Invalid action')
   })(request)
 }


### PR DESCRIPTION
Adds the deploy action to the dashboard agents API, allowing users to start/deploy agents from the dashboard UI.

## Changes
- Add  POST endpoint to 

## Edge cases not handled
1. Agent already deployed/running - backend will return error
2. Invalid agent ID format - validated with Zod
3. Network failures between dashboard and control plane API