### PR TITLE
docs: local dev quickstart (fixes #561)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ MUTX is building the infrastructure layer for deploying and operating agents saf
 
 ---
 
+# Local Development
+
+## Quick Start (Makefile)
+
+```bash
+make help              # Show all available commands
+make dev               # Start local dev stack (Docker Compose)
+make test-auth         # Register test user, login, get token (one-command)
+make test-api          # Run API health tests
+make lint              # Run linters
+```
+
+After `make test-auth`, you will have:
+- A registered test user
+- A valid access token
+- Ready-to-copy curl examples
+
+Frontend: http://localhost:3000 | Backend: http://localhost:8000 | API Docs: http://localhost:8000/docs
+
 # Project Structure
 
 mutx-dev/


### PR DESCRIPTION
## Summary

Adds a Local Development section to README.md documenting the Makefile targets for quick local setup.

## Changes

- Added "Local Development" section with Makefile quickstart
- Documents 🧪 MUTX Auth Flow - One-Command Setup
======================================

Registering test user...
✓ User registered (or already exists)

Logging in... as one-command auth setup
- Lists service URLs (frontend, backend, API docs)

## Acceptance (from #561)

- [x] Reduce manual curl setup needed to test API locally (via `make test-auth`)
- [x] Add local dev script or makefile targets (Makefile already exists)
- [x] Document minimal local dev workflow (this PR)