### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/dashboard/control/page.tsx
+++ b/app/dashboard/control/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { Settings, Power, RotateCcw, Shield, Server, Database, Globe, Key, Bell, Sliders } from "lucide-react";
 
 interface SystemService {


### PR DESCRIPTION
To fix the problem, remove the unused `useState` import from the React import statement so that only actually used symbols are imported. This keeps the file clean, avoids linter/static-analysis warnings, and does not affect runtime behavior because `useState` is never referenced.

Concretely, in `app/dashboard/control/page.tsx`, edit the import on line 3 to remove `useState`, leaving no React imports if nothing else from React is used. No additional methods, imports, or definitions are needed; this is a simple deletion of an unused named import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._