### PR TITLE
fix(api): add /v1 prefix to all backend API calls

### DIFF
--- a/app/api/agents/[id]/deploy/route.ts
+++ b/app/api/agents/[id]/deploy/route.ts
@@ -19,7 +19,7 @@ export async function POST(
 
     const { id } = await params
     
-    const response = await fetch(`${API_BASE_URL}/api/agents/${id}/deploy`, {
+    const response = await fetch(`${API_BASE_URL}/v1/agents/${id}/deploy`, {
       method: 'POST',
       headers: { 
         Authorization: `Bearer ${token}`,

--- a/app/api/agents/[id]/logs/route.ts
+++ b/app/api/agents/[id]/logs/route.ts
@@ -21,7 +21,7 @@ export async function GET(
     const { searchParams } = new URL(request.url)
     const paramsStr = searchParams.toString()
     
-    const response = await fetch(`${API_BASE_URL}/api/agents/${id}/logs?${paramsStr}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/agents/${id}/logs?${paramsStr}`, {
       headers: { 
         Authorization: `Bearer ${token}`,
       },

--- a/app/api/agents/[id]/route.ts
+++ b/app/api/agents/[id]/route.ts
@@ -19,7 +19,7 @@ export async function GET(
 
     const { id } = await params
     
-    const response = await fetch(`${API_BASE_URL}/api/agents/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/agents/${id}`, {
       headers: { 
         Authorization: `Bearer ${token}`,
       },
@@ -43,7 +43,7 @@ export async function DELETE(
 
     const { id } = await params
     
-    const response = await fetch(`${API_BASE_URL}/api/agents/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/agents/${id}`, {
       method: 'DELETE',
       headers: { 
         Authorization: `Bearer ${token}`,

--- a/app/api/agents/[id]/stop/route.ts
+++ b/app/api/agents/[id]/stop/route.ts
@@ -19,7 +19,7 @@ export async function POST(
 
     const { id } = await params
     
-    const response = await fetch(`${API_BASE_URL}/api/agents/${id}/stop`, {
+    const response = await fetch(`${API_BASE_URL}/v1/agents/${id}/stop`, {
       method: 'POST',
       headers: { 
         Authorization: `Bearer ${token}`,

--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const { searchParams } = new URL(request.url)
     const params = new URLSearchParams(searchParams)
     
-    const response = await fetch(`${API_BASE_URL}/api/agents?${params}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/agents?${params}`, {
       headers: { 
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
@@ -43,7 +43,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     const body = await req.json()
     
-    const response = await fetch(`${API_BASE_URL}/api/agents`, {
+    const response = await fetch(`${API_BASE_URL}/v1/agents`, {
       method: 'POST',
       headers: { 
         Authorization: `Bearer ${token}`,

--- a/app/api/api-keys/[id]/rotate/route.ts
+++ b/app/api/api-keys/[id]/rotate/route.ts
@@ -18,7 +18,7 @@ export async function POST(
 
     const { id } = await params
 
-    const response = await fetch(`${API_BASE_URL}/api-keys/${id}/rotate`, {
+    const response = await fetch(`${API_BASE_URL}/v1/api-keys/${id}/rotate`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,

--- a/app/api/api-keys/[id]/route.ts
+++ b/app/api/api-keys/[id]/route.ts
@@ -18,7 +18,7 @@ export async function DELETE(
 
     const { id } = await params
 
-    const response = await fetch(`${API_BASE_URL}/api-keys/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/api-keys/${id}`, {
       method: 'DELETE',
       headers: {
         'Authorization': `Bearer ${token}`,

--- a/app/api/api-keys/route.ts
+++ b/app/api/api-keys/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const response = await fetch(`${API_BASE_URL}/api-keys`, {
+    const response = await fetch(`${API_BASE_URL}/v1/api-keys`, {
       headers: {
         'Authorization': `Bearer ${token}`,
       },
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json()
 
-    const response = await fetch(`${API_BASE_URL}/api-keys`, {
+    const response = await fetch(`${API_BASE_URL}/v1/api-keys`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${token}`,

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const secureCookies = shouldUseSecureCookies(request)
     const cookieDomain = getCookieDomain(request)
 
-    const response = await fetch(`${API_BASE_URL}/auth/login`, {
+    const response = await fetch(`${API_BASE_URL}/v1/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ detail: 'Unauthorized' }, { status: 401 })
     }
 
-    const response = await fetch(`${API_BASE_URL}/auth/me`, {
+    const response = await fetch(`${API_BASE_URL}/v1/auth/me`, {
       headers: { Authorization: `Bearer ${token}` },
       cache: 'no-store',
     })

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const secureCookies = shouldUseSecureCookies(request)
     const cookieDomain = getCookieDomain(request)
 
-    const response = await fetch(`${API_BASE_URL}/auth/register`, {
+    const response = await fetch(`${API_BASE_URL}/v1/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/app/api/dashboard/agents/[agentId]/route.ts
+++ b/app/api/dashboard/agents/[agentId]/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return badRequest('Invalid agent ID format')
     }
 
-    const response = await fetch(`${API_BASE_URL}/agents/${agentId}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/agents/${agentId}`, {
       method: 'GET',
       headers: { Authorization: `Bearer ${token}` },
       cache: 'no-store',
@@ -49,7 +49,7 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
       return badRequest('Invalid agent ID format')
     }
 
-    const response = await fetch(`${API_BASE_URL}/agents/${agentId}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/agents/${agentId}`, {
       method: 'DELETE',
       headers: { Authorization: `Bearer ${token}` },
       cache: 'no-store',
@@ -84,7 +84,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     const action = searchParams.get('action')
 
     if (action === 'stop') {
-      const response = await fetch(`${API_BASE_URL}/agents/${agentId}/stop`, {
+      const response = await fetch(`${API_BASE_URL}/v1/agents/${agentId}/stop`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
         cache: 'no-store',
@@ -95,7 +95,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     }
 
     if (action === 'deploy') {
-      const response = await fetch(`${API_BASE_URL}/agents/${agentId}/deploy`, {
+      const response = await fetch(`${API_BASE_URL}/v1/agents/${agentId}/deploy`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
         cache: 'no-store',

--- a/app/api/dashboard/agents/route.ts
+++ b/app/api/dashboard/agents/route.ts
@@ -14,7 +14,7 @@ export const dynamic = 'force-dynamic'
  */
 async function getCurrentUserId(token: string): Promise<string | null> {
   try {
-    const response = await fetch(`${API_BASE_URL}/auth/me`, {
+    const response = await fetch(`${API_BASE_URL}/v1/auth/me`, {
       headers: { Authorization: `Bearer ${token}` },
       cache: 'no-store',
     })
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     }
 
     // Filter by user_id to enforce ownership - derived from auth token, not client input
-    const response = await fetch(`${API_BASE_URL}/agents?limit=20&user_id=${userId}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/agents?limit=20&user_id=${userId}`, {
       headers: { Authorization: `Bearer ${token}` },
       cache: 'no-store',
     })
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return validation.response
     }
 
-    const response = await fetch(`${API_BASE_URL}/agents`, {
+    const response = await fetch(`${API_BASE_URL}/v1/agents`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,

--- a/app/api/dashboard/deployments/[id]/route.ts
+++ b/app/api/dashboard/deployments/[id]/route.ts
@@ -21,7 +21,7 @@ export async function GET(
     const path = searchParams.get('path') || ''
 
     if (path === 'versions') {
-      const response = await fetch(`${API_BASE_URL}/deployments/${id}/versions`, {
+      const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}/versions`, {
         headers: { Authorization: `Bearer ${token}` },
         cache: 'no-store',
       })
@@ -30,7 +30,7 @@ export async function GET(
       return NextResponse.json(payload, { status: response.status })
     }
 
-    const response = await fetch(`${API_BASE_URL}/deployments/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}`, {
       headers: { Authorization: `Bearer ${token}` },
       cache: 'no-store',
     })
@@ -59,7 +59,7 @@ export async function POST(
 
     if (action === 'rollback') {
       const body = await request.json()
-      const response = await fetch(`${API_BASE_URL}/deployments/${id}/rollback`, {
+      const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}/rollback`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
@@ -74,7 +74,7 @@ export async function POST(
     }
 
     if (action === 'restart') {
-      const response = await fetch(`${API_BASE_URL}/deployments/${id}/restart`, {
+      const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}/restart`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
         cache: 'no-store',
@@ -86,7 +86,7 @@ export async function POST(
 
     if (action === 'scale') {
       const body = await request.json()
-      const response = await fetch(`${API_BASE_URL}/deployments/${id}/scale`, {
+      const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}/scale`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
@@ -118,7 +118,7 @@ export async function DELETE(
       return NextResponse.json({ detail: 'Unauthorized' }, { status: 401 })
     }
 
-    const response = await fetch(`${API_BASE_URL}/deployments/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}`, {
       method: 'DELETE',
       headers: { Authorization: `Bearer ${token}` },
       cache: 'no-store',

--- a/app/api/dashboard/deployments/route.ts
+++ b/app/api/dashboard/deployments/route.ts
@@ -14,7 +14,7 @@ export const dynamic = 'force-dynamic'
  */
 async function getCurrentUserId(token: string): Promise<string | null> {
   try {
-    const response = await fetch(`${API_BASE_URL}/auth/me`, {
+    const response = await fetch(`${API_BASE_URL}/v1/auth/me`, {
       headers: { Authorization: `Bearer ${token}` },
       cache: 'no-store',
     })
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     }
 
     // Filter by user_id to enforce ownership - derived from auth token, not client input
-    const response = await fetch(`${API_BASE_URL}/deployments?limit=20&user_id=${userId}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/deployments?limit=20&user_id=${userId}`, {
       headers: { Authorization: `Bearer ${token}` },
       cache: 'no-store',
     })
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return validation.response
     }
 
-    const response = await fetch(`${API_BASE_URL}/deployments`, {
+    const response = await fetch(`${API_BASE_URL}/v1/deployments`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,

--- a/app/api/deployments/[id]/events/route.ts
+++ b/app/api/deployments/[id]/events/route.ts
@@ -21,7 +21,7 @@ export async function GET(
     const { searchParams } = new URL(request.url)
     const paramsStr = searchParams.toString()
     
-    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}/events?${paramsStr}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}/events?${paramsStr}`, {
       headers: { 
         Authorization: `Bearer ${token}`,
       },

--- a/app/api/deployments/[id]/logs/route.ts
+++ b/app/api/deployments/[id]/logs/route.ts
@@ -21,7 +21,7 @@ export async function GET(
     const { searchParams } = new URL(request.url)
     const paramsStr = searchParams.toString()
     
-    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}/logs?${paramsStr}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}/logs?${paramsStr}`, {
       headers: { 
         Authorization: `Bearer ${token}`,
       },

--- a/app/api/deployments/[id]/metrics/route.ts
+++ b/app/api/deployments/[id]/metrics/route.ts
@@ -21,7 +21,7 @@ export async function GET(
     const { searchParams } = new URL(request.url)
     const paramsStr = searchParams.toString()
     
-    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}/metrics?${paramsStr}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}/metrics?${paramsStr}`, {
       headers: { 
         Authorization: `Bearer ${token}`,
       },

--- a/app/api/deployments/[id]/restart/route.ts
+++ b/app/api/deployments/[id]/restart/route.ts
@@ -19,7 +19,7 @@ export async function POST(
 
     const { id } = await params
     
-    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}/restart`, {
+    const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}/restart`, {
       method: 'POST',
       headers: { 
         Authorization: `Bearer ${token}`,

--- a/app/api/deployments/[id]/route.ts
+++ b/app/api/deployments/[id]/route.ts
@@ -19,7 +19,7 @@ export async function GET(
 
     const { id } = await params
     
-    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}`, {
       headers: { 
         Authorization: `Bearer ${token}`,
       },
@@ -43,7 +43,7 @@ export async function DELETE(
 
     const { id } = await params
     
-    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}`, {
       method: 'DELETE',
       headers: { 
         Authorization: `Bearer ${token}`,

--- a/app/api/deployments/[id]/scale/route.ts
+++ b/app/api/deployments/[id]/scale/route.ts
@@ -20,7 +20,7 @@ export async function POST(
     const { id } = await params
     const body = await req.json()
     
-    const response = await fetch(`${API_BASE_URL}/api/deployments/${id}/scale`, {
+    const response = await fetch(`${API_BASE_URL}/v1/deployments/${id}/scale`, {
       method: 'POST',
       headers: { 
         Authorization: `Bearer ${token}`,

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       source: validation.data.source || 'contact-page',
     }
 
-    const response = await fetch(`${API_BASE_URL}/leads`, {
+    const response = await fetch(`${API_BASE_URL}/v1/leads`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/app/api/webhooks/[id]/route.ts
+++ b/app/api/webhooks/[id]/route.ts
@@ -25,7 +25,7 @@ export async function PATCH(
       return NextResponse.json({ error: "URL is required" }, { status: 400 });
     }
 
-    const response = await fetch(`${API_BASE_URL}/webhooks/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/webhooks/${id}`, {
       method: "PATCH",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -61,7 +61,7 @@ export async function DELETE(
   try {
     const { id } = await params;
 
-    const response = await fetch(`${API_BASE_URL}/webhooks/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/v1/webhooks/${id}`, {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/app/api/webhooks/[id]/test/route.ts
+++ b/app/api/webhooks/[id]/test/route.ts
@@ -19,7 +19,7 @@ export async function POST(
   try {
     const { id } = await params;
 
-    const response = await fetch(`${API_BASE_URL}/webhooks/${id}/test`, {
+    const response = await fetch(`${API_BASE_URL}/v1/webhooks/${id}/test`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/app/api/webhooks/route.ts
+++ b/app/api/webhooks/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       return unauthorized()
     }
 
-    const response = await fetch(`${API_BASE_URL}/webhooks`, {
+    const response = await fetch(`${API_BASE_URL}/v1/webhooks`, {
       headers: { 
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json"
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return validation.response
     }
 
-    const response = await fetch(`${API_BASE_URL}/webhooks`, {
+    const response = await fetch(`${API_BASE_URL}/v1/webhooks`, {
       method: "POST",
       headers: { 
         Authorization: `Bearer ${token}`,

--- a/tests/unit/apiKeyRoutes.test.ts
+++ b/tests/unit/apiKeyRoutes.test.ts
@@ -59,7 +59,7 @@ describe('API key route proxies', () => {
 
     const response = await GET(mockRequest())
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/api-keys', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/api-keys', {
       headers: {
         Authorization: 'Bearer token',
       },
@@ -108,7 +108,7 @@ describe('API key route proxies', () => {
       params: Promise.resolve({ id: 'key_123' }),
     })
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/api-keys/key_123/rotate', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/api-keys/key_123/rotate', {
       method: 'POST',
       headers: {
         Authorization: 'Bearer token',
@@ -133,7 +133,7 @@ describe('API key route proxies', () => {
       params: Promise.resolve({ id: 'key_123' }),
     })
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/api-keys/key_123', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/api-keys/key_123', {
       method: 'DELETE',
       headers: {
         Authorization: 'Bearer token',
@@ -156,7 +156,7 @@ describe('API key route proxies', () => {
 
     const response = await POST(mockJsonRequest({ name: 'blocked-key' }))
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/api-keys', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/api-keys', {
       method: 'POST',
       headers: {
         Authorization: 'Bearer token',
@@ -181,7 +181,7 @@ describe('API key route proxies', () => {
 
     const response = await POST(mockJsonRequest({ name: 'overflow-key' }))
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/api-keys', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/api-keys', {
       method: 'POST',
       headers: {
         Authorization: 'Bearer token',
@@ -209,7 +209,7 @@ describe('API key route proxies', () => {
       params: Promise.resolve({ id: 'key_123' }),
     })
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/api-keys/key_123', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/api-keys/key_123', {
       method: 'DELETE',
       headers: {
         Authorization: 'Bearer token',
@@ -237,7 +237,7 @@ describe('API key route proxies', () => {
       params: Promise.resolve({ id: 'key_123' }),
     })
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/api-keys/key_123/rotate', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/api-keys/key_123/rotate', {
       method: 'POST',
       headers: {
         Authorization: 'Bearer token',
@@ -268,7 +268,7 @@ describe('API key route proxies', () => {
 
     const response = await POST(mockJsonRequest({ name: 'build-key' }))
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/api-keys', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/api-keys', {
       method: 'POST',
       headers: {
         Authorization: 'Bearer token',
@@ -303,7 +303,7 @@ describe('API key route proxies', () => {
 
     const response = await GET(mockRequest())
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/api-keys', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/api-keys', {
       headers: {
         Authorization: 'Bearer token',
       },

--- a/tests/unit/dashboardRoutes.test.ts
+++ b/tests/unit/dashboardRoutes.test.ts
@@ -39,7 +39,7 @@ describe('dashboard route proxies', () => {
 
     const response = await GET(mockRequest())
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/auth/me', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/auth/me', {
       headers: { Authorization: 'Bearer token' },
       cache: 'no-store',
     })
@@ -63,7 +63,7 @@ describe('dashboard route proxies', () => {
 
     const response = await GET(mockRequest())
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/agents?limit=20&user_id=user_123', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/agents?limit=20&user_id=user_123', {
       headers: { Authorization: 'Bearer token' },
       cache: 'no-store',
     })
@@ -94,7 +94,7 @@ describe('dashboard route proxies', () => {
 
     const response = await GET(mockRequest())
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/agents?limit=20&user_id=user_123', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/agents?limit=20&user_id=user_123', {
       headers: { Authorization: 'Bearer token' },
       cache: 'no-store',
     })
@@ -130,7 +130,7 @@ describe('dashboard route proxies', () => {
 
     const response = await GET(mockRequest())
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/auth/me', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/auth/me', {
       headers: { Authorization: 'Bearer token' },
       cache: 'no-store',
     })
@@ -154,7 +154,7 @@ describe('dashboard route proxies', () => {
 
     const response = await GET(mockRequest())
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/deployments?limit=20&user_id=user_123', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/deployments?limit=20&user_id=user_123', {
       headers: { Authorization: 'Bearer token' },
       cache: 'no-store',
     })
@@ -185,7 +185,7 @@ describe('dashboard route proxies', () => {
 
     const response = await GET(mockRequest())
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/deployments?limit=20&user_id=user_123', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/deployments?limit=20&user_id=user_123', {
       headers: { Authorization: 'Bearer token' },
       cache: 'no-store',
     })
@@ -212,7 +212,7 @@ describe('dashboard route proxies', () => {
       json: async () => ({ agent_id: '123e4567-e89b-12d3-a456-426614174000' }),
     } as NextRequest)
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/deployments', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/deployments', {
       method: 'POST',
       headers: {
         Authorization: 'Bearer token',
@@ -235,11 +235,11 @@ describe('dashboard route proxies', () => {
     const { POST } = await import('../../app/api/dashboard/deployments/[id]/route')
 
     const response = await POST(
-      { url: 'http://localhost:3000/api/dashboard/deployments/dep_123?action=restart' } as NextRequest,
+      { url: 'http://localhost:3000/api/dashboard/v1/deployments/dep_123?action=restart' } as NextRequest,
       { params: Promise.resolve({ id: 'dep_123' }) }
     )
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/deployments/dep_123/restart', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/deployments/dep_123/restart', {
       method: 'POST',
       headers: { Authorization: 'Bearer token' },
       cache: 'no-store',
@@ -262,7 +262,7 @@ describe('dashboard route proxies', () => {
       { params: Promise.resolve({ id: 'dep_123' }) }
     )
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/deployments/dep_123', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/deployments/dep_123', {
       method: 'DELETE',
       headers: { Authorization: 'Bearer token' },
       cache: 'no-store',
@@ -282,7 +282,7 @@ describe('dashboard route proxies', () => {
 
     const response = await GET(mockRequest())
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/auth/me', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/auth/me', {
       headers: { Authorization: 'Bearer token' },
       cache: 'no-store',
     })
@@ -316,7 +316,7 @@ describe('dashboard route proxies', () => {
 
     const response = await GET(mockRequest())
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/auth/me', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/auth/me', {
       headers: { Authorization: 'Bearer token' },
       cache: 'no-store',
     })
@@ -381,7 +381,7 @@ describe('dashboard route proxies', () => {
 
     const response = await GET(mockRequest())
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/api-keys', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/api-keys', {
       headers: { Authorization: 'Bearer token' },
       cache: 'no-store',
     })
@@ -402,7 +402,7 @@ describe('dashboard route proxies', () => {
       json: async () => ({ name: 'Demo key' }),
     } as NextRequest)
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/api-keys', {
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/api-keys', {
       method: 'POST',
       headers: {
         Authorization: 'Bearer token',

--- a/tests/unit/webhooksRoutes.test.ts
+++ b/tests/unit/webhooksRoutes.test.ts
@@ -52,7 +52,7 @@ describe('Webhooks route proxies', () => {
 
       const response = await GET(mockRequest())
 
-      expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/webhooks', {
+      expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/webhooks', {
         headers: {
           Authorization: 'Bearer token',
           'Content-Type': 'application/json',
@@ -190,7 +190,7 @@ describe('Webhooks route proxies', () => {
       }))
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:8000/webhooks',
+        'http://localhost:8000/v1/webhooks',
         expect.objectContaining({
           method: 'POST',
           headers: {
@@ -233,7 +233,7 @@ describe('Webhooks route proxies', () => {
       }))
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:8000/webhooks',
+        'http://localhost:8000/v1/webhooks',
         expect.objectContaining({
           method: 'POST',
           headers: {


### PR DESCRIPTION
## Summary

Aligns frontend routes with backend API contract per roadmap item "CLI, SDK, and API contract alignment".

## Changes

The FastAPI backend uses  prefix for all API routes. This PR updates all frontend API proxy routes to use the correct prefix:

| Path Type | Before | After |
|-----------|--------|-------|
| Auth |  |  |
| Agents |  |  |
| Deployments |  |  |
| API Keys |  |  |
| Leads |  |  |
| Webhooks |  |  |

## Testing

- `npm run build` passes
- `npm run test:app` passes (70 tests)