### PR TITLE
fix: ensure sonner dependency is installed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "react-turnstile": "^1.1.5",
         "resend": "^6.9.3",
         "sharp": "^0.33.5",
-        "sonner": "^1.7.0",
+        "sonner": "^1.7.4",
         "tailwind-merge": "^2.4.0",
         "three": "^0.169.0"
       },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-turnstile": "^1.1.5",
     "resend": "^6.9.3",
     "sharp": "^0.33.5",
-    "sonner": "^1.7.0",
+    "sonner": "^1.7.4",
     "tailwind-merge": "^2.4.0",
     "three": "^0.169.0"
   },


### PR DESCRIPTION
## Summary

Missing sonner package caused build failure. This fix ensures the sonner dependency is properly installed.

## Changes
- Reinstalled sonner package to fix Toaster component import error

## Testing
- `npm run build` passes successfully

Closes: build fix