### PR TITLE
fix(api): consolidate Plan enum into PlanTier

### DIFF
--- a/src/api/models/models.py
+++ b/src/api/models/models.py
@@ -7,6 +7,7 @@ from sqlalchemy.dialects.postgresql import UUID, ARRAY as PG_ARRAY
 import enum
 
 from src.api.database import Base
+from src.api.models.plan_tiers import PlanTier
 
 
 def ARRAY(type_):
@@ -80,8 +81,7 @@ class User(Base):
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     password_hash: Mapped[str] = mapped_column(String(255), nullable=True)
-    plan: Mapped[Plan] = mapped_column(SQLEnum(Plan), default=Plan.FREE)
-    tier: Mapped[Plan] = mapped_column(SQLEnum(Plan), default=Plan.FREE)
+    plan: Mapped[PlanTier] = mapped_column(SQLEnum(PlanTier), default=PlanTier.FREE)
     api_key: Mapped[str] = mapped_column(String(64), unique=True, nullable=True, index=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)


### PR DESCRIPTION
Consolidates legacy Plan enum into PlanTier from plan_tiers.py

- Import PlanTier in models.py
- Remove duplicate tier field 
- Use PlanTier for plan field

Part of #506