### PR TITLE
fix(cli): update api_url to strip /v1 suffix instead of /api

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -39,10 +39,10 @@ class CLIConfig:
 
     @api_url.setter
     def api_url(self, value: str):
-        # Strip trailing /api to avoid double-path issues
-        # since CLI commands explicitly add /api prefix
-        if value.endswith("/api"):
-            value = value[:-4]
+        # Strip trailing /v1 to avoid double-path issues
+        # since CLI commands explicitly add /v1 prefix
+        if value.endswith("/v1"):
+            value = value[:-3]
         self._config["api_url"] = value
         self.save()
 


### PR DESCRIPTION
## Summary

The CLI uses  paths, not . This fix updates the  setter in  to correctly strip trailing  to avoid double-path issues.

## Changes

- Updated comment to reference  instead of 
- Changed the suffix stripping logic from  (4 chars) to  (3 chars)

## Testing

- Python syntax check passed
- Import test passed
- Manual verification of URL stripping logic passed

## Edge cases handled

1.  suffix is correctly stripped (new behavior)
2. Base URL without suffix remains unchanged
3. Old-style  suffix is no longer stripped (was incorrect)

Fixes #557