### PR TITLE
feat(ops): add self-healing for common failure modes

### DIFF
--- a/src/runtime/adapters/openai.py
+++ b/src/runtime/adapters/openai.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import inspect
 import json
 from dataclasses import dataclass
 from typing import Any
 
 from openai import AsyncOpenAI
+from openai.types import RateLimitError, APITimeoutError
 
 from ..base import (
     AgentRuntime,
@@ -205,42 +208,42 @@ class OpenAIAdapter(AgentRuntime):
 
     def _extract_usage(self, response: Any) -> RuntimeUsage | None:
         """Extract usage statistics from the API response."""
-        usage = getattr(response, 'usage', None)
+        usage = getattr(response, "usage", None)
         if not usage:
             return None
-        
-        prompt_tokens = getattr(usage, 'prompt_tokens', 0) or 0
-        completion_tokens = getattr(usage, 'completion_tokens', 0) or 0
-        total_tokens = getattr(usage, 'total_tokens', 0) or 0
-        
+
+        prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+        completion_tokens = getattr(usage, "completion_tokens", 0) or 0
+        total_tokens = getattr(usage, "total_tokens", 0) or 0
+
         # Calculate approximate cost (can be customized per model)
         cost = self._calculate_cost(prompt_tokens, completion_tokens, self.config.model)
-        
+
         return {
-            'prompt_tokens': prompt_tokens,
-            'completion_tokens': completion_tokens,
-            'total_tokens': total_tokens,
-            'model': self.config.model,
-            'cost_usd': cost,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+            "model": self.config.model,
+            "cost_usd": cost,
         }
-    
+
     def _calculate_cost(self, prompt_tokens: int, completion_tokens: int, model: str) -> float:
         """Calculate approximate cost in USD based on model pricing."""
         # Pricing per 1M tokens (approximate, as of 2024)
         pricing = {
-            'gpt-4o': {'prompt': 2.50, 'completion': 10.00},
-            'gpt-4-turbo': {'prompt': 10.00, 'completion': 30.00},
-            'gpt-4': {'prompt': 30.00, 'completion': 60.00},
-            'gpt-3.5-turbo': {'prompt': 0.50, 'completion': 1.50},
-            'o1': {'prompt': 15.00, 'completion': 60.00},
-            'o1-preview': {'prompt': 15.00, 'completion': 60.00},
-            'o1-mini': {'prompt': 3.00, 'completion': 12.00},
+            "gpt-4o": {"prompt": 2.50, "completion": 10.00},
+            "gpt-4-turbo": {"prompt": 10.00, "completion": 30.00},
+            "gpt-4": {"prompt": 30.00, "completion": 60.00},
+            "gpt-3.5-turbo": {"prompt": 0.50, "completion": 1.50},
+            "o1": {"prompt": 15.00, "completion": 60.00},
+            "o1-preview": {"prompt": 15.00, "completion": 60.00},
+            "o1-mini": {"prompt": 3.00, "completion": 12.00},
         }
-        
-        model_pricing = pricing.get(model.lower(), {'prompt': 5.0, 'completion': 15.0})
-        prompt_cost = (prompt_tokens / 1_000_000) * model_pricing['prompt']
-        completion_cost = (completion_tokens / 1_000_000) * model_pricing['completion']
-        
+
+        model_pricing = pricing.get(model.lower(), {"prompt": 5.0, "completion": 15.0})
+        prompt_cost = (prompt_tokens / 1_000_000) * model_pricing["prompt"]
+        completion_cost = (completion_tokens / 1_000_000) * model_pricing["completion"]
+
         return round(prompt_cost + completion_cost, 6)
 
     async def _create_completion(
@@ -262,7 +265,36 @@ class OpenAIAdapter(AgentRuntime):
         if stream:
             request["stream"] = True
 
-        return await self._client.chat.completions.create(**request)
+        return await self._with_retry(lambda: self._client.chat.completions.create(**request))
+
+    async def _with_retry(self, func, max_retries: int = 3, base_delay: float = 1.0):
+        """Execute a function with exponential backoff retry for transient failures."""
+        last_exception = None
+
+        for attempt in range(max_retries):
+            try:
+                return await func()
+            except RateLimitError as e:
+                last_exception = e
+                if attempt < max_retries - 1:
+                    # Check for retry-after header
+                    retry_after = getattr(e.response, "headers", {}).get("retry-after")
+                    if retry_after:
+                        delay = float(retry_after)
+                    else:
+                        delay = base_delay * (2**attempt)  # Exponential backoff
+                    await asyncio.sleep(delay)
+            except APITimeoutError as e:
+                last_exception = e
+                if attempt < max_retries - 1:
+                    delay = base_delay * (2**attempt)
+                    await asyncio.sleep(delay)
+            except Exception:
+                # For other errors, log and re-raise immediately
+                raise
+
+        # All retries exhausted
+        raise last_exception
 
     async def _append_tool_results(
         self,


### PR DESCRIPTION
Adds retry logic with exponential backoff to the OpenAI runtime adapter for handling transient failures like rate limits (429) and API timeouts.

- Max 3 retries with exponential backoff
- Respects Retry-After header from rate limit responses
- Handles RateLimitError and APITimeoutError specifically

Closes #993