### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/src/api/middleware/rate_limit.py
+++ b/src/api/middleware/rate_limit.py
@@ -119,8 +119,8 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self._requests.setdefault(client_id, []).append(datetime.now(timezone.utc))
 
         logger.debug(
-            "Rate limit check | client=%s | count=%s | limit=%s | path=%s",
-            client_id,
+            "Rate limit check | client_fp=%s | count=%s | limit=%s | path=%s",
+            self._fingerprint(client_id),
             current_count + 1,
             self.requests,
             path,


### PR DESCRIPTION
Potential fix for [https://github.com/mutx-dev/mutx-dev/security/code-scanning/4](https://github.com/mutx-dev/mutx-dev/security/code-scanning/4)

In general, to fix clear-text logging of potentially sensitive values, you should avoid logging raw secrets or identifiers that may embed secrets. Instead, either remove them from logs or replace them with non-sensitive derivatives (e.g., truncated hashes) that allow correlation without revealing the original value.

For this specific case in `src/api/middleware/rate_limit.py`, the best fix without changing behavior is to keep using `client_id` internally for rate limiting, but avoid printing it directly in logs. We already have a `_fingerprint` helper that produces a truncated SHA-256 hash of a string. We can reuse this to create a log-safe representation of `client_id`. The minimal change is to modify the `logger.debug` call in `dispatch` to log `self._fingerprint(client_id)` instead of `client_id`, and adjust the log message text to reflect that it is a fingerprint. This keeps operational usefulness (we can still correlate requests from the same client) while preventing leakage of `auth_api_key_identifier` or other sensitive identifiers. No new imports or additional helpers are needed, since `_fingerprint` already exists.

Concretely:
- In `dispatch`, around line 121–127, update the debug log statement to:
  - Change the message to mention `client_fp` or similar instead of `client`.
  - Pass `self._fingerprint(client_id)` as the first format argument.
- Leave all other behavior unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
