### PR TITLE
feat(analytics): add event tracking (issue #264)

### DIFF
--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.api.database import get_db
 from src.api.models.models import User
 from src.api.services.user_service import UserService
+from src.api.services.analytics import log_analytics_event, AnalyticsEventType
 from src.api.middleware.auth import get_current_user
 from src.api.auth.jwt import (
     create_access_token,
@@ -93,6 +94,14 @@ async def register(request: RegisterRequest, session: AsyncSession = Depends(get
     access_token, access_token_expires_at = create_access_token(user.id)
     refresh_token, _ = create_refresh_token(user.id)
 
+    # Track analytics event
+    await log_analytics_event(
+        session,
+        event_name="User logged in",
+        event_type=AnalyticsEventType.USER_LOGIN,
+        user_id=user.id,
+    )
+
     return TokenResponse(
         access_token=access_token,
         refresh_token=refresh_token,
@@ -122,6 +131,14 @@ async def login(request: LoginRequest, session: AsyncSession = Depends(get_db)):
 
     access_token, access_token_expires_at = create_access_token(user.id)
     refresh_token, _ = create_refresh_token(user.id)
+
+    # Track analytics event
+    await log_analytics_event(
+        session,
+        event_name="User logged in",
+        event_type=AnalyticsEventType.USER_LOGIN,
+        user_id=user.id,
+    )
 
     return TokenResponse(
         access_token=access_token,

--- a/src/api/routes/runs.py
+++ b/src/api/routes/runs.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import selectinload
 from src.api.database import get_db
 from src.api.middleware.auth import get_current_user
 from src.api.models import Agent, AgentRun, AgentRunTrace, User, UsageEvent
+from src.api.services.analytics import log_analytics_event, AnalyticsEventType
 from src.api.models.schemas import (
     RunCreate,
     RunDetailResponse,
@@ -127,6 +128,15 @@ async def create_run(
         )
 
     await db.commit()
+
+    # Track analytics event
+    await log_analytics_event(
+        db,
+        event_name="Agent run created",
+        event_type=AnalyticsEventType.AGENT_RUN_STARTED,
+        user_id=current_user.id,
+        properties={"agent_id": str(agent.id), "run_id": str(run.id)},
+    )
 
     # Track usage event
     usage_event = UsageEvent(


### PR DESCRIPTION
## Summary

Quick win for issue #264 - adds basic analytics event tracking:

- Adds AnalyticsEvent model and service
- Tracks agent_run.started when a run is created
- Tracks user.login when user logs in or registers

## Testing

Run the API and verify events are logged to the analytics_events table.