### PR TITLE
feat(ci): add test coverage thresholds check (#956)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,59 @@ jobs:
         run: |
           npx playwright test --project=chromium
 
+  coverage:
+    name: Coverage Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e ".[dev]"
+
+      - name: Run Python tests with coverage
+        run: |
+          python -m pytest tests/api --cov --cov-fail-under=70 --maxfail=1 -q
+
+      - name: Run frontend tests with coverage
+        run: |
+          npm run test:app -- --coverage --coverageThreshold='{"global":{"branches":60,"functions":60,"lines":60,"statements":60}}'
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-reports
+          path: |
+            coverage/
+            coverage_html/
+          retention-days: 7
+
   container-scan:
     name: Container Image Scan
     runs-on: ubuntu-latest
     needs: validate
-    
+
     permissions:
       contents: read
       security-events: write
-    
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -8,4 +8,22 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/$1',
   },
   modulePathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
+  collectCoverageFrom: [
+    'app/**/*.{ts,tsx}',
+    'components/**/*.{ts,tsx}',
+    'lib/**/*.{ts,tsx}',
+    '!**/*.d.ts',
+    '!**/node_modules/**',
+    '!**/.next/**',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 60,
+      functions: 60,
+      lines: 60,
+      statements: 60,
+    },
+  },
+  coverageReporters: ['text', 'lcov', 'html'],
+  coverageDirectory: 'coverage',
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,6 @@ dev = [
     "mutmut>=3.0.0",
 ]
 
-
-
 [project.scripts]
 mutx = "cli.main:cli"
 
@@ -67,3 +65,26 @@ python_files = "test_*.py"
 [tool.mutmut]
 paths = ["tests", "cli"]
 exclude = ["tests/website.spec.ts", "tests/conftest.py"]
+
+[tool.coverage.run]
+source = ["src", "cli", "sdk"]
+omit = ["*/tests/*", "*/test_*.py"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "@abstractmethod",
+]
+precision = 2
+show_missing = true
+skip_covered = false
+
+[tool.coverage.html]
+directory = "coverage_html"
+
+[tool.coverage.fail_under]
+min_cov_line = 70


### PR DESCRIPTION
## Summary

Adds CI check for test coverage thresholds to ensure code quality.

## Changes

- **pyproject.toml**: Add pytest-cov configuration with 70% line coverage threshold
- **jest.config.cjs**: Add Jest coverage configuration with 60% thresholds for branches, functions, lines, statements  
- **.github/workflows/ci.yml**: Add new coverage job that runs both Python and frontend coverage checks and uploads reports as artifacts

## Testing

The coverage job will fail if:
- Python API tests fall below 70% line coverage
- Frontend unit tests fall below 60% on branches, functions, lines, or statements

## Related

Fixes #956