### PR TITLE
feat(dashboard): add API key expiration option

### DIFF
--- a/components/app/ApiKeysPageClient.tsx
+++ b/components/app/ApiKeysPageClient.tsx
@@ -16,6 +16,7 @@ export function ApiKeysPageClient() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [newKeyName, setNewKeyName] = useState('');
+  const [newKeyExpires, setNewKeyExpires] = useState<number | null>(null);
   const [creating, setCreating] = useState(false);
   const [createdKey, setCreatedKey] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -80,7 +81,7 @@ export function ApiKeysPageClient() {
       const res = await fetch('/api/api-keys', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: newKeyName.trim() }),
+        body: JSON.stringify({ name: newKeyName.trim(), expires_in_days: newKeyExpires }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({ detail: 'Failed to create' }));
@@ -89,6 +90,7 @@ export function ApiKeysPageClient() {
       const data = await res.json();
       setCreatedKey(data.key);
       setNewKeyName('');
+      setNewKeyExpires(null);
       fetchKeys();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create API key');
@@ -201,6 +203,18 @@ export function ApiKeysPageClient() {
             placeholder="e.g., Production API Key"
             className="flex-1 rounded-lg border border-white/10 bg-black/20 px-4 py-2.5 text-white placeholder:text-slate-500 focus:border-cyan-400/50 focus:outline-none"
           />
+          <select
+            value={newKeyExpires ?? ''}
+            onChange={(e) => setNewKeyExpires(e.target.value ? Number(e.target.value) : null)}
+            className="rounded-lg border border-white/10 bg-black/20 px-3 py-2.5 text-sm text-white"
+          >
+            <option value="">Never</option>
+            <option value="30">30 days</option>
+            <option value="60">60 days</option>
+            <option value="90">90 days</option>
+            <option value="180">6 months</option>
+            <option value="365">1 year</option>
+          </select>
           <button
             type="submit"
             disabled={creating || !newKeyName.trim()}
@@ -255,7 +269,7 @@ export function ApiKeysPageClient() {
                   </div>
                   <div className="flex gap-4 mt-2 text-xs text-slate-500">
                     <span>Created: {formatDate(key.created_at)}</span>
-                    <span>Last used: {formatDate(key.last_used)}</span>
+                    <span>Expires: {formatDate(key.expires_at)}</span>
                   </div>
                 </div>
                 <div className="flex gap-2">

--- a/fix.mjs
+++ b/fix.mjs
@@ -1,0 +1,63 @@
+import fs from 'fs';
+const f = 'components/app/ApiKeysPageClient.tsx';
+let c = fs.readFileSync(f, 'utf8');
+
+// Add EXPIRATION_OPTIONS after interface
+c = c.replace(
+  /interface ApiKey \{[\s\S]*?expires_at: string \| null;\n\}/,
+  `interface ApiKey {
+  id: string;
+  name: string;
+  created_at: string;
+  last_used: string | null;
+  expires_at: string | null;
+}
+
+const EXPIRATION_OPTIONS = [
+  { value: null, label: 'Never' },
+  { value: 30, label: '30 days' },
+  { value: 60, label: '60 days' },
+  { value: 90, label: '90 days' },
+  { value: 180, label: '6 months' },
+  { value: 365, label: '1 year' },
+];
+`
+);
+
+// Add newKeyExpires state
+c = c.replace(
+  "const [newKeyName, setNewKeyName] = useState('');",
+  "const [newKeyName, setNewKeyName] = useState('');\n  const [newKeyExpires, setNewKeyExpires] = useState<number | null>(null);"
+);
+
+// Update createKey function to include expires_in_days
+c = c.replace(
+  "body: JSON.stringify({ name: newKeyName.trim() }),",
+  "body: JSON.stringify({ name: newKeyName.trim(), expires_in_days: newKeyExpires }),"
+);
+
+// Reset form after creation  
+c = c.replace(
+  "setNewKeyName('');\n      fetchKeys();",
+  "setNewKeyName('');\n      setNewKeyExpires(null);\n      fetchKeys();"
+);
+
+// Add select dropdown - find the input and add select after it
+c = c.replace(
+  /(className="flex-1 rounded-lg[^>]+>)\s*(\n\s*<button)/,
+  `$1</select>$2`
+);
+
+c = c.replace(
+  /(<input[^>]*className="flex-1[^>]*>)/,
+  `$1\n            <select\n              value={newKeyExpires ?? ''}\n              onChange={(e) => setNewKeyExpires(e.target.value ? Number(e.target.value) : null)}\n              className="rounded-lg border border-white/10 bg-black/20 px-3 py-2.5 text-sm text-white"\n            >\n              <option value="">Never</option>\n              <option value="30">30 days</option>\n              <option value="60">60 days</option>\n              <option value="90">90 days</option>\n              <option value="180">6 months</option>\n              <option value="365">1 year</option>\n            </select>`
+);
+
+// Change "Last used" to "Expires" in list
+c = c.replace(
+  /<span>Last used: \{formatDate\(key\.last_used\)\}<\/span>/,
+  '<span>Expires: {formatDate(key.expires_at)}</span>'
+);
+
+fs.writeFileSync(f, c);
+console.log('done');

--- a/fix2.mjs
+++ b/fix2.mjs
@@ -1,0 +1,24 @@
+import fs from 'fs';
+const f = 'components/app/ApiKeysPageClient.tsx';
+let c = fs.readFileSync(f, 'utf8');
+
+// Add newKeyExpires state after newKeyName state
+c = c.replace(
+  "const [newKeyName, setNewKeyName] = useState('');",
+  "const [newKeyName, setNewKeyName] = useState('');\n  const [newKeyExpires, setNewKeyExpires] = useState<number | null>(null);"
+);
+
+// Update createKey function - add expires_in_days to payload
+c = c.replace(
+  "body: JSON.stringify({ name: newKeyName.trim() }),",
+  "body: JSON.stringify({ name: newKeyName.trim(), expires_in_days: newKeyExpires }),"
+);
+
+// Reset newKeyExpires after successful creation
+c = c.replace(
+  "setNewKeyName('');\n      fetchKeys();",
+  "setNewKeyName('');\n      setNewKeyExpires(null);\n      fetchKeys();"
+);
+
+fs.writeFileSync(f, c);
+console.log('done');


### PR DESCRIPTION
## Summary

Add expiration options to API key creation form in the MUTX dashboard.

## Changes

- Add  parameter to API key creation
- Add expiration dropdown (Never, 30 days, 60 days, 90 days, 6 months, 1 year)
- Display expiration date in key list (replaces "Last used")

## Related

Part of "Contact and API key workflows" from ROADMAP.md - "expose a usable API key lifecycle for automation"