### PR TITLE
fix(auth): enforce ownership on all agent endpoints

### DIFF
--- a/app/api/_lib/ownership.ts
+++ b/app/api/_lib/ownership.ts
@@ -112,3 +112,85 @@ export async function checkDeploymentOwnership(
   }
   return null
 }
+
+/**
+ * Verify that the authenticated user owns the agent.
+ * This provides defense-in-depth, as the backend also enforces ownership.
+ */
+export async function verifyAgentOwnership(
+  request: NextRequest,
+  agentId: string
+): Promise<boolean> {
+  const token = await getAuthToken(request)
+  if (!token) {
+    // Let the backend handle authentication errors
+    return true
+  }
+
+  try {
+    // Fetch the agent to get its user_id
+    const agentResponse = await fetch(`${API_BASE_URL}/v1/agents/${agentId}`, {
+      headers: { 
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    if (agentResponse.status === 404) {
+      // Let the backend return 404
+      return true
+    }
+
+    if (!agentResponse.ok) {
+      // If we can't verify ownership, let the backend handle it
+      return true
+    }
+
+    const agent = await agentResponse.json().catch(() => null)
+    if (!agent || !agent.user_id) {
+      // Can't determine ownership, let backend handle it
+      return true
+    }
+
+    // Get the current user's ID to compare
+    const userResponse = await fetch(`${API_BASE_URL}/v1/auth/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    })
+
+    if (!userResponse.ok) {
+      // Can't get user info, let backend handle it
+      return true
+    }
+
+    const user = await userResponse.json().catch(() => null)
+    if (!user || !user.id) {
+      // Can't determine user, let backend handle it
+      return true
+    }
+
+    // Check if the agent belongs to the authenticated user
+    if (agent.user_id !== user.id) {
+      return false
+    }
+
+    return true
+  } catch {
+    // On any error, fall through to backend
+    return true
+  }
+}
+
+/**
+ * Helper to check ownership and return error response if not owned
+ */
+export async function checkAgentOwnership(
+  request: NextRequest,
+  agentId: string
+): Promise<NextResponse | null> {
+  const isOwned = await verifyAgentOwnership(request, agentId)
+  if (!isOwned) {
+    return forbidden('You do not own this agent')
+  }
+  return null
+}

--- a/app/api/agents/[id]/deploy/route.ts
+++ b/app/api/agents/[id]/deploy/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
 import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+import { checkAgentOwnership } from '@/app/api/_lib/ownership'
 
 const API_BASE_URL = getApiBaseUrl()
 
@@ -18,6 +19,12 @@ export async function POST(
     }
 
     const { id } = await params
+    
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, id)
+    if (ownershipError) {
+      return ownershipError
+    }
     
     const response = await fetch(`${API_BASE_URL}/v1/agents/${id}/deploy`, {
       method: 'POST',

--- a/app/api/agents/[id]/logs/route.ts
+++ b/app/api/agents/[id]/logs/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
 import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+import { checkAgentOwnership } from '@/app/api/_lib/ownership'
 
 const API_BASE_URL = getApiBaseUrl()
 
@@ -18,6 +19,13 @@ export async function GET(
     }
 
     const { id } = await params
+    
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, id)
+    if (ownershipError) {
+      return ownershipError
+    }
+    
     const { searchParams } = new URL(request.url)
     const paramsStr = searchParams.toString()
     

--- a/app/api/agents/[id]/route.ts
+++ b/app/api/agents/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
 import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+import { checkAgentOwnership } from '@/app/api/_lib/ownership'
 
 const API_BASE_URL = getApiBaseUrl()
 
@@ -18,6 +19,12 @@ export async function GET(
     }
 
     const { id } = await params
+    
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, id)
+    if (ownershipError) {
+      return ownershipError
+    }
     
     const response = await fetch(`${API_BASE_URL}/v1/agents/${id}`, {
       headers: { 
@@ -42,6 +49,12 @@ export async function DELETE(
     }
 
     const { id } = await params
+    
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, id)
+    if (ownershipError) {
+      return ownershipError
+    }
     
     const response = await fetch(`${API_BASE_URL}/v1/agents/${id}`, {
       method: 'DELETE',

--- a/app/api/agents/[id]/stop/route.ts
+++ b/app/api/agents/[id]/stop/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
 import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+import { checkAgentOwnership } from '@/app/api/_lib/ownership'
 
 const API_BASE_URL = getApiBaseUrl()
 
@@ -18,6 +19,12 @@ export async function POST(
     }
 
     const { id } = await params
+    
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, id)
+    if (ownershipError) {
+      return ownershipError
+    }
     
     const response = await fetch(`${API_BASE_URL}/v1/agents/${id}/stop`, {
       method: 'POST',

--- a/app/api/dashboard/agents/[agentId]/route.ts
+++ b/app/api/dashboard/agents/[agentId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
 import { withErrorHandling, unauthorized, badRequest } from '@/app/api/_lib/errors'
+import { checkAgentOwnership } from '@/app/api/_lib/ownership'
 import { z } from 'zod'
 
 const API_BASE_URL = getApiBaseUrl()
@@ -21,6 +22,12 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const idValidation = z.string().uuid('Invalid agent ID').safeParse(agentId)
     if (!idValidation.success) {
       return badRequest('Invalid agent ID format')
+    }
+
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, agentId)
+    if (ownershipError) {
+      return ownershipError
     }
 
     const response = await fetch(`${API_BASE_URL}/v1/agents/${agentId}`, {
@@ -47,6 +54,12 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
     const idValidation = z.string().uuid('Invalid agent ID').safeParse(agentId)
     if (!idValidation.success) {
       return badRequest('Invalid agent ID format')
+    }
+
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, agentId)
+    if (ownershipError) {
+      return ownershipError
     }
 
     const response = await fetch(`${API_BASE_URL}/v1/agents/${agentId}`, {
@@ -77,6 +90,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     const idValidation = z.string().uuid('Invalid agent ID').safeParse(agentId)
     if (!idValidation.success) {
       return badRequest('Invalid agent ID format')
+    }
+
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, agentId)
+    if (ownershipError) {
+      return ownershipError
     }
 
     // Determine action from URL search params


### PR DESCRIPTION
## Summary

Adds frontend-side ownership verification to all agent API endpoints, providing defense-in-depth alongside backend enforcement.

## Changes

- Added `verifyAgentOwnership` and `checkAgentOwnership` functions to `ownership.ts`
- Added ownership checks to all agent endpoints:
  - `/api/agents/[id]` (GET, DELETE)
  - `/api/agents/[id]/deploy` (POST)
  - `/api/agents/[id]/stop` (POST)
  - `/api/agents/[id]/logs` (GET)
  - `/api/dashboard/agents/[agentId]` (GET, DELETE, POST)

## Verification

- `pnpm lint` ✓
- `pnpm build` ✓

Closes #979