### PR TITLE
test: add analytics and budgets API route coverage

### DIFF
--- a/tests/api/test_analytics.py
+++ b/tests/api/test_analytics.py
@@ -1,0 +1,81 @@
+"""
+Tests for /analytics endpoints.
+"""
+
+import pytest
+import uuid
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class TestAnalyticsSummary:
+    """Tests for GET /analytics/summary endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_analytics_summary_authenticated(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        """Test getting analytics summary as authenticated user."""
+        from src.api.models.models import Agent, AgentStatus
+
+        # Create a test agent
+        agent = Agent(
+            id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+            user_id=test_user.id,
+            name="test-agent",
+            description="Test agent",
+            type="openai",
+            status=AgentStatus.RUNNING,
+            config='{"name": "test-agent", "model": "gpt-4o"}',
+        )
+        db_session.add(agent)
+        await db_session.commit()
+
+        response = await client.get("/v1/analytics/summary")
+        assert response.status_code == 200
+        data = response.json()
+        assert "total_agents" in data
+        assert "active_agents" in data
+        assert "period_start" in data
+        assert "period_end" in data
+
+
+class TestAgentMetricsSummary:
+    """Tests for GET /analytics/agents/{agent_id}/summary endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_agent_metrics_summary_not_found(self, client: AsyncClient):
+        """Test 404 for non-existent agent."""
+        response = await client.get(
+            "/v1/analytics/agents/99999999-9999-9999-9999-999999999999/summary"
+        )
+        assert response.status_code == 404
+
+
+class TestCostSummary:
+    """Tests for GET /analytics/costs endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_cost_summary_authenticated(self, client: AsyncClient):
+        """Test getting cost summary as authenticated user."""
+        response = await client.get("/v1/analytics/costs")
+        assert response.status_code == 200
+        data = response.json()
+        assert "total_credits_used" in data
+        assert "credits_remaining" in data
+        assert "credits_total" in data
+
+
+class TestBudgetEndpoint:
+    """Tests for GET /analytics/budget endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_budget_authenticated(self, client: AsyncClient):
+        """Test getting budget as authenticated user."""
+        response = await client.get("/v1/analytics/budget")
+        assert response.status_code == 200
+        data = response.json()
+        assert "user_id" in data
+        assert "plan" in data
+        assert "credits_total" in data
+        assert "credits_used" in data

--- a/tests/api/test_budgets.py
+++ b/tests/api/test_budgets.py
@@ -1,0 +1,51 @@
+"""
+Tests for /budgets endpoints.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+
+class TestGetBudget:
+    """Tests for GET /budgets endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_budget_authenticated(self, client: AsyncClient):
+        """Test getting budget as authenticated user."""
+        response = await client.get("/v1/budgets")
+        assert response.status_code == 200
+        data = response.json()
+        assert "user_id" in data
+        assert "plan" in data
+        assert "credits_total" in data
+        assert "credits_used" in data
+        assert "credits_remaining" in data
+        assert "reset_date" in data
+        assert "usage_percentage" in data
+
+
+class TestGetUsageBreakdown:
+    """Tests for GET /budgets/usage endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_usage_breakdown_authenticated(self, client: AsyncClient):
+        """Test getting usage breakdown as authenticated user."""
+        response = await client.get("/v1/budgets/usage")
+        assert response.status_code == 200
+        data = response.json()
+        assert "total_credits_used" in data
+        assert "credits_remaining" in data
+        assert "credits_total" in data
+        assert "period_start" in data
+        assert "period_end" in data
+        assert "usage_by_agent" in data
+        assert "usage_by_type" in data
+
+    @pytest.mark.asyncio
+    async def test_get_usage_breakdown_with_period(self, client: AsyncClient):
+        """Test getting usage breakdown with period parameter."""
+        response = await client.get("/v1/budgets/usage?period_start=7d")
+        assert response.status_code == 200
+        data = response.json()
+        assert "period_start" in data
+        assert "period_end" in data


### PR DESCRIPTION
## Summary

Add test coverage for previously untested API routes:

- **tests/api/test_analytics.py** - Tests for /analytics endpoints
- **tests/api/test_budgets.py** - Tests for /budgets endpoints

7 new passing tests. All 220 API tests pass.

Closes #615