### PR TITLE
fix(dashboard): add CTA buttons for empty agents/deployments state

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -165,7 +165,12 @@ export default function DashboardPage() {
             </Link>
           </div>
           {agents.length === 0 ? (
-            <p className="mt-4 text-slate-400">No agents yet</p>
+            <div className="mt-4 space-y-3">
+              <p className="text-slate-400">No agents yet</p>
+              <Link href="/dashboard/agents" className="inline-flex items-center gap-2 rounded-lg bg-cyan-500/20 px-4 py-2 text-sm font-medium text-cyan-400 hover:bg-cyan-500/30">
+                Create your first agent →
+              </Link>
+            </div>
           ) : (
             <ul className="mt-4 space-y-3">
               {agents.slice(0, 3).map((agent) => (
@@ -201,7 +206,12 @@ export default function DashboardPage() {
             </Link>
           </div>
           {deployments.length === 0 ? (
-            <p className="mt-4 text-slate-400">No deployments yet</p>
+            <div className="mt-4 space-y-3">
+              <p className="text-slate-400">No deployments yet</p>
+              <Link href="/dashboard/agents" className="inline-flex items-center gap-2 rounded-lg bg-cyan-500/20 px-4 py-2 text-sm font-medium text-cyan-400 hover:bg-cyan-500/30">
+                Deploy an agent →
+              </Link>
+            </div>
           ) : (
             <ul className="mt-4 space-y-3">
               {deployments.slice(0, 3).map((deployment) => (


### PR DESCRIPTION
## Summary

Add 'Create your first agent' and 'Deploy an agent' buttons when no agents or deployments exist in the dashboard.

## Changes

- Modified  to add CTA buttons for empty states

## Testing

- Built successfully with `npm run build`
- All tests pass

## Edge cases

- Auth required: Page already handles auth state, shows sign-in prompt
- API failures: Already handled with error states
- Link component: Already imported in the file

Closes #371