### PR TITLE
docs: add OpenTelemetry documentation and Docker examples (Issue #1029)

### DIFF
--- a/docs/otel.md
+++ b/docs/otel.md
@@ -1,0 +1,358 @@
+# OpenTelemetry Configuration Guide
+
+This guide covers OpenTelemetry integration for distributed tracing in MUTX.
+
+## Overview
+
+MUTX supports OpenTelemetry for distributed tracing, enabling you to track requests across services. The system exports traces to configurable backends like Jaeger, Grafana Tempo, or any OTLP-compatible collector.
+
+## Quick Start
+
+### 1. Install Dependencies
+
+Ensure you have the required packages:
+
+```bash
+pip install opentelemetry-api   opentelemetry-sdk   opentelemetry-exporter-otlp   opentelemetry-instrumentation-flask   opentelemetry-instrumentation-requests
+```
+
+### 2. Configure Environment Variables
+
+Add these to your `.env` file:
+
+```bash
+# Enable OpenTelemetry
+OTEL_ENABLED=true
+OTEL_SERVICE_NAME=mutx-api
+
+# Choose your exporter (otlp, jaeger, zipkin)
+OTEL_EXPORTER=otlp
+
+# For OTLP (HTTP)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+
+# For Jaeger
+OTEL_EXPORTER_JAEGER_ENDPOINT=http://localhost:14268/api/traces
+
+# For Zipkin
+OTEL_EXPORTER_ZIPKIN_ENDPOINT=http://localhost:9411/api/v2/spans
+```
+
+### 3. Initialize in Your Application
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+
+# Configure resource
+resource = Resource(attributes={
+    SERVICE_NAME: os.getenv("OTEL_SERVICE_NAME", "mutx-api"),
+    "deployment.environment": os.getenv("ENVIRONMENT", "development")
+})
+
+# Setup provider
+provider = TracerProvider(resource=resource)
+processor = BatchSpanProcessor(OTLPSpanExporter(
+    endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318/v1/traces")
+))
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+
+# Auto-instrument requests
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+
+FlaskInstrumentor().instrument_app(app)
+RequestsInstrumentor().instrument()
+```
+
+## Environment Variable Configuration
+
+### General Settings
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_ENABLED` | Enable/disable tracing | `false` |
+| `OTEL_SERVICE_NAME` | Service name for traces | `mutx-api` |
+| `OTEL_SERVICE_NAMESPACE` | Service namespace | - |
+| `OTEL_ENVIRONMENT` | Deployment environment | `development` |
+| `OTEL_DEBUG` | Enable debug logging | `false` |
+
+### Exporter Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_EXPORTER` | Exporter type: `otlp`, `jaeger`, `zipkin` | `otlp` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP HTTP endpoint | `http://localhost:4318` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | OTLP protocol | `http/protobuf` |
+| `OTEL_EXPORTER_OTLP_CERT` | TLS certificate path | - |
+| `OTEL_EXPORTER_JAEGER_ENDPOINT` | Jaeger HTTP thrift endpoint | `http://localhost:14268` |
+| `OTEL_EXPORTER_JAEGER_AGENT_HOST` | Jaeger agent host | `localhost` |
+| `OTEL_EXPORTER_JAEGER_AGENT_PORT` | Jaeger agent port | `6831` |
+| `OTEL_EXPORTER_ZIPKIN_ENDPOINT` | Zipkin API endpoint | `http://localhost:9411` |
+
+### Sampling Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_TRACES_SAMPLER` | Sampler type: `always_on`, `always_off`, `parentbased_always_on`, `parentbased_always_off`, `traceidratio` | `always_on` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler argument (e.g., `0.1` for 10%) | - |
+
+### Resource Attributes
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated k=v pairs | - |
+
+### Propagators
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_PROPAGATORS` | Comma-separated: `tracecontext`, `baggage`, `b3`, `jaeger` | `tracecontext` |
+
+## Docker Compose Examples
+
+### Option 1: Grafana Tempo + Grafana + Prometheus
+
+This stack provides full observability with Tempo for traces, Prometheus for metrics, and Grafana for visualization.
+
+```bash
+cd infrastructure/docker
+docker-compose -f otel-compose.yml up -d tempo
+```
+
+Or use the Makefile:
+
+```bash
+make up-otel-tempo
+```
+
+Access:
+- Grafana: http://localhost:3001 (traces via Tempo)
+- Tempo: http://localhost:3200
+
+### Option 2: Jaeger (All-in-One)
+
+Quick setup for development:
+
+```bash
+docker-compose -f otel-compose.yml up -d jaeger
+```
+
+Access:
+- Jaeger UI: http://localhost:16686
+
+### Option 3: OpenTelemetry Collector + Prometheus + Grafana
+
+Full stack with collector:
+
+```bash
+docker-compose -f otel-compose.yml up -d otel-collector
+```
+
+Access:
+- Grafana: http://localhost:3001
+- Prometheus: http://localhost:9090
+- OTLP Receiver: http://localhost:4318
+
+See `infrastructure/docker/otel-compose.yml` for complete configuration.
+
+## Troubleshooting
+
+### Enable Debug Logging
+
+Set `OTEL_DEBUG=true` to enable verbose logging:
+
+```bash
+OTEL_DEBUG=true OTEL_ENABLED=true docker-compose up
+```
+
+Or add to your `.env`:
+
+```bash
+OTEL_DEBUG=true
+```
+
+Debug mode outputs:
+- Span creation and completion
+- Exporter connection attempts
+- Sampling decisions
+- Propagator details
+
+### Common Issues
+
+#### No traces appearing
+
+1. **Check OTEL_ENABLED is set**
+   ```bash
+   echo $OTEL_ENABLED  # Should be "true"
+   ```
+
+2. **Verify network connectivity**
+   ```bash
+   curl http://localhost:4318/v1/traces
+   ```
+
+3. **Check collector/receiver logs**
+   ```bash
+   docker logs mutx-otel-collector
+   docker logs mutx-tempo
+   ```
+
+4. **Verify exporter endpoint**
+   ```bash
+   # For OTLP
+   echo $OTEL_EXPORTER_OTLP_ENDPOINT
+   
+   # For Jaeger
+   curl -s http://localhost:14268/api/traces/status
+   ```
+
+#### High memory usage
+
+Reduce sampling rate:
+
+```bash
+OTEL_TRACES_SAMPLER=traceidratio
+OTEL_TRACES_SAMPLER_ARG=0.1
+```
+
+#### Export timeouts
+
+Increase timeout:
+
+```bash
+OTEL_EXPORTER_OTLP_TIMEOUT=30000
+```
+
+### Verification Commands
+
+```bash
+# Check if spans are being exported
+curl -X POST http://localhost:4318/v1/traces   -H "Content-Type: application/json"   -d '{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"test"}}]}}]}'
+```
+
+### Checking Service Status
+
+```python
+from opentelemetry import trace
+
+# Get tracer provider status
+provider = trace.get_tracer_provider()
+print(f"Tracer provider: {provider}")
+```
+
+## Redaction Configuration
+
+By default, certain sensitive attributes are redacted from traces.
+
+### Default Redacted Attributes
+
+The following attributes are NOT exported to tracing backends:
+
+- `http.request.body` - Request body content
+- `http.response.body` - Response body content
+- `token` - Authentication tokens
+- `password` - Password fields
+- `api_key` - API keys
+- `authorization` - Authorization headers
+- `x-api-key` - API key headers
+
+### Custom Redaction
+
+To customize redaction, set environment variables:
+
+```bash
+# Add custom sensitive keys
+OTEL_REDACTED_ATTRIBUTES=secret,private_token,credit_card
+
+# Disable all redaction (not recommended for production)
+OTEL_REDACTION_ENABLED=false
+```
+
+### Implementing Custom Redaction
+
+```python
+from opentelemetry.sdk.trace import SpanProcessor
+
+class RedactingSpanProcessor(SpanProcessor):
+    SENSITIVE_ATTRIBUTES = {
+        'password', 'token', 'api_key', 'authorization',
+        'secret', 'private_token', 'credit_card'
+    }
+    
+    def on_end(self, span):
+        for key in list(span.attributes.keys()):
+            if key.lower() in self.SENSITIVE_ATTRIBUTES:
+                span.attributes[key] = '[REDACTED]'
+
+# Add to your tracer provider
+provider.add_span_processor(RedactingSpanProcessor())
+```
+
+### Redacting Specific Spans
+
+```python
+from opentelemetry import trace
+
+tracer = trace.get_tracer(__name__)
+
+with tracer.start_as_current_span("sensitive-operation") as span:
+    span.set_attribute("password", "[REDACTED]")
+    span.set_attribute("api_key", "[REDACTED]")
+```
+
+## Integration Examples
+
+### Flask Application
+
+```python
+from flask import Flask
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+
+app = Flask(__name__)
+
+# Initialize after creating app
+FlaskInstrumentor().instrument_app(app)
+```
+
+### FastAPI Application
+
+```python
+from fastapi import FastAPI
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+app = FastAPI()
+
+FastAPIInstrumentor.instrument_app(app)
+```
+
+### Custom Span Creation
+
+```python
+from opentelemetry import trace
+
+tracer = trace.get_tracer(__name__)
+
+def process_data(data):
+    with tracer.start_as_current_span("process_data") as span:
+        span.set_attribute("data.type", type(data).__name__)
+        span.set_attribute("data.size", len(data))
+        
+        # Nested span
+        with tracer.start_as_current_span("transform") as transform_span:
+            result = transform(data)
+            transform_span.set_attribute("result.size", len(result))
+        
+        return result
+```
+
+## Related Files
+
+- `infrastructure/docker/otel-compose.yml` - Docker Compose stacks
+- `.env.example` - Environment variable template
+- `src/api/metrics.py` - Prometheus metrics (complementary to traces)

--- a/infrastructure/docker/grafana-provisioning/datasources/datasources.yml
+++ b/infrastructure/docker/grafana-provisioning/datasources/datasources.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+  
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false

--- a/infrastructure/docker/otel-collector-config.yaml
+++ b/infrastructure/docker/otel-collector-config.yaml
@@ -1,0 +1,65 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+  
+  zipkin:
+    endpoint: 0.0.0.0:9411
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 1000
+  
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 400
+  
+  # Redact sensitive attributes
+  attributes:
+    actions:
+      - key: password
+        action: delete
+      - key: token
+        action: delete
+      - key: authorization
+        action: delete
+      - key: api_key
+        action: delete
+      - key: secret
+        action: delete
+
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    namespace: otel
+    const_labels:
+      service: mutx
+  
+  jaeger:
+    endpoint: jaeger:14250
+    tls:
+      insecure: true
+  
+  otlp:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  
+  logging:
+    loglevel: debug
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp, zipkin]
+      processors: [memory_limiter, batch, attributes]
+      exporters: [jaeger, otlp, logging]
+    
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [prometheus, logging]

--- a/infrastructure/docker/otel-compose.yml
+++ b/infrastructure/docker/otel-compose.yml
@@ -1,0 +1,166 @@
+version: '3.8'
+
+# OpenTelemetry Docker Compose Examples
+# Usage: docker-compose -f otel-compose.yml up -d <service>
+# Services: tempo, jaeger, otel-collector
+
+services:
+  # ============================================
+  # Option 1: Grafana Tempo + Grafana + Prometheus
+  # Best for: Production tracing with metrics
+  # ============================================
+  tempo:
+    image: grafana/tempo:2.4.1
+    container_name: mutx-tempo
+    command: ["-config.file=/tempo.yaml"]
+    volumes:
+      - ./tempo.yaml:/tempo.yaml:ro
+      - tempo_data:/tempo
+    ports:
+      - "3200:3200"     # tempo query
+      - "4317:4317"     # OTLP gRPC
+      - "4318:4318"     # OTLP HTTP
+      - "9411:9411"     # zipkin
+    restart: unless-stopped
+    networks:
+      - otel
+
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: mutx-prometheus-otel
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    restart: unless-stopped
+    networks:
+      - otel
+
+  grafana:
+    image: grafana/grafana:11.2.2
+    container_name: mutx-grafana-otel
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    ports:
+      - "3001:3000"
+    volumes:
+      - ./grafana-provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    restart: unless-stopped
+    networks:
+      - otel
+    depends_on:
+      - tempo
+      - prometheus
+
+  # ============================================
+  # Option 2: Jaeger (All-in-One)
+  # Best for: Quick development setup
+  # ============================================
+  jaeger:
+    image: jaegertracing/all-in-one:1.54
+    container_name: mutx-jaeger
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - SPAN_STORAGE_TYPE=badger
+      - BADGER_EPHEMERAL=false
+      - BADGER_DIRECTORY_VALUE=/var/lib/jaeger/data
+      - BADGER_DIRECTORY_KEY=/var/lib/jaeger/index
+    ports:
+      - "16686:16686"     # Jaeger UI
+      - "4317:4317"       # OTLP gRPC
+      - "4318:4318"       # OTLP HTTP
+      - "14268:14268"     # Jaeger HTTP
+      - "14250:14250"     # Jaeger gRPC
+    volumes:
+      - jaeger_data:/var/lib/jaeger
+    restart: unless-stopped
+    networks:
+      - otel
+
+  # ============================================
+  # Option 3: OpenTelemetry Collector + Prometheus + Grafana
+  # Best for: Full control over telemetry pipeline
+  # ============================================
+  otel-collector:
+    image: otel/opentelemetry-collector:0.102.1
+    container_name: mutx-otel-collector
+    command: ["--config=/etc/otelcol-contrib/otelcol-contrib.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/otelcol-contrib.yaml:ro
+    ports:
+      - "4317:4317"       # OTLP gRPC receiver
+      - "4318:4318"       # OTLP HTTP receiver
+      - "8888:8888"       # Prometheus metrics exposed by the collector
+      - "8889:8889"       # Prometheus metrics exporter
+      - "17000:17000"     # zipkin receiver
+    restart: unless-stopped
+    networks:
+      - otel
+    depends_on:
+      - prometheus
+      - grafana
+
+  prometheus-for-collector:
+    image: prom/prometheus:v2.54.1
+    container_name: mutx-prometheus-collector
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./prometheus-collector.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_collector_data:/prometheus
+    restart: unless-stopped
+    networks:
+      - otel
+
+  grafana-for-collector:
+    image: grafana/grafana:11.2.2
+    container_name: mutx-grafana-collector
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    ports:
+      - "3002:3000"
+    volumes:
+      - ./grafana-provisioning:/etc/grafana/provisioning:ro
+      - grafana_collector_data:/var/lib/grafana
+    restart: unless-stopped
+    networks:
+      - otel
+
+  # ============================================
+  # Zipkin (Optional standalone)
+  # ============================================
+  zipkin:
+    image: openzipkin/zipkin:3.0
+    container_name: mutx-zipkin
+    ports:
+      - "9411:9411"
+    restart: unless-stopped
+    networks:
+      - otel
+
+volumes:
+  tempo_data:
+  prometheus_data:
+  grafana_data:
+  jaeger_data:
+  prometheus_collector_data:
+  grafana_collector_data:
+
+networks:
+  otel:
+    driver: bridge

--- a/infrastructure/docker/prometheus-collector.yml
+++ b/infrastructure/docker/prometheus-collector.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9091']
+
+  - job_name: 'otel-collector'
+    static_configs:
+      - targets: ['otel-collector:8888', 'otel-collector:8889']

--- a/infrastructure/docker/prometheus.yml
+++ b/infrastructure/docker/prometheus.yml
@@ -1,0 +1,16 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'tempo'
+    static_configs:
+      - targets: ['tempo:3200']
+
+  - job_name: 'otel-collector'
+    static_configs:
+      - targets: ['otel-collector:8888', 'otel-collector:8889']

--- a/infrastructure/docker/tempo.yaml
+++ b/infrastructure/docker/tempo.yaml
@@ -1,0 +1,36 @@
+server:
+  http_listen_port: 3200
+  grpc_listen_port: 4317
+
+distributor:
+  receivers:
+    jaeger:
+      protocols:
+        thrift_http:
+        grpc:
+        thrift_binary:
+        thrift_compact:
+    zipkin:
+    otlp:
+      protocols:
+        http:
+        grpc:
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 1h
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /tempo/wal
+    local:
+      path: /tempo/blocks
+
+overrides:
+  defaults:
+    max_bytes_per_trace: 5000000


### PR DESCRIPTION
Implements Phase 5 for Issue #1029

## Changes

### Documentation (docs/otel.md)
- Quick start guide for OpenTelemetry setup
- Environment variable configuration reference (OTEL_ENABLED, OTEL_EXPORTER, etc.)
- Docker compose examples for:
  - Grafana Tempo + Grafana + Prometheus
  - Jaeger all-in-one
  - OpenTelemetry Collector + Prometheus + Grafana
- Troubleshooting section with OTEL_DEBUG=True
- Redaction configuration for sensitive attributes
- Integration examples for Flask and FastAPI

### Docker Infrastructure (infrastructure/docker/otel-compose.yml)
- Added example stacks for:
  - Grafana Tempo (full tracing stack)
  - Jaeger (all-in-one for development)
  - OpenTelemetry Collector (customizable pipeline)
  - Zipkin (standalone)
- Added supporting config files:
  - tempo.yaml - Tempo configuration
  - prometheus.yml - Prometheus config for Tempo
  - prometheus-collector.yml - Prometheus config for OTel Collector
  - otel-collector-config.yaml - OTel Collector pipeline with redaction
  - grafana-provisioning/datasources/datasources.yml - Grafana datasources

## Usage

