### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/mutx-dev/mutx-dev/security/code-scanning/1](https://github.com/mutx-dev/mutx-dev/security/code-scanning/1)

In general, fix this by adding a `permissions` block that grants only the minimal scopes needed by the workflow, either at the top level (applies to all jobs) or within the specific job. For this CI workflow, all steps only read repository contents and run local commands; they do not push commits, create releases, or modify issues/PRs. Therefore `contents: read` is sufficient.

The single best minimal fix without changing behavior is to add a root-level `permissions` block immediately under the workflow `name` (before `on:`), setting `contents: read`. This will apply to the `validate` job (and any future jobs that don’t override permissions), constraining the `GITHUB_TOKEN` while keeping everything functional. No additional imports, tools, or changes to steps are required.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: CI`) and before the existing `on:` block. No other regions need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
