### PR TITLE
Potential fix for code scanning alert no. 2: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/src/api/services/user_service.py
+++ b/src/api/services/user_service.py
@@ -28,7 +28,8 @@ def generate_user_api_key() -> str:
 
 
 def hash_api_key(key: str) -> str:
-    return hashlib.sha256(key.encode()).hexdigest()
+    # Use a computationally expensive hash (bcrypt via passlib) for API keys
+    return api_key_context.hash(key)
 
 
 def verify_api_key(plain_key: str, hashed_key: str) -> bool:


### PR DESCRIPTION
Potential fix for [https://github.com/mutx-dev/mutx-dev/security/code-scanning/2](https://github.com/mutx-dev/mutx-dev/security/code-scanning/2)

In general, the fix is to stop using a fast general‑purpose hash (SHA‑256) directly on sensitive authentication material and instead use a password hashing/KDF function that is intentionally computationally expensive, such as bcrypt via `passlib`. Since this file already defines a `CryptContext` with `schemes=["bcrypt"]`, we can reuse it to hash API keys and to verify them.

Concretely, we should:
- Change `hash_api_key` to use `api_key_context.hash(key)` instead of `hashlib.sha256(...)`.
- Leave `verify_api_key` logic intact: it first does a constant‑time compare against the existing hash output (for legacy records) and then falls back to `api_key_context.verify`. However, once we switch `hash_api_key` to bcrypt, new keys will be created in bcrypt format; the initial `secrets.compare_digest(hash_api_key(plain_key), hashed_key)` then becomes redundant for new entries but still harmless, and it may help with old SHA‑256 hashes if any exist.
- No new imports are strictly necessary because `CryptContext` and `api_key_context` are already present. We keep `import hashlib` only if it’s used elsewhere in this file; otherwise, it could be removed, but since you didn’t show the whole file, we won’t touch it.

The main code change is in `src/api/services/user_service.py` around the `hash_api_key` definition (line 30–32). We replace the SHA‑256 hashing call with a bcrypt hash using `api_key_context`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
