### PR TITLE
feat(runtime): add agent versioning and rollback support

### DIFF
--- a/.minimax/skills/minimax-docx/check/detectors.py
+++ b/.minimax/skills/minimax-docx/check/detectors.py
@@ -24,6 +24,7 @@ HEADING_STYLE_RE = re.compile(r"^heading\d+$", re.IGNORECASE)
 
 class Detector(Protocol):
     """Interface contract for all validation detectors."""
+
     name: str
 
     def scan(self, ctx: "ScanContext") -> None:
@@ -64,7 +65,9 @@ class ScanContext:
 
         result = {}
         tree = ET.parse(rels_path)
-        for rel in tree.findall(".//{http://schemas.openxmlformats.org/package/2006/relationships}Relationship"):
+        for rel in tree.findall(
+            ".//{http://schemas.openxmlformats.org/package/2006/relationships}Relationship"
+        ):
             rid = rel.get("Id", "")
             target = rel.get("Target", "")
             if rid and target:
@@ -155,6 +158,7 @@ class GridConsistencyDetector:
     Tables in OOXML define column widths in tblGrid, and each cell can
     specify its own width. Mismatches cause rendering unpredictability.
     """
+
     name = "grid-consistency"
 
     def scan(self, ctx: ScanContext) -> None:
@@ -196,13 +200,13 @@ class GridConsistencyDetector:
                     if tc_w is not None:
                         cell_width = tc_w.get(f"{{{WML}}}w")
                         if cell_width and cell_width.isdigit():
-                            expected = sum(defined_widths[col_cursor:col_cursor + span])
+                            expected = sum(defined_widths[col_cursor : col_cursor + span])
                             actual = int(cell_width)
                             # Use 8% tolerance to allow for rounding in grid calculations
                             if expected > 0 and abs(actual - expected) / expected > 0.08:
                                 ctx.report.warning(
                                     f"table[{idx}]/row[{row_idx}]",
-                                    f"Cell width {actual} deviates from grid sum {expected}"
+                                    f"Cell width {actual} deviates from grid sum {expected}",
                                 )
 
                     col_cursor += span
@@ -214,6 +218,7 @@ class AspectRatioDetector:
     Distorted images indicate cx/cy values were modified without
     maintaining the source aspect ratio.
     """
+
     name = "aspect-ratio"
 
     def scan(self, ctx: ScanContext) -> None:
@@ -222,10 +227,14 @@ class AspectRatioDetector:
         except ImportError:
             return
 
-        drawings = ctx.document_root.findall(".//{http://schemas.openxmlformats.org/drawingml/2006/main}blip")
+        drawings = ctx.document_root.findall(
+            ".//{http://schemas.openxmlformats.org/drawingml/2006/main}blip"
+        )
 
         for blip in drawings:
-            embed = blip.get("{http://schemas.openxmlformats.org/officeDocument/2006/relationships}embed")
+            embed = blip.get(
+                "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}embed"
+            )
             if not embed or embed not in ctx.relationships:
                 continue
 
@@ -266,7 +275,7 @@ class AspectRatioDetector:
             if abs(src_ratio - doc_ratio) / src_ratio > 0.03:
                 ctx.report.warning(
                     f"image/{embed}",
-                    f"Aspect ratio changed from {src_ratio:.2f} to {doc_ratio:.2f}"
+                    f"Aspect ratio changed from {src_ratio:.2f} to {doc_ratio:.2f}",
                 )
 
 
@@ -276,6 +285,7 @@ class AnnotationLinkDetector:
     Comments in OOXML span from commentRangeStart to commentRangeEnd,
     referencing entries in comments.xml. Orphaned references cause errors.
     """
+
     name = "annotation-links"
 
     def scan(self, ctx: ScanContext) -> None:
@@ -290,8 +300,7 @@ class AnnotationLinkDetector:
         if not comments_file.exists():
             for rid in referenced_ids:
                 ctx.report.blocker(
-                    f"comment/{rid}",
-                    "Comment reference exists but comments.xml is missing"
+                    f"comment/{rid}", "Comment reference exists but comments.xml is missing"
                 )
             return
 
@@ -304,10 +313,7 @@ class AnnotationLinkDetector:
 
         orphans = referenced_ids - defined_ids
         for oid in orphans:
-            ctx.report.blocker(
-                f"comment/{oid}",
-                "Reference points to undefined comment entry"
-            )
+            ctx.report.blocker(f"comment/{oid}", "Reference points to undefined comment entry")
 
 
 class BookmarkIntegrityDetector:
@@ -316,6 +322,7 @@ class BookmarkIntegrityDetector:
     Bookmarks require both bookmarkStart and bookmarkEnd with matching IDs.
     Unmatched bookmarks cause cross-reference failures.
     """
+
     name = "bookmark-integrity"
 
     def scan(self, ctx: ScanContext) -> None:
@@ -328,18 +335,12 @@ class BookmarkIntegrityDetector:
         # Check for orphaned starts (no matching end)
         orphan_starts = start_ids - end_ids
         for oid in orphan_starts:
-            ctx.report.warning(
-                f"bookmark/{oid}",
-                "bookmarkStart has no matching bookmarkEnd"
-            )
+            ctx.report.warning(f"bookmark/{oid}", "bookmarkStart has no matching bookmarkEnd")
 
         # Check for orphaned ends (no matching start)
         orphan_ends = end_ids - start_ids
         for oid in orphan_ends:
-            ctx.report.warning(
-                f"bookmark/{oid}",
-                "bookmarkEnd has no matching bookmarkStart"
-            )
+            ctx.report.warning(f"bookmark/{oid}", "bookmarkEnd has no matching bookmarkStart")
 
 
 class DrawingIdUniquenessDetector:
@@ -348,6 +349,7 @@ class DrawingIdUniquenessDetector:
     Duplicate docPr id values cause rendering issues in some viewers
     and may result in images not displaying correctly.
     """
+
     name = "drawing-id-uniqueness"
 
     def scan(self, ctx: ScanContext) -> None:
@@ -367,8 +369,7 @@ class DrawingIdUniquenessDetector:
         for id_val, count in seen_ids.items():
             if count > 1:
                 ctx.report.warning(
-                    f"drawing/docPr[@id={id_val}]",
-                    f"Duplicate drawing ID found {count} times"
+                    f"drawing/docPr[@id={id_val}]", f"Duplicate drawing ID found {count} times"
                 )
 
 
@@ -378,6 +379,7 @@ class HyperlinkValidityDetector:
     Hyperlinks referencing missing relationships will not work
     when clicked in Word.
     """
+
     name = "hyperlink-validity"
 
     def scan(self, ctx: ScanContext) -> None:
@@ -389,8 +391,7 @@ class HyperlinkValidityDetector:
                 anchor = hl.get(f"{{{WML}}}anchor", "")
                 if not anchor:  # Only flag if no internal anchor either
                     ctx.report.warning(
-                        f"hyperlink/{rid}",
-                        "Hyperlink references missing relationship"
+                        f"hyperlink/{rid}", "Hyperlink references missing relationship"
                     )
 
 
@@ -400,6 +401,7 @@ class SectionIsolationDetector:
     Cover pages using excessive spacing (Gaps) without section breaks
     risk content overflow on smaller paper sizes (A5, B5).
     """
+
     name = "section-isolation"
 
     # Threshold: if total spacing before first page break exceeds this, warn
@@ -468,6 +470,7 @@ class OutlineLevelDetector:
     Detects flat TOC structures where all headings use the same outline level,
     which results in incorrect TOC nesting.
     """
+
     name = "outline-level"
 
     def scan(self, ctx: ScanContext) -> None:
@@ -512,6 +515,7 @@ class HeaderFooterDetector:
     Documents with multiple sections or many paragraphs should typically
     have headers and/or footers for navigation.
     """
+
     name = "header-footer"
 
     PARAGRAPH_THRESHOLD = 30  # Suggest headers/footers for documents with 30+ paragraphs

--- a/.minimax/skills/minimax-docx/check/pipeline.py
+++ b/.minimax/skills/minimax-docx/check/pipeline.py
@@ -78,8 +78,7 @@ class ValidationPipeline:
                     detector.scan(ctx)
                 except Exception as e:
                     report.warning(
-                        f"detector/{detector.name}",
-                        f"Detector failed: {type(e).__name__}: {e}"
+                        f"detector/{detector.name}", f"Detector failed: {type(e).__name__}: {e}"
                     )
 
         return report

--- a/.minimax/skills/minimax-docx/check/report.py
+++ b/.minimax/skills/minimax-docx/check/report.py
@@ -12,6 +12,7 @@ class Gravity(Enum):
     WARNING: Problems that may cause rendering inconsistencies.
     HINT: Suggestions for best practices compliance.
     """
+
     BLOCKER = "blocker"
     WARNING = "warning"
     HINT = "hint"
@@ -26,6 +27,7 @@ class Issue:
         location: XPath or human-readable path to the problematic element.
         summary: Brief description of what was detected.
     """
+
     gravity: Gravity
     location: str
     summary: str
@@ -38,6 +40,7 @@ class ValidationReport:
     Provides convenience methods for adding issues at different severity
     levels and querying the collection.
     """
+
     issues: list[Issue] = field(default_factory=list)
 
     def blocker(self, location: str, summary: str) -> None:

--- a/.minimax/skills/minimax-docx/diagnostics/compiler.py
+++ b/.minimax/skills/minimax-docx/diagnostics/compiler.py
@@ -21,6 +21,7 @@ from typing import Iterator
 
 class DiagnosticSeverity(Enum):
     """Compiler diagnostic severity levels from MSBuild."""
+
     ERROR = "error"
     WARNING = "warning"
     INFO = "info"
@@ -38,6 +39,7 @@ class RoslynDiagnostic:
         line: Line number in source file
         column: Column number in source file
     """
+
     id: str
     severity: DiagnosticSeverity
     message: str
@@ -81,12 +83,11 @@ class DiagnosticParser:
     _MSBUILD_PATTERN = re.compile(
         r"^(?P<file>[^(]+)\((?P<line>\d+),(?P<col>\d+)\):\s*"
         r"(?P<sev>error|warning|info)\s+(?P<id>CS\d+):\s*(?P<msg>.+)$",
-        re.MULTILINE
+        re.MULTILINE,
     )
 
     _SIMPLE_PATTERN = re.compile(
-        r"^(?P<sev>error|warning|info)\s+(?P<id>CS\d+):\s*(?P<msg>.+)$",
-        re.MULTILINE
+        r"^(?P<sev>error|warning|info)\s+(?P<id>CS\d+):\s*(?P<msg>.+)$", re.MULTILINE
     )
 
     def parse(self, output: str) -> Iterator[RoslynDiagnostic]:
@@ -126,6 +127,7 @@ class FixSuggestion:
         description: Detailed explanation
         code_action: Optional code snippet demonstrating the fix
     """
+
     diagnostic_id: str
     title: str
     description: str
@@ -223,13 +225,26 @@ class SuggestionEngine:
 
     def _infer_namespace(self, type_name: str) -> str | None:
         """Guess the namespace for common OpenXML types."""
-        if type_name in ("Body", "Paragraph", "Run", "Text", "Table",
-                         "TableRow", "TableCell", "SectionProperties",
-                         "ParagraphProperties", "RunProperties"):
+        if type_name in (
+            "Body",
+            "Paragraph",
+            "Run",
+            "Text",
+            "Table",
+            "TableRow",
+            "TableCell",
+            "SectionProperties",
+            "ParagraphProperties",
+            "RunProperties",
+        ):
             return "DocumentFormat.OpenXml.Wordprocessing"
 
-        if type_name in ("WordprocessingDocument", "MainDocumentPart",
-                         "StyleDefinitionsPart", "NumberingDefinitionsPart"):
+        if type_name in (
+            "WordprocessingDocument",
+            "MainDocumentPart",
+            "StyleDefinitionsPart",
+            "NumberingDefinitionsPart",
+        ):
             return "DocumentFormat.OpenXml.Packaging"
 
         if type_name in ("Drawing", "Inline", "Anchor"):

--- a/.minimax/skills/minimax-docx/docx_engine.py
+++ b/.minimax/skills/minimax-docx/docx_engine.py
@@ -150,18 +150,22 @@ def locate_dotnet_binary() -> Optional[Path]:
     search_paths = ["dotnet"]
 
     if os_type == "Windows":
-        search_paths.extend([
-            Path.home() / ".dotnet" / "dotnet.exe",
-            Path(os.environ.get("ProgramFiles", "")) / "dotnet" / "dotnet.exe",
-            Path(os.environ.get("ProgramFiles(x86)", "")) / "dotnet" / "dotnet.exe",
-        ])
+        search_paths.extend(
+            [
+                Path.home() / ".dotnet" / "dotnet.exe",
+                Path(os.environ.get("ProgramFiles", "")) / "dotnet" / "dotnet.exe",
+                Path(os.environ.get("ProgramFiles(x86)", "")) / "dotnet" / "dotnet.exe",
+            ]
+        )
     else:
-        search_paths.extend([
-            Path.home() / ".dotnet" / "dotnet",
-            Path("/usr/local/share/dotnet/dotnet"),
-            Path("/usr/share/dotnet/dotnet"),
-            Path("/opt/dotnet/dotnet"),
-        ])
+        search_paths.extend(
+            [
+                Path.home() / ".dotnet" / "dotnet",
+                Path("/usr/local/share/dotnet/dotnet"),
+                Path("/usr/share/dotnet/dotnet"),
+                Path("/opt/dotnet/dotnet"),
+            ]
+        )
 
     for candidate in search_paths:
         if isinstance(candidate, str):
@@ -186,8 +190,7 @@ def assess_runtime_health() -> Tuple[str, Optional[Path], Optional[str]]:
 
     try:
         proc = subprocess.run(
-            [str(binary), "--version"],
-            capture_output=True, text=True, timeout=10
+            [str(binary), "--version"], capture_output=True, text=True, timeout=10
         )
         if proc.returncode == 0:
             ver = proc.stdout.strip()
@@ -230,7 +233,9 @@ def provision_dotnet() -> Optional[Path]:
             """
             subprocess.run(
                 ["powershell", "-Command", powershell_script],
-                capture_output=True, text=True, timeout=300
+                capture_output=True,
+                text=True,
+                timeout=300,
             )
             binary = target_dir / "dotnet.exe"
         else:
@@ -239,13 +244,13 @@ def provision_dotnet() -> Optional[Path]:
 
             installer_path = Path(tempfile.gettempdir()) / "dotnet-bootstrap.sh"
             subprocess.run(
-                ["curl", "-sSL", installer_url, "-o", str(installer_path)],
-                check=True, timeout=60
+                ["curl", "-sSL", installer_url, "-o", str(installer_path)], check=True, timeout=60
             )
             installer_path.chmod(0o755)
             subprocess.run(
                 [str(installer_path), "--channel", channel, "--install-dir", str(target_dir)],
-                check=True, timeout=300
+                check=True,
+                timeout=300,
             )
             binary = target_dir / "dotnet"
 
@@ -305,7 +310,9 @@ def audit_python_dependencies() -> dict:
     pandoc_binary = shutil.which("pandoc")
     if pandoc_binary:
         try:
-            proc = subprocess.run(["pandoc", "--version"], capture_output=True, text=True, timeout=5)
+            proc = subprocess.run(
+                ["pandoc", "--version"], capture_output=True, text=True, timeout=5
+            )
             ver = proc.stdout.split("\n")[0].split()[-1] if proc.returncode == 0 else "?"
             inventory["pandoc"] = ("available", ver)
         except Exception:
@@ -367,8 +374,15 @@ def execute_verification(document_path: Path, runtime: Path) -> bool:
     if validator_dll.exists():
         try:
             proc = subprocess.run(
-                [str(runtime), "--roll-forward", "LatestMajor", str(validator_dll), str(document_path)],
-                capture_output=True, text=True
+                [
+                    str(runtime),
+                    "--roll-forward",
+                    "LatestMajor",
+                    str(validator_dll),
+                    str(document_path),
+                ],
+                capture_output=True,
+                text=True,
             )
             print(proc.stdout, end="")
             if proc.stderr:
@@ -384,7 +398,13 @@ def execute_verification(document_path: Path, runtime: Path) -> bool:
 
 def extract_document_metrics(document_path: Path) -> dict:
     """Collect statistics about the document using pandoc."""
-    metrics = {"characters": 0, "tokens": 0, "media_count": 0, "has_markup": False, "has_annotations": False}
+    metrics = {
+        "characters": 0,
+        "tokens": 0,
+        "media_count": 0,
+        "has_markup": False,
+        "has_annotations": False,
+    }
 
     if not shutil.which("pandoc"):
         return metrics
@@ -392,14 +412,16 @@ def extract_document_metrics(document_path: Path) -> dict:
     try:
         proc = subprocess.run(
             ["pandoc", str(document_path), "-t", "plain"],
-            capture_output=True, text=True, timeout=30
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if proc.returncode == 0:
             content = proc.stdout
             metrics["characters"] = len(content)
             metrics["tokens"] = len(content.split())
 
-        with zipfile.ZipFile(document_path, 'r') as archive:
+        with zipfile.ZipFile(document_path, "r") as archive:
             entries = archive.namelist()
             metrics["media_count"] = sum(1 for e in entries if e.startswith("word/media/"))
             metrics["has_annotations"] = "word/comments.xml" in entries
@@ -473,7 +495,9 @@ def extract_text_nodes(xml_text: str) -> List[str]:
     return values
 
 
-def detect_residual_placeholders(document_path: Path, allow_tokens: Optional[List[str]] = None) -> Counter:
+def detect_residual_placeholders(
+    document_path: Path, allow_tokens: Optional[List[str]] = None
+) -> Counter:
     """Find unresolved placeholder/sample fragments in document text."""
     allowed = {token.strip().lower() for token in (allow_tokens or []) if token.strip()}
     findings: Counter = Counter()
@@ -506,9 +530,9 @@ def action_doctor():
         print(f"  Output dir:    {resolve_artifact_dir()}")
     except RuntimeError:
         in_skill_dir = True
-        print(f"  Project home:  (running from skill dir - set PROJECT_HOME or run from workspace)")
-        print(f"  Workspace:     N/A")
-        print(f"  Output dir:    N/A")
+        print("  Project home:  (running from skill dir - set PROJECT_HOME or run from workspace)")
+        print("  Workspace:     N/A")
+        print("  Output dir:    N/A")
     print()
 
     print("Runtime:")
@@ -545,7 +569,9 @@ def action_doctor():
 
     if "libreoffice-soffice" in missing_required:
         print("Dependency Gate:")
-        print("  - libreoffice-soffice is required for template-driven .doc -> .docx normalization.")
+        print(
+            "  - libreoffice-soffice is required for template-driven .doc -> .docx normalization."
+        )
         if "textutil" in unsupported:
             print("  - textutil is detected but cannot be used as a fallback.")
         print("  - Install LibreOffice and ensure `soffice` is on PATH.")
@@ -559,7 +585,7 @@ def action_doctor():
         if needs_setup:
             print("=== Provisioning Dependencies ===")
             runtime = guarantee_dotnet()
-            ver_proc = subprocess.run([str(runtime), '--version'], capture_output=True, text=True)
+            ver_proc = subprocess.run([str(runtime), "--version"], capture_output=True, text=True)
             print(f"  + dotnet {ver_proc.stdout.strip()}")
 
             print()
@@ -581,8 +607,12 @@ def action_doctor():
     print("Ready!")
     print(f"  Render: python {Path(__file__).name} render")
     print(f"  Preset: python {Path(__file__).name} render output.docx tech")
-    print(f"  Template: dotnet run --project \"{SCRIPT_LOCATION / 'src' / 'DocForge.csproj'}\" -- from-template template.docx output.docx")
-    print(f"  Mapping template: python {Path(__file__).name} map-template mapping.json --require R1,R2")
+    print(
+        f'  Template: dotnet run --project "{SCRIPT_LOCATION / "src" / "DocForge.csproj"}" -- from-template template.docx output.docx'
+    )
+    print(
+        f"  Mapping template: python {Path(__file__).name} map-template mapping.json --require R1,R2"
+    )
     print(f"  Residual gate: python {Path(__file__).name} residual output.docx")
     print(f"  Mapping gate: python {Path(__file__).name} map-gate mapping.json --require R1,R2")
     print(f"  Mapping schema: {resolve_mapping_schema_path()}")
@@ -616,7 +646,9 @@ def action_render(target_name: Optional[str] = None, preset: str = "tech"):
     proj_file = SCRIPT_LOCATION / "src" / "DocForge.csproj"
     proc = subprocess.run(
         [str(runtime), "build", str(proj_file), "--verbosity", "quiet"],
-        capture_output=True, text=True, cwd=str(SCRIPT_LOCATION)
+        capture_output=True,
+        text=True,
+        cwd=str(SCRIPT_LOCATION),
     )
 
     if proc.returncode != 0:
@@ -685,8 +717,10 @@ def action_render(target_name: Optional[str] = None, preset: str = "tech"):
     metrics = extract_document_metrics(target)
     if metrics["characters"] > 0:
         media_note = "" if metrics["media_count"] > 0 else " - verify image embedding path"
-        print(f"  >> {metrics['characters']} chars, {metrics['tokens']} words, {metrics['media_count']} images{media_note}")
-        print(f"  >> Structural check passed. Content review: pandoc \"{target}\" -t plain")
+        print(
+            f"  >> {metrics['characters']} chars, {metrics['tokens']} words, {metrics['media_count']} images{media_note}"
+        )
+        print(f'  >> Structural check passed. Content review: pandoc "{target}" -t plain')
         if metrics["has_markup"] or metrics["has_annotations"]:
             print("     Track changes detected - use --track-changes=all for review")
 
@@ -725,8 +759,7 @@ def action_preview(document_path: str):
     print(f">> Preview: {path}")
     print("-" * 60)
     proc = subprocess.run(
-        ["pandoc", str(path), "-t", "plain"],
-        capture_output=True, text=True, timeout=30
+        ["pandoc", str(path), "-t", "plain"], capture_output=True, text=True, timeout=30
     )
     if proc.returncode == 0:
         print(proc.stdout)
@@ -958,9 +991,7 @@ def check_mapping_schema_header(mapping_doc: dict[str, Any]) -> Tuple[List[str],
 
     schema_version = mapping_doc.get("schema_version")
     if schema_version is None:
-        warnings.append(
-            f"missing `schema_version` (recommended: {MAPPING_SCHEMA_VERSION})"
-        )
+        warnings.append(f"missing `schema_version` (recommended: {MAPPING_SCHEMA_VERSION})")
     elif not isinstance(schema_version, str) or not schema_version.strip():
         errors.append("`schema_version` must be a non-empty string")
     elif schema_version.strip() != MAPPING_SCHEMA_VERSION:
@@ -974,7 +1005,9 @@ def check_mapping_schema_header(mapping_doc: dict[str, Any]) -> Tuple[List[str],
     return errors, warnings
 
 
-def evaluate_mapping_doc(mapping_doc: dict[str, Any], cli_required: Optional[Set[str]] = None) -> dict[str, Any]:
+def evaluate_mapping_doc(
+    mapping_doc: dict[str, Any], cli_required: Optional[Set[str]] = None
+) -> dict[str, Any]:
     """Evaluate mapping completeness and return normalized execution rows."""
     header_errors, header_warnings = check_mapping_schema_header(mapping_doc)
     if header_errors:
@@ -1104,9 +1137,7 @@ def evaluate_mapping_doc(mapping_doc: dict[str, Any], cli_required: Optional[Set
 
     missing = sorted(req for req in required_ids if req not in covered_requirements)
     if missing:
-        errors.append(
-            "missing required requirements in resolved rows: " + ", ".join(missing)
-        )
+        errors.append("missing required requirements in resolved rows: " + ", ".join(missing))
 
     if not required_ids:
         warnings.append("No required requirement IDs provided; gate only checked row completeness")
@@ -1150,7 +1181,9 @@ def action_map_gate(mapping_path: str, cli_required: Optional[Set[str]] = None):
         print("!! Mapping gate failed:")
         for err in result["errors"]:
             print(f"  - {err}")
-        print("  Fill-mode is blocked. Complete the mapping table or switch to template-apply rebuild mode.")
+        print(
+            "  Fill-mode is blocked. Complete the mapping table or switch to template-apply rebuild mode."
+        )
         sys.exit(1)
 
     print("+ Mapping gate passed")
@@ -1204,7 +1237,9 @@ def replace_paragraph_content(paragraph: ET.Element, text: str) -> None:
     paragraph.append(make_text_run(text))
 
 
-def find_ancestor_paragraph(node: ET.Element, parent_map: dict[ET.Element, ET.Element]) -> Optional[ET.Element]:
+def find_ancestor_paragraph(
+    node: ET.Element, parent_map: dict[ET.Element, ET.Element]
+) -> Optional[ET.Element]:
     """Ascend to nearest paragraph ancestor."""
     cursor: Optional[ET.Element] = node
     while cursor is not None:
@@ -1255,9 +1290,7 @@ def resolve_selector_to_paragraph(root: ET.Element, selector: str) -> ET.Element
             raise ValueError(f"selector `{selector}` has no paragraph ancestor")
         return paragraph
 
-    raise ValueError(
-        f"selector `{selector}` unsupported; use text:, bookmark:, or xpath:"
-    )
+    raise ValueError(f"selector `{selector}` unsupported; use text:, bookmark:, or xpath:")
 
 
 def delete_paragraph(root: ET.Element, paragraph: ET.Element) -> None:
@@ -1306,9 +1339,7 @@ def execute_mapping_rows(root: ET.Element, rows: List[dict[str, Any]]) -> List[s
             )
         elif action == "delete":
             delete_paragraph(root, paragraph)
-            summaries.append(
-                f"{row_id}: delete on `{selector}` removed paragraph `{before[:60]}`"
-            )
+            summaries.append(f"{row_id}: delete on `{selector}` removed paragraph `{before[:60]}`")
         elif action == "insert":
             insert_paragraph_after(root, paragraph, target_value)
             summaries.append(
@@ -1446,7 +1477,9 @@ def parse_map_gate_args(argv: List[str]) -> Tuple[str, Set[str]]:
         flag = argv[index]
         if flag == "--require":
             if index + 1 >= len(argv):
-                print("Usage: python docx_engine.py map-gate <mapping.json> [--require ID[,ID...]]...")
+                print(
+                    "Usage: python docx_engine.py map-gate <mapping.json> [--require ID[,ID...]]..."
+                )
                 print("- Missing value after --require")
                 sys.exit(1)
             for req in split_requirement_ids(argv[index + 1]):
@@ -1620,7 +1653,7 @@ Modification Workflow:
 
 Template-Driven Workflow (when user provides a template):
   1. Keep the template as source of truth (no preset structure injection)
-  2. Run: dotnet run --project "{SCRIPT_LOCATION / 'src' / 'DocForge.csproj'}" -- from-template template.docx output.docx
+  2. Run: dotnet run --project "{SCRIPT_LOCATION / "src" / "DocForge.csproj"}" -- from-template template.docx output.docx
   3. Run: python docx_engine.py audit output.docx
   4. Run: python docx_engine.py residual output.docx
   5. Run: python docx_engine.py map-template mapping.json --require R1,R2
@@ -1673,7 +1706,9 @@ def main():
             overwrite=overwrite,
         )
     elif command == "map-apply":
-        input_docx, mapping_path, output_docx, required_ids, dry_run, allow_tokens = parse_map_apply_args(sys.argv)
+        input_docx, mapping_path, output_docx, required_ids, dry_run, allow_tokens = (
+            parse_map_apply_args(sys.argv)
+        )
         action_map_apply(
             input_docx=input_docx,
             mapping_path=mapping_path,

--- a/.minimax/skills/minimax-docx/render/data_plot.py
+++ b/.minimax/skills/minimax-docx/render/data_plot.py
@@ -7,6 +7,7 @@ from typing import Sequence
 
 try:
     import matplotlib
+
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
 except ImportError:
@@ -40,8 +41,7 @@ class DataPlotter:
         """
         if plt is None:
             raise ImportError(
-                "matplotlib is required for chart rendering. "
-                "Install with: pip install matplotlib"
+                "matplotlib is required for chart rendering. Install with: pip install matplotlib"
             )
         self._style = style
         self._width = width
@@ -105,10 +105,7 @@ class DataPlotter:
 
         for i, (name, values) in enumerate(datasets):
             color = self._style.accent_at(i)
-            positions = [
-                idx + i * bar_width - (n_series - 1) * bar_width / 2
-                for idx in indices
-            ]
+            positions = [idx + i * bar_width - (n_series - 1) * bar_width / 2 for idx in indices]
             bars = ax.bar(positions, values, bar_width, label=name, color=color)
 
             if show_values:
@@ -157,10 +154,7 @@ class DataPlotter:
 
         for i, (name, values) in enumerate(datasets):
             color = self._style.accent_at(i)
-            positions = [
-                idx + i * bar_height - (n_series - 1) * bar_height / 2
-                for idx in indices
-            ]
+            positions = [idx + i * bar_height - (n_series - 1) * bar_height / 2 for idx in indices]
             ax.barh(positions, values, bar_height, label=name, color=color)
 
         ax.set_yticks(indices)

--- a/.minimax/skills/minimax-docx/render/themes.py
+++ b/.minimax/skills/minimax-docx/render/themes.py
@@ -14,6 +14,7 @@ class PlotStyle:
         grid_color: Color for chart grid lines.
         font_family: Font family for text elements.
     """
+
     background: str
     foreground: str
     accents: tuple[str, ...]

--- a/.minimax/skills/minimax-docx/spec/__init__.py
+++ b/.minimax/skills/minimax-docx/spec/__init__.py
@@ -16,8 +16,13 @@ from .tree_fixer import tag_name, make_rank_index, sort_by_spec
 from .document_repair import DocumentFixer, SchemaProvider, RepairEvent, create_default_fixer
 
 __all__ = [
-    "W", "R", "WP", "A", "PIC",
-    "clark", "ensure_prefixes",
+    "W",
+    "R",
+    "WP",
+    "A",
+    "PIC",
+    "clark",
+    "ensure_prefixes",
     "CONTAINER_ORDERS",
     "DEFAULT_PROFILE",
     "RuleLevel",
@@ -27,6 +32,11 @@ __all__ = [
     "get_phase_plan",
     "explain_container",
     "known_profiles",
-    "tag_name", "make_rank_index", "sort_by_spec",
-    "DocumentFixer", "SchemaProvider", "RepairEvent", "create_default_fixer",
+    "tag_name",
+    "make_rank_index",
+    "sort_by_spec",
+    "DocumentFixer",
+    "SchemaProvider",
+    "RepairEvent",
+    "create_default_fixer",
 ]

--- a/.minimax/skills/minimax-docx/spec/document_repair.py
+++ b/.minimax/skills/minimax-docx/spec/document_repair.py
@@ -19,11 +19,9 @@ from .tree_fixer import sort_by_spec, tag_name
 
 
 class SchemaProvider(Protocol):
-    def get_child_order(self, container_name: str) -> Sequence[str] | None:
-        ...
+    def get_child_order(self, container_name: str) -> Sequence[str] | None: ...
 
-    def get_all_containers(self) -> Sequence[str]:
-        ...
+    def get_all_containers(self) -> Sequence[str]: ...
 
 
 @dataclass(frozen=True)
@@ -59,7 +57,9 @@ class DocumentFixer:
             if local == "pPr":
                 moved = self.wrap_border_group(node)
                 if moved:
-                    self._record("wrap-border-group", local, "moved loose border leaves into pBdr", moved)
+                    self._record(
+                        "wrap-border-group", local, "moved loose border leaves into pBdr", moved
+                    )
                     changes += moved
 
             order = self._schema.get_child_order(local)
@@ -191,7 +191,9 @@ class DocumentFixer:
 
         parent.insert(insert_index, node)
 
-    def _iter_non_nested_tables(self, root: Element, parent_map: dict[Element, Element]) -> Iterable[Element]:
+    def _iter_non_nested_tables(
+        self, root: Element, parent_map: dict[Element, Element]
+    ) -> Iterable[Element]:
         for table in root.iter(clark("tbl")):
             parent = parent_map.get(table)
             nested = False

--- a/.minimax/skills/minimax-docx/spec/ooxml_order.py
+++ b/.minimax/skills/minimax-docx/spec/ooxml_order.py
@@ -18,6 +18,7 @@ from typing import Iterable, Sequence
 try:
     from enum import StrEnum
 except ImportError:  # pragma: no cover - Python < 3.11
+
     class StrEnum(str, Enum):
         """Compatibility shim for Python versions without enum.StrEnum."""
 
@@ -87,7 +88,19 @@ ORDER_BOOK: dict[str, ContainerOrder] = {
     "rPr": ContainerOrder(
         name="rPr",
         phases=(
-            _phase(RuleLevel.MUST, "must-core", "rStyle", "rFonts", "b", "i", "color", "sz", "szCs", "u", "rtl"),
+            _phase(
+                RuleLevel.MUST,
+                "must-core",
+                "rStyle",
+                "rFonts",
+                "b",
+                "i",
+                "color",
+                "sz",
+                "szCs",
+                "u",
+                "rtl",
+            ),
             _phase(
                 RuleLevel.SHOULD,
                 "should-emphasis",
@@ -102,14 +115,35 @@ ORDER_BOOK: dict[str, ContainerOrder] = {
                 "lang",
                 "oMath",
             ),
-            _phase(RuleLevel.MAY, "may-typography", "spacing", "w", "kern", "position", "fitText", "eastAsianLayout"),
+            _phase(
+                RuleLevel.MAY,
+                "may-typography",
+                "spacing",
+                "w",
+                "kern",
+                "position",
+                "fitText",
+                "eastAsianLayout",
+            ),
             _phase(RuleLevel.VENDOR, "vendor-tail", "specVanish"),
         ),
     ),
     "pPr": ContainerOrder(
         name="pPr",
         phases=(
-            _phase(RuleLevel.MUST, "must-layout", "pStyle", "numPr", "pBdr", "tabs", "spacing", "ind", "jc", "rPr", "sectPr"),
+            _phase(
+                RuleLevel.MUST,
+                "must-layout",
+                "pStyle",
+                "numPr",
+                "pBdr",
+                "tabs",
+                "spacing",
+                "ind",
+                "jc",
+                "rPr",
+                "sectPr",
+            ),
             _phase(
                 RuleLevel.SHOULD,
                 "should-flow-control",
@@ -122,7 +156,15 @@ ORDER_BOOK: dict[str, ContainerOrder] = {
                 "outlineLvl",
                 "pPrChange",
             ),
-            _phase(RuleLevel.MAY, "may-asian-layout", "kinsoku", "wordWrap", "autoSpaceDE", "autoSpaceDN", "snapToGrid"),
+            _phase(
+                RuleLevel.MAY,
+                "may-asian-layout",
+                "kinsoku",
+                "wordWrap",
+                "autoSpaceDE",
+                "autoSpaceDN",
+                "snapToGrid",
+            ),
             _phase(RuleLevel.VENDOR, "vendor-formatting", "divId", "cnfStyle"),
         ),
     ),
@@ -142,23 +184,62 @@ ORDER_BOOK: dict[str, ContainerOrder] = {
                 "bidi",
                 "rtlGutter",
             ),
-            _phase(RuleLevel.MAY, "may-page-extensions", "paperSrc", "pgBorders", "lnNumType", "pgNumType", "printerSettings"),
+            _phase(
+                RuleLevel.MAY,
+                "may-page-extensions",
+                "paperSrc",
+                "pgBorders",
+                "lnNumType",
+                "pgNumType",
+                "printerSettings",
+            ),
             _phase(RuleLevel.VENDOR, "vendor-tail", "sectPrChange"),
         ),
     ),
     "tcPr": ContainerOrder(
         name="tcPr",
         phases=(
-            _phase(RuleLevel.MUST, "must-cell", "tcW", "gridSpan", "hMerge", "vMerge", "tcBorders", "tcMar", "vAlign"),
-            _phase(RuleLevel.SHOULD, "should-cell-layout", "cnfStyle", "shd", "noWrap", "textDirection", "tcFitText", "hideMark"),
-            _phase(RuleLevel.MAY, "may-cell-revision", "headers", "cellIns", "cellDel", "cellMerge"),
+            _phase(
+                RuleLevel.MUST,
+                "must-cell",
+                "tcW",
+                "gridSpan",
+                "hMerge",
+                "vMerge",
+                "tcBorders",
+                "tcMar",
+                "vAlign",
+            ),
+            _phase(
+                RuleLevel.SHOULD,
+                "should-cell-layout",
+                "cnfStyle",
+                "shd",
+                "noWrap",
+                "textDirection",
+                "tcFitText",
+                "hideMark",
+            ),
+            _phase(
+                RuleLevel.MAY, "may-cell-revision", "headers", "cellIns", "cellDel", "cellMerge"
+            ),
             _phase(RuleLevel.VENDOR, "vendor-tail", "tcPrChange"),
         ),
     ),
     "tblPr": ContainerOrder(
         name="tblPr",
         phases=(
-            _phase(RuleLevel.MUST, "must-table", "tblStyle", "tblW", "jc", "tblBorders", "tblLayout", "tblCellMar", "tblLook"),
+            _phase(
+                RuleLevel.MUST,
+                "must-table",
+                "tblStyle",
+                "tblW",
+                "jc",
+                "tblBorders",
+                "tblLayout",
+                "tblCellMar",
+                "tblLook",
+            ),
             _phase(
                 RuleLevel.SHOULD,
                 "should-table-layout",
@@ -169,20 +250,47 @@ ORDER_BOOK: dict[str, ContainerOrder] = {
                 "tblStyleRowBandSize",
                 "tblStyleColBandSize",
             ),
-            _phase(RuleLevel.MAY, "may-table-meta", "tblOverlap", "bidiVisual", "tblCaption", "tblDescription"),
+            _phase(
+                RuleLevel.MAY,
+                "may-table-meta",
+                "tblOverlap",
+                "bidiVisual",
+                "tblCaption",
+                "tblDescription",
+            ),
             _phase(RuleLevel.VENDOR, "vendor-tail", "tblPrChange"),
         ),
     ),
     "tblBorders": ContainerOrder(
         name="tblBorders",
         phases=(
-            _phase(RuleLevel.MUST, "must-outer-and-inner", "top", "left", "bottom", "right", "insideH", "insideV"),
+            _phase(
+                RuleLevel.MUST,
+                "must-outer-and-inner",
+                "top",
+                "left",
+                "bottom",
+                "right",
+                "insideH",
+                "insideV",
+            ),
             _phase(RuleLevel.MAY, "may-bidi-edges", "start", "end"),
         ),
     ),
     "pBdr": ContainerOrder(
         name="pBdr",
-        phases=(_phase(RuleLevel.MUST, "must-border-loop", "top", "left", "bottom", "right", "between", "bar"),),
+        phases=(
+            _phase(
+                RuleLevel.MUST,
+                "must-border-loop",
+                "top",
+                "left",
+                "bottom",
+                "right",
+                "between",
+                "bar",
+            ),
+        ),
     ),
     "tcMar": ContainerOrder(
         name="tcMar",
@@ -201,8 +309,25 @@ ORDER_BOOK: dict[str, ContainerOrder] = {
     "lvl": ContainerOrder(
         name="lvl",
         phases=(
-            _phase(RuleLevel.MUST, "must-numbering", "start", "numFmt", "lvlText", "lvlJc", "pPr", "rPr"),
-            _phase(RuleLevel.SHOULD, "should-numbering-controls", "lvlRestart", "pStyle", "isLgl", "suff", "lvlPicBulletId"),
+            _phase(
+                RuleLevel.MUST,
+                "must-numbering",
+                "start",
+                "numFmt",
+                "lvlText",
+                "lvlJc",
+                "pPr",
+                "rPr",
+            ),
+            _phase(
+                RuleLevel.SHOULD,
+                "should-numbering-controls",
+                "lvlRestart",
+                "pStyle",
+                "isLgl",
+                "suff",
+                "lvlPicBulletId",
+            ),
             _phase(RuleLevel.MAY, "may-legacy", "legacy"),
         ),
     ),
@@ -218,7 +343,14 @@ ORDER_BOOK: dict[str, ContainerOrder] = {
         name="tr",
         phases=(
             _phase(RuleLevel.MUST, "must-row-core", "tblPrEx", "trPr", "tc"),
-            _phase(RuleLevel.SHOULD, "should-row-content", "customXml", "sdt", "bookmarkStart", "bookmarkEnd"),
+            _phase(
+                RuleLevel.SHOULD,
+                "should-row-content",
+                "customXml",
+                "sdt",
+                "bookmarkStart",
+                "bookmarkEnd",
+            ),
             _phase(
                 RuleLevel.MAY,
                 "may-ranges",
@@ -247,17 +379,58 @@ ORDER_BOOK: dict[str, ContainerOrder] = {
         name="style",
         phases=(
             _phase(RuleLevel.MUST, "must-style-identity", "name", "basedOn", "next", "qFormat"),
-            _phase(RuleLevel.SHOULD, "should-style-switches", "aliases", "link", "uiPriority", "semiHidden", "unhideWhenUsed", "locked", "rsid"),
-            _phase(RuleLevel.MUST, "must-style-payload", "pPr", "rPr", "tblPr", "trPr", "tcPr", "tblStylePr"),
-            _phase(RuleLevel.MAY, "may-style-personalization", "autoRedefine", "hidden", "personal", "personalCompose", "personalReply"),
+            _phase(
+                RuleLevel.SHOULD,
+                "should-style-switches",
+                "aliases",
+                "link",
+                "uiPriority",
+                "semiHidden",
+                "unhideWhenUsed",
+                "locked",
+                "rsid",
+            ),
+            _phase(
+                RuleLevel.MUST,
+                "must-style-payload",
+                "pPr",
+                "rPr",
+                "tblPr",
+                "trPr",
+                "tcPr",
+                "tblStylePr",
+            ),
+            _phase(
+                RuleLevel.MAY,
+                "may-style-personalization",
+                "autoRedefine",
+                "hidden",
+                "personal",
+                "personalCompose",
+                "personalReply",
+            ),
         ),
     ),
     "tbl": ContainerOrder(
         name="tbl",
         phases=(
             _phase(RuleLevel.MUST, "must-table-core", "tblPr", "tblGrid", "tr"),
-            _phase(RuleLevel.SHOULD, "should-table-anchors", "bookmarkStart", "bookmarkEnd", "commentRangeStart", "commentRangeEnd"),
-            _phase(RuleLevel.MAY, "may-move-ranges", "moveFromRangeStart", "moveFromRangeEnd", "moveToRangeStart", "moveToRangeEnd"),
+            _phase(
+                RuleLevel.SHOULD,
+                "should-table-anchors",
+                "bookmarkStart",
+                "bookmarkEnd",
+                "commentRangeStart",
+                "commentRangeEnd",
+            ),
+            _phase(
+                RuleLevel.MAY,
+                "may-move-ranges",
+                "moveFromRangeStart",
+                "moveFromRangeEnd",
+                "moveToRangeStart",
+                "moveToRangeEnd",
+            ),
             _phase(
                 RuleLevel.VENDOR,
                 "vendor-custom-ranges",
@@ -277,7 +450,14 @@ ORDER_BOOK: dict[str, ContainerOrder] = {
         phases=(
             _phase(RuleLevel.MUST, "must-main-flow", "p", "tbl"),
             _phase(RuleLevel.SHOULD, "should-embedded-blocks", "customXml", "sdt", "altChunk"),
-            _phase(RuleLevel.MAY, "may-ranges", "bookmarkStart", "bookmarkEnd", "commentRangeStart", "commentRangeEnd"),
+            _phase(
+                RuleLevel.MAY,
+                "may-ranges",
+                "bookmarkStart",
+                "bookmarkEnd",
+                "commentRangeStart",
+                "commentRangeEnd",
+            ),
             _phase(
                 RuleLevel.VENDOR,
                 "vendor-move-ranges",
@@ -341,7 +521,15 @@ ORDER_BOOK: dict[str, ContainerOrder] = {
                 "alwaysMergeEmptyNamespace",
                 "updateFields",
             ),
-            _phase(RuleLevel.VENDOR, "vendor-tail", "docId", "defaultImageDpi", "conflictMode", "decimalSymbol", "listSeparator"),
+            _phase(
+                RuleLevel.VENDOR,
+                "vendor-tail",
+                "docId",
+                "defaultImageDpi",
+                "conflictMode",
+                "decimalSymbol",
+                "listSeparator",
+            ),
         ),
     ),
 }
@@ -384,7 +572,9 @@ def get_child_order(container: str, profile: str = DEFAULT_PROFILE) -> tuple[str
     return spec.build_sequence(profile)
 
 
-def get_phase_plan(container: str, profile: str = DEFAULT_PROFILE) -> tuple[AssemblyPhase, ...] | None:
+def get_phase_plan(
+    container: str, profile: str = DEFAULT_PROFILE
+) -> tuple[AssemblyPhase, ...] | None:
     spec = ORDER_BOOK.get(container)
     return spec.active_phases(profile) if spec else None
 

--- a/.minimax/skills/minimax-docx/spec/tree_fixer.py
+++ b/.minimax/skills/minimax-docx/spec/tree_fixer.py
@@ -23,7 +23,7 @@ def tag_name(clark_notation: str) -> str:
     close_brace = clark_notation.rfind("}")
     if close_brace == -1:
         return clark_notation
-    return clark_notation[close_brace + 1:]
+    return clark_notation[close_brace + 1 :]
 
 
 def make_rank_index(sequence: Sequence[str]) -> dict[str, int]:

--- a/cli/commands/config.py
+++ b/cli/commands/config.py
@@ -24,12 +24,12 @@ def show_config():
 def get_config(key: str):
     """Get a specific config value"""
     config = CLIConfig()
-    
+
     valid_keys = ["api_url", "api_key", "refresh_token", "config_path"]
     if key not in valid_keys:
         click.echo(f"Error: Invalid key '{key}'. Valid keys: {', '.join(valid_keys)}", err=True)
         return
-    
+
     if key == "config_path":
         click.echo(str(config.config_path))
     elif key == "api_key":
@@ -48,20 +48,20 @@ def get_config(key: str):
 def set_config(key: str, value: str, unset: bool):
     """Set a config value"""
     config = CLIConfig()
-    
+
     valid_keys = ["api_url"]
     if key not in valid_keys:
         click.echo(f"Error: Invalid key '{key}'. Editable keys: {', '.join(valid_keys)}", err=True)
         return
-    
+
     if unset:
         click.echo(f"Error: Cannot unset '{key}' via this command.", err=True)
         return
-    
+
     if key == "api_url":
         config.api_url = value
         click.echo(f"API URL set to: {value}")
-    
+
     config.save()
 
 
@@ -71,21 +71,21 @@ def set_config(key: str, value: str, unset: bool):
 def unset_config(key: str, force: bool):
     """Unset a config value"""
     config = CLIConfig()
-    
+
     valid_keys = ["api_key", "refresh_token"]
     if key not in valid_keys:
         click.echo(f"Error: Invalid key '{key}'. Can only unset: {', '.join(valid_keys)}", err=True)
         return
-    
+
     if not force:
         if not click.confirm(f"Are you sure you want to unset {key}?"):
             return
-    
+
     if key == "api_key":
         config.api_key = None
     elif key == "refresh_token":
         config.refresh_token = None
-    
+
     config.save()
     click.echo(f"Unset {key}")
 
@@ -97,12 +97,12 @@ def reset_config(force: bool):
     if not force:
         if not click.confirm("This will clear all local settings. Continue?"):
             return
-    
+
     config = CLIConfig()
     config.api_url = "http://localhost:8000"
     config.api_key = None
     config.refresh_token = None
     config.save()
-    
+
     click.echo("Configuration reset to defaults.")
     click.echo("API URL: http://localhost:8000")

--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 # Issue definition
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class Issue:
     title: str
@@ -354,7 +355,6 @@ ISSUES: list[Issue] = [
         ),
         labels=["area:api", "area:test", "size:s", "risk:low"],
     ),
-
     # ── area:web  (18 issues) ──────────────────────────────────────────────
     Issue(
         title="feat(web): add authenticated agent list view to dashboard",
@@ -649,7 +649,6 @@ ISSUES: list[Issue] = [
         ),
         labels=["area:web", "area:auth", "size:s", "risk:low"],
     ),
-
     # ── area:cli-sdk  (12 issues) ──────────────────────────────────────────
     Issue(
         title="fix(cli): fix mutx agents create to use current API contract",
@@ -843,7 +842,6 @@ ISSUES: list[Issue] = [
         ),
         labels=["area:cli-sdk", "size:s", "risk:low"],
     ),
-
     # ── area:test  (15 issues) ─────────────────────────────────────────────
     Issue(
         title="test(api): add route tests for GET /agents",
@@ -1086,7 +1084,6 @@ ISSUES: list[Issue] = [
         ),
         labels=["area:test", "size:s", "risk:low"],
     ),
-
     # ── area:docs  (10 issues) ─────────────────────────────────────────────
     Issue(
         title="docs: add quickstart guide for new contributors",
@@ -1247,7 +1244,6 @@ ISSUES: list[Issue] = [
         ),
         labels=["area:docs", "size:s", "risk:low"],
     ),
-
     # ── area:infra  (10 issues) ────────────────────────────────────────────
     Issue(
         title="feat(infra): add database migration CI check",
@@ -1410,7 +1406,6 @@ ISSUES: list[Issue] = [
         ),
         labels=["area:infra", "size:s", "risk:low"],
     ),
-
     # ── area:auth  (5 issues) ──────────────────────────────────────────────
     Issue(
         title="feat(auth): enforce ownership on all agent endpoints",
@@ -1491,7 +1486,6 @@ ISSUES: list[Issue] = [
         ),
         labels=["area:auth", "area:api", "size:s", "risk:medium"],
     ),
-
     # ── area:runtime  (5 issues) ───────────────────────────────────────────
     Issue(
         title="feat(runtime): add agent execution timeout enforcement",
@@ -1576,7 +1570,6 @@ ISSUES: list[Issue] = [
         ),
         labels=["area:runtime", "area:api", "size:m", "risk:medium"],
     ),
-
     # ── area:ops  (5 issues) ───────────────────────────────────────────────
     Issue(
         title="feat(ops): add Prometheus metrics endpoint",
@@ -1671,11 +1664,12 @@ if len(ISSUES) != 100:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def dry_run(issues: list[Issue]) -> None:
     """Print all issues that would be created."""
     for idx, issue in enumerate(issues, 1):
         labels = ", ".join(issue.labels) if issue.labels else "(none)"
-        print(f"\n{'='*72}")
+        print(f"\n{'=' * 72}")
         print(f"Issue {idx}/100")
         print(f"  Title:  {issue.title}")
         print(f"  Labels: {labels}")
@@ -1683,7 +1677,7 @@ def dry_run(issues: list[Issue]) -> None:
         if len(issue.body) > 200:
             body_preview += "..."
         print(f"  Body:\n{body_preview}")
-    print(f"\n{'='*72}")
+    print(f"\n{'=' * 72}")
     print(f"Total: {len(issues)} issues ready to create.")
     print("Run with --execute to create them.\n")
 
@@ -1694,10 +1688,15 @@ def create_issues(issues: list[Issue], repo: str) -> None:
     failed = 0
     for idx, issue in enumerate(issues, 1):
         cmd = [
-            "gh", "issue", "create",
-            "--repo", repo,
-            "--title", issue.title,
-            "--body", issue.body,
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            repo,
+            "--title",
+            issue.title,
+            "--body",
+            issue.body,
         ]
         for label in issue.labels:
             cmd.extend(["--label", label])
@@ -1735,10 +1734,9 @@ def create_issues(issues: list[Issue], repo: str) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
+
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Generate 100 GitHub issues for the MUTX project."
-    )
+    parser = argparse.ArgumentParser(description="Generate 100 GitHub issues for the MUTX project.")
     parser.add_argument(
         "--execute",
         action="store_true",

--- a/sdk/mutx/__init__.py
+++ b/sdk/mutx/__init__.py
@@ -14,7 +14,7 @@ from mutx.agents import Agents
 from mutx.api_keys import APIKeys
 from mutx.clawhub import ClawHub
 from mutx.deployments import Deployments
-from mutx.leads import Leads, Contacts
+from mutx.leads import Contacts, Leads
 from mutx.webhooks import Webhooks
 
 

--- a/src/api/auth/jwt.py
+++ b/src/api/auth/jwt.py
@@ -35,29 +35,33 @@ def create_refresh_token(
 ) -> tuple[str, datetime]:
     """
     Create a refresh token with optional sliding expiry.
-    
+
     If original_iat is provided, the token expiry will be calculated from that
     time instead of now, enabling sliding expiry up to REFRESH_TOKEN_MAX_SLIDING_DAYS.
-    
+
     Args:
         user_id: The user's UUID
         original_iat: Original issue time for calculating sliding expiry
-        
+
     Returns:
         Tuple of (encoded JWT, expiry datetime)
     """
     now = datetime.now(timezone.utc)
-    
+
     if original_iat is not None:
         # Sliding expiry: calculate expiry from original issue time
-        original_iat = original_iat.replace(tzinfo=timezone.utc) if original_iat.tzinfo is None else original_iat
+        original_iat = (
+            original_iat.replace(tzinfo=timezone.utc)
+            if original_iat.tzinfo is None
+            else original_iat
+        )
         max_expire = original_iat + timedelta(days=REFRESH_TOKEN_MAX_SLIDING_DAYS)
         expire = min(now + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS), max_expire)
         iat = original_iat  # Keep original issue time for future sliding
     else:
         expire = now + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
         iat = now
-    
+
     to_encode = {
         "sub": str(user_id),
         "type": "refresh",
@@ -106,18 +110,18 @@ def get_refresh_token_iat(token: str) -> Optional[datetime]:
     payload = verify_token(token)
     if not payload or payload.get("type") != "refresh":
         return None
-    
+
     iat = payload.get("iat")
     if not iat:
         return None
-    
+
     # Handle both string and numeric timestamps
     if isinstance(iat, str):
         # Parse ISO format string
         return datetime.fromisoformat(iat.replace("Z", "+00:00"))
     elif isinstance(iat, (int, float)):
         return datetime.fromtimestamp(iat, tz=timezone.utc)
-    
+
     return None
 
 
@@ -126,7 +130,7 @@ async def refresh_access_token(
 ) -> Optional[tuple[str, datetime, str]]:
     """
     Refresh access token with sliding expiry.
-    
+
     When a refresh token is used, the new refresh token will have its expiry
     calculated from the ORIGINAL issue time of the old token (sliding window),
     capped at REFRESH_TOKEN_MAX_SLIDING_DAYS.
@@ -142,7 +146,7 @@ async def refresh_access_token(
 
     # Get original issue time for sliding expiry
     original_iat = get_refresh_token_iat(refresh_token)
-    
+
     access_token, access_token_expires_at = create_access_token(user_id)
     # Pass original_iat to implement sliding expiry
     new_refresh_token, _ = create_refresh_token(user_id, original_iat=original_iat)

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -1,8 +1,6 @@
-
 from functools import lru_cache
 from json import JSONDecodeError, loads
 import os
-import re
 import secrets
 
 from pydantic import AliasChoices, Field, field_validator, model_validator
@@ -150,7 +148,7 @@ class Settings(BaseSettings):
             if is_production:
                 errors.append(
                     "JWT_SECRET environment variable must be set in production. "
-                    "Generate one with: python3 -c \"import secrets; print(secrets.token_urlsafe(32))\""
+                    'Generate one with: python3 -c "import secrets; print(secrets.token_urlsafe(32))"'
                 )
             else:
                 warnings.append(
@@ -200,13 +198,18 @@ class Settings(BaseSettings):
 
         # Raise errors if any
         if errors:
-            error_message = "Environment variable validation failed:\n" + "\n".join(f"  - {e}" for e in errors)
+            error_message = "Environment variable validation failed:\n" + "\n".join(
+                f"  - {e}" for e in errors
+            )
             raise ValueError(error_message)
 
         # Log warnings (these will be captured by the caller)
         if warnings:
-            warning_message = "Environment variable warnings:\n" + "\n".join(f"  - {w}" for w in warnings)
+            warning_message = "Environment variable warnings:\n" + "\n".join(
+                f"  - {w}" for w in warnings
+            )
             import logging
+
             logging.warning(warning_message)
 
         return self

--- a/src/api/logging_config.py
+++ b/src/api/logging_config.py
@@ -5,11 +5,9 @@ Provides JSON logging with configurable fields and formats for better
 log aggregation and analysis in production environments.
 """
 
-import json
 import logging
 import sys
 from datetime import datetime, timezone
-from typing import Any
 from uuid import uuid4
 
 from pythonjsonlogger import jsonlogger
@@ -18,41 +16,41 @@ from pythonjsonlogger import jsonlogger
 class StructuredJsonFormatter(jsonlogger.JsonFormatter):
     """
     Custom JSON formatter that adds structured fields to all log records.
-    
+
     Features:
     - ISO 8601 timestamps
     - Request/trace IDs
     - Configurable extra fields
     - Exception stack traces preserved
     """
-    
+
     def add_fields(self, log_record: dict, record: logging.LogRecord, message_dict: dict) -> None:
         """Add structured fields to the log record."""
         super().add_fields(log_record, record, message_dict)
-        
+
         # Timestamp in ISO 8601 format
         log_record["timestamp"] = datetime.now(timezone.utc).isoformat()
-        
+
         # Level as string
         log_record["level"] = record.levelname
-        
+
         # Logger name
         log_record["logger"] = record.name
-        
+
         # Function and line number for debugging
         log_record["function"] = record.funcName
         log_record["line"] = record.lineno
-        
+
         # Module path
         log_record["module"] = record.module
-        
+
         # Process and thread IDs
         log_record["process_id"] = record.process
         log_record["thread_id"] = record.thread
-        
+
         # Message
         log_record["message"] = record.getMessage()
-        
+
         # Exception info if present
         if record.exc_info:
             log_record["exception"] = self.formatException(record.exc_info)
@@ -62,7 +60,7 @@ class RequestIdFilter(logging.Filter):
     """
     Filter that adds a request ID to log records if not present.
     """
-    
+
     def filter(self, record: logging.LogRecord) -> bool:
         if not hasattr(record, "request_id"):
             record.request_id = str(uuid4())[:8]
@@ -70,62 +68,58 @@ class RequestIdFilter(logging.Filter):
 
 
 def setup_json_logging(
-    log_level: str = "INFO",
-    json_format: bool = True,
-    log_file: str | None = None
+    log_level: str = "INFO", json_format: bool = True, log_file: str | None = None
 ) -> logging.Logger:
     """
     Configure structured JSON logging for the application.
-    
+
     Args:
         log_level: The logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
         json_format: Whether to use JSON format (True) or plain text (False)
         log_file: Optional file path to write logs to
-        
+
     Returns:
         The configured root logger
     """
     root_logger = logging.getLogger()
     root_logger.setLevel(getattr(logging, log_level.upper(), logging.INFO))
-    
+
     # Remove existing handlers
     for handler in root_logger.handlers[:]:
         root_logger.removeHandler(handler)
-    
+
     # Create formatter
     if json_format:
         formatter = StructuredJsonFormatter(
             "%(timestamp)s %(level)s %(name)s %(message)s",
-            rename_fields={"levelname": "level", "name": "logger"}
+            rename_fields={"levelname": "level", "name": "logger"},
         )
     else:
-        formatter = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        )
-    
+        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
     # Console handler
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setFormatter(formatter)
     console_handler.addFilter(RequestIdFilter())
     root_logger.addHandler(console_handler)
-    
+
     # File handler if specified
     if log_file:
         file_handler = logging.FileHandler(log_file)
         file_handler.setFormatter(formatter)
         file_handler.addFilter(RequestIdFilter())
         root_logger.addHandler(file_handler)
-    
+
     return root_logger
 
 
 def get_logger(name: str) -> logging.Logger:
     """
     Get a logger instance with the given name.
-    
+
     Args:
         name: The name for the logger (typically __name__)
-        
+
     Returns:
         A configured logger instance
     """

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -52,9 +52,7 @@ start_time = time.time()
 
 # Setup logging - use JSON format if configured
 setup_json_logging(
-    log_level=settings.log_level,
-    json_format=settings.json_logging,
-    log_file=settings.log_file
+    log_level=settings.log_level, json_format=settings.json_logging, log_file=settings.log_file
 )
 logger = logging.getLogger(__name__)
 
@@ -95,14 +93,14 @@ async def _start_monitor_when_database_ready(app: FastAPI) -> None:
 
 def _validate_environment() -> None:
     """Validate environment variables on startup.
-    
+
     This function is called during app startup to ensure required
     environment variables are properly configured.
     """
     # Re-access settings to trigger validation
     # The Settings class already validates on instantiation
     logger.info("Environment variable validation completed")
-    
+
     # Log the validation results
     if settings.is_production:
         logger.info("Running in PRODUCTION mode")
@@ -113,7 +111,7 @@ def _validate_environment() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logger.info("Starting up API...")
-    
+
     # Validate environment variables on startup
     try:
         _validate_environment()
@@ -123,7 +121,7 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.exception("Unexpected error during environment validation: %s", e)
         raise RuntimeError(f"Environment validation failed: {e}") from e
-    
+
     app.state.start_time = time.time()
     app.state.database_ready = False
     app.state.database_error = None

--- a/src/api/metrics.py
+++ b/src/api/metrics.py
@@ -2,7 +2,7 @@
 Prometheus metrics for MUTX API monitoring.
 """
 
-from prometheus_client import Counter, Histogram, Gauge, generate_latest, CONTENT_TYPE_LATEST
+from prometheus_client import Counter, Histogram, Gauge, generate_latest
 from fastapi import APIRouter, Response, Request
 import time
 

--- a/src/api/models/migrations/versions/alter_plan_column.py
+++ b/src/api/models/migrations/versions/alter_plan_column.py
@@ -1,10 +1,12 @@
 """Alter plan column from enum to varchar."""
+
 from alembic import op
 
-revision = 'alter_plan_to_varchar'
-down_revision = 'e8f636a73690_initial_migration_create_all_tables'
+revision = "alter_plan_to_varchar"
+down_revision = "e8f636a73690_initial_migration_create_all_tables"
 branch_labels = None
 depends_on = None
+
 
 def upgrade() -> None:
     # First, drop the default to avoid conflicts
@@ -13,6 +15,7 @@ def upgrade() -> None:
     op.execute("ALTER TABLE users ALTER COLUMN plan TYPE VARCHAR(20)")
     # Set the default
     op.execute("ALTER TABLE users ALTER COLUMN plan SET DEFAULT 'FREE'")
+
 
 def downgrade() -> None:
     op.execute("CREATE TYPE plan AS ENUM ('FREE', 'STARTER', 'PRO', 'ENTERPRISE')")

--- a/src/api/models/models.py
+++ b/src/api/models/models.py
@@ -7,7 +7,6 @@ from sqlalchemy.dialects.postgresql import UUID, ARRAY as PG_ARRAY
 import enum
 
 from src.api.database import Base
-from src.api.models.plan_tiers import PlanTier
 
 
 def ARRAY(type_):
@@ -86,7 +85,8 @@ class User(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True),
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
@@ -132,7 +132,8 @@ class Agent(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True),
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )

--- a/src/api/models/schemas.py
+++ b/src/api/models/schemas.py
@@ -243,7 +243,6 @@ class AgentMetricResponse(BaseModel):
     timestamp: datetime
 
 
-
 class AgentResourceUsageResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -273,6 +272,7 @@ class AgentResourceUsageCreate(BaseModel):
     extra_metadata: Optional[dict[str, Any]] = Field(default_factory=dict)
     period_start: datetime
     period_end: Optional[datetime] = None
+
 
 class RunTraceCreate(BaseModel):
     event_type: str = Field(..., min_length=1, max_length=100)

--- a/src/api/routes/agents.py
+++ b/src/api/routes/agents.py
@@ -13,6 +13,7 @@ from src.api.auth.ownership import get_owned_agent
 from src.api.database import get_db
 from src.api.middleware.auth import get_current_user
 from src.api.models import (
+    AgentVersion,
     UsageEvent,
     Agent,
     AgentLog,
@@ -40,6 +41,9 @@ from src.api.models.schemas import (
     CustomAgentConfig,
     LangChainAgentConfig,
     OpenAIAgentConfig,
+    AgentVersionResponse,
+    AgentVersionHistoryResponse,
+    AgentRollbackRequest,
 )
 
 router = APIRouter(prefix="/agents", tags=["agents"])
@@ -524,8 +528,6 @@ async def get_agent_metrics(
 
 # --- Resource Usage Routes ---
 
-from src.api.models import AgentResourceUsage
-from src.api.models.schemas import AgentResourceUsageCreate, AgentResourceUsageResponse
 
 
 @router.post(
@@ -595,3 +597,169 @@ async def list_agent_resource_usage(
     result = await db.execute(query)
     usages = result.scalars().all()
     return usages
+
+
+@router.get("/{agent_id}/versions", response_model=AgentVersionHistoryResponse)
+async def list_agent_versions(
+    agent_id: uuid.UUID,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List all versions of an agent."""
+    await get_owned_agent(
+        agent_id,
+        db,
+        current_user,
+        forbidden_detail="Not authorized to access this agent's versions",
+    )
+
+    query = (
+        select(AgentVersion)
+        .where(AgentVersion.agent_id == agent_id)
+        .order_by(AgentVersion.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+    )
+    result = await db.execute(query)
+    versions = result.scalars().all()
+
+    # Get total count
+    count_query = select(AgentVersion).where(AgentVersion.agent_id == agent_id)
+    count_result = await db.execute(count_query)
+    total = len(count_result.scalars().all())
+
+    return {
+        "agent_id": agent_id,
+        "items": versions,
+        "total": total,
+    }
+
+
+@router.get("/{agent_id}/versions/{version_id}", response_model=AgentVersionResponse)
+async def get_agent_version(
+    agent_id: uuid.UUID,
+    version_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get a specific version of an agent."""
+    await get_owned_agent(
+        agent_id,
+        db,
+        current_user,
+        forbidden_detail="Not authorized to access this agent's versions",
+    )
+
+    query = select(AgentVersion).where(
+        AgentVersion.id == version_id,
+        AgentVersion.agent_id == agent_id,
+    )
+    result = await db.execute(query)
+    version = result.scalar_one_or_none()
+
+    if not version:
+        raise HTTPException(status_code=404, detail="Version not found")
+
+    return version
+
+
+@router.post("/{agent_id}/versions", response_model=AgentVersionResponse, status_code=201)
+async def create_agent_version(
+    agent_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Create a new version snapshot of an agent's configuration."""
+    agent = await get_owned_agent(
+        agent_id,
+        db,
+        current_user,
+        forbidden_detail="Not authorized to create versions for this agent",
+    )
+
+    # Get the latest version number
+    query = (
+        select(AgentVersion)
+        .where(AgentVersion.agent_id == agent_id)
+        .order_by(AgentVersion.version.desc())
+    )
+    result = await db.execute(query)
+    latest_version = result.scalar_one_or_none()
+    new_version = (latest_version.version + 1) if latest_version else 1
+
+    # Mark previous versions as not current
+    await db.execute(
+        AgentVersion.__table__.update()
+        .where(AgentVersion.agent_id == agent_id)
+        .values(status="archived")
+    )
+
+    # Create new version
+    agent_version = AgentVersion(
+        agent_id=agent_id,
+        version=new_version,
+        config_snapshot=agent.config,
+        status="current",
+    )
+    db.add(agent_version)
+    await db.commit()
+    await db.refresh(agent_version)
+
+    logger.info(f"Created version {new_version} for agent: {agent_id}")
+    return agent_version
+
+
+@router.post("/{agent_id}/rollback", response_model=AgentVersionResponse)
+async def rollback_agent(
+    agent_id: uuid.UUID,
+    request: AgentRollbackRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Rollback an agent to a specific version."""
+    agent = await get_owned_agent(
+        agent_id,
+        db,
+        current_user,
+        forbidden_detail="Not authorized to rollback this agent",
+    )
+
+    # Find the version to rollback to
+    query = select(AgentVersion).where(
+        AgentVersion.agent_id == agent_id,
+        AgentVersion.version == request.version,
+    )
+    result = await db.execute(query)
+    target_version = result.scalar_one_or_none()
+
+    if not target_version:
+        raise HTTPException(
+            status_code=404, detail=f"Version {request.version} not found for this agent"
+        )
+
+    # Mark current version as rolled back
+    current_query = select(AgentVersion).where(
+        AgentVersion.agent_id == agent_id,
+        AgentVersion.status == "current",
+    )
+    current_result = await db.execute(current_query)
+    current_version = current_result.scalar_one_or_none()
+    if current_version:
+        current_version.status = "archived"
+        current_version.rolled_back_at = datetime.now(timezone.utc)
+
+    # Mark target version as current
+    target_version.status = "current"
+    target_version.rolled_back_at = None
+
+    # Restore the agent config
+    agent.config = target_version.config_snapshot
+    agent.updated_at = datetime.now(timezone.utc)
+
+    await db.commit()
+    await db.refresh(target_version)
+
+    logger.info(f"Rolled back agent {agent_id} to version {request.version}")
+    return target_version

--- a/src/api/routes/runs.py
+++ b/src/api/routes/runs.py
@@ -252,7 +252,9 @@ async def list_run_traces(
     )
 
 
-@router.post("/{run_id}/traces", response_model=RunTraceHistoryResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/{run_id}/traces", response_model=RunTraceHistoryResponse, status_code=status.HTTP_201_CREATED
+)
 async def add_run_traces(
     run_id: uuid.UUID,
     traces: list[RunTraceCreate],
@@ -263,18 +265,18 @@ async def add_run_traces(
 ):
     """
     Add traces to an existing run.
-    
+
     This endpoint allows adding execution traces to a run after it has been created.
     Traces are used to track the step-by-step execution of an agent.
     """
     run = await _get_user_run(run_id, current_user, db)
-    
+
     # Get the current max sequence to continue from
     max_seq_result = await db.execute(
         select(func.max(AgentRunTrace.sequence)).where(AgentRunTrace.run_id == run.id)
     )
     current_max_seq = max_seq_result.scalar() or -1
-    
+
     # Add new traces
     new_traces = []
     for idx, trace in enumerate(traces):
@@ -288,19 +290,19 @@ async def add_run_traces(
         )
         db.add(new_trace)
         new_traces.append(new_trace)
-    
+
     await db.commit()
-    
+
     # Refresh the new traces
     for trace in new_traces:
         await db.refresh(trace)
-    
+
     # Fetch all traces for the run (respecting limit)
     trace_filters = [AgentRunTrace.run_id == run.id]
-    
+
     total_stmt = select(func.count()).select_from(AgentRunTrace).where(*trace_filters)
     total = (await db.execute(total_stmt)).scalar_one()
-    
+
     traces_query = (
         select(AgentRunTrace)
         .where(*trace_filters)
@@ -309,7 +311,7 @@ async def add_run_traces(
         .limit(limit)
     )
     all_traces = (await db.execute(traces_query)).scalars().all()
-    
+
     return RunTraceHistoryResponse(
         run_id=run.id,
         items=[_serialize_trace(trace) for trace in all_traces],

--- a/src/runtime/adapters/openai.py
+++ b/src/runtime/adapters/openai.py
@@ -205,42 +205,42 @@ class OpenAIAdapter(AgentRuntime):
 
     def _extract_usage(self, response: Any) -> RuntimeUsage | None:
         """Extract usage statistics from the API response."""
-        usage = getattr(response, 'usage', None)
+        usage = getattr(response, "usage", None)
         if not usage:
             return None
-        
-        prompt_tokens = getattr(usage, 'prompt_tokens', 0) or 0
-        completion_tokens = getattr(usage, 'completion_tokens', 0) or 0
-        total_tokens = getattr(usage, 'total_tokens', 0) or 0
-        
+
+        prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+        completion_tokens = getattr(usage, "completion_tokens", 0) or 0
+        total_tokens = getattr(usage, "total_tokens", 0) or 0
+
         # Calculate approximate cost (can be customized per model)
         cost = self._calculate_cost(prompt_tokens, completion_tokens, self.config.model)
-        
+
         return {
-            'prompt_tokens': prompt_tokens,
-            'completion_tokens': completion_tokens,
-            'total_tokens': total_tokens,
-            'model': self.config.model,
-            'cost_usd': cost,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+            "model": self.config.model,
+            "cost_usd": cost,
         }
-    
+
     def _calculate_cost(self, prompt_tokens: int, completion_tokens: int, model: str) -> float:
         """Calculate approximate cost in USD based on model pricing."""
         # Pricing per 1M tokens (approximate, as of 2024)
         pricing = {
-            'gpt-4o': {'prompt': 2.50, 'completion': 10.00},
-            'gpt-4-turbo': {'prompt': 10.00, 'completion': 30.00},
-            'gpt-4': {'prompt': 30.00, 'completion': 60.00},
-            'gpt-3.5-turbo': {'prompt': 0.50, 'completion': 1.50},
-            'o1': {'prompt': 15.00, 'completion': 60.00},
-            'o1-preview': {'prompt': 15.00, 'completion': 60.00},
-            'o1-mini': {'prompt': 3.00, 'completion': 12.00},
+            "gpt-4o": {"prompt": 2.50, "completion": 10.00},
+            "gpt-4-turbo": {"prompt": 10.00, "completion": 30.00},
+            "gpt-4": {"prompt": 30.00, "completion": 60.00},
+            "gpt-3.5-turbo": {"prompt": 0.50, "completion": 1.50},
+            "o1": {"prompt": 15.00, "completion": 60.00},
+            "o1-preview": {"prompt": 15.00, "completion": 60.00},
+            "o1-mini": {"prompt": 3.00, "completion": 12.00},
         }
-        
-        model_pricing = pricing.get(model.lower(), {'prompt': 5.0, 'completion': 15.0})
-        prompt_cost = (prompt_tokens / 1_000_000) * model_pricing['prompt']
-        completion_cost = (completion_tokens / 1_000_000) * model_pricing['completion']
-        
+
+        model_pricing = pricing.get(model.lower(), {"prompt": 5.0, "completion": 15.0})
+        prompt_cost = (prompt_tokens / 1_000_000) * model_pricing["prompt"]
+        completion_cost = (completion_tokens / 1_000_000) * model_pricing["completion"]
+
         return round(prompt_cost + completion_cost, 6)
 
     async def _create_completion(

--- a/src/runtime/base.py
+++ b/src/runtime/base.py
@@ -39,6 +39,7 @@ class RuntimeMessage(TypedDict, total=False):
 
 class RuntimeUsage(TypedDict, total=False):
     """Usage statistics from model execution."""
+
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int

--- a/tests/api/test_agents.py
+++ b/tests/api/test_agents.py
@@ -170,7 +170,9 @@ class TestCreateAgent:
         assert response.status_code == 422
 
     @pytest.mark.asyncio
-    async def test_create_agent_duplicate_name_allowed(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_create_agent_duplicate_name_allowed(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Test that creating agents with duplicate names is allowed."""
         # Create first agent
         response = await client.post(

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -282,12 +282,14 @@ class TestAuthEndpoints:
         assert response.status_code == 200
 
     @pytest.mark.asyncio
-    async def test_refresh_token_sliding_expiry(self, client_no_auth: AsyncClient, db_session: AsyncSession):
+    async def test_refresh_token_sliding_expiry(
+        self, client_no_auth: AsyncClient, db_session: AsyncSession
+    ):
         """Test that refresh token uses sliding expiry."""
         from src.api.auth.password import hash_password
-        from datetime import datetime, timedelta, timezone
-        from src.api.auth.jwt import create_refresh_token, get_refresh_token_iat, verify_refresh_token
-        from src.api.services.user_service import UserService
+        from src.api.auth.jwt import (
+            get_refresh_token_iat,
+        )
 
         # Create a user
         user = User(
@@ -311,11 +313,11 @@ class TestAuthEndpoints:
         assert response.status_code == 200
         data = response.json()
         refresh_token = data["refresh_token"]
-        
+
         # Get original iat
         original_iat = get_refresh_token_iat(refresh_token)
         assert original_iat is not None
-        
+
         # Use the refresh token
         response = await client_no_auth.post(
             "/v1/auth/refresh",
@@ -323,19 +325,25 @@ class TestAuthEndpoints:
         )
         assert response.status_code == 200
         data = response.json()
-        
+
         new_refresh_token = data["refresh_token"]
         new_iat = get_refresh_token_iat(new_refresh_token)
-        
+
         # The new token should keep the original iat (for sliding window calculation)
         assert new_iat == original_iat
 
     @pytest.mark.asyncio
-    async def test_refresh_token_sliding_expiry_max_days(self, client_no_auth: AsyncClient, db_session: AsyncSession):
+    async def test_refresh_token_sliding_expiry_max_days(
+        self, client_no_auth: AsyncClient, db_session: AsyncSession
+    ):
         """Test that sliding expiry is capped at max days."""
         from src.api.auth.password import hash_password
         from datetime import datetime, timedelta, timezone
-        from src.api.auth.jwt import create_refresh_token, get_refresh_token_iat, verify_refresh_token, REFRESH_TOKEN_MAX_SLIDING_DAYS
+        from src.api.auth.jwt import (
+            create_refresh_token,
+            get_refresh_token_iat,
+            verify_refresh_token,
+        )
 
         # Create a user
         user = User(
@@ -358,11 +366,11 @@ class TestAuthEndpoints:
         )
         assert response.status_code == 200
         data = response.json()
-        
+
         # Simulate a refresh token that was issued 25 days ago (almost at max)
         old_iat = datetime.now(timezone.utc) - timedelta(days=25)
         old_token, _ = create_refresh_token(user.id, original_iat=old_iat)
-        
+
         # Refresh with the old token
         response = await client_no_auth.post(
             "/v1/auth/refresh",
@@ -370,14 +378,14 @@ class TestAuthEndpoints:
         )
         assert response.status_code == 200
         data = response.json()
-        
+
         new_refresh_token = data["refresh_token"]
         new_iat = get_refresh_token_iat(new_refresh_token)
-        
+
         # The iat should still be the original (25 days ago)
         assert new_iat is not None
         age = (datetime.now(timezone.utc) - new_iat).days
         assert age >= 25  # Original iat preserved
-        
+
         # Verify the new token is still valid (not more than 30 days from original iat)
         assert verify_refresh_token(new_refresh_token) is not None

--- a/tests/api/test_deployments.py
+++ b/tests/api/test_deployments.py
@@ -637,7 +637,6 @@ class TestRollbackDeployment:
         assert response.status_code == 403
 
 
-
 class TestDeploymentVersions:
     """Tests for GET /deployments/{deployment_id}/versions endpoint."""
 

--- a/tests/api/test_prometheus_metrics.py
+++ b/tests/api/test_prometheus_metrics.py
@@ -94,8 +94,10 @@ async def test_prometheus_metrics_endpoint_returns_prometheus_format():
     assert response.status_code == 200
     content = response.text
     # Prometheus format typically has lines like "metric_name{labels} value"
-    assert "# HELP" in content or "# TYPE" in content or any(
-        line for line in content.split("\n") if line and not line.startswith("#")
+    assert (
+        "# HELP" in content
+        or "# TYPE" in content
+        or any(line for line in content.split("\n") if line and not line.startswith("#"))
     )
 
 

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -247,7 +247,7 @@ async def test_add_traces_to_existing_run(client, test_agent):
     )
     assert add_traces_response.status_code == 201
     traces_payload = add_traces_response.json()
-    
+
     assert traces_payload["run_id"] == run_id
     assert traces_payload["total"] == 3
     assert len(traces_payload["items"]) == 3
@@ -293,7 +293,7 @@ async def test_add_traces_continues_sequence(client, test_agent):
         ],
     )
     assert add_response.status_code == 201
-    
+
     # Verify sequences are correct
     traces = add_response.json()["items"]
     assert traces[0]["sequence"] == 0  # init

--- a/tests/api/test_webhooks.py
+++ b/tests/api/test_webhooks.py
@@ -495,7 +495,9 @@ async def test_webhook_delivery_history_empty(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_webhook_test_delivery_failure_returns_502(client: AsyncClient, test_user, monkeypatch):
+async def test_webhook_test_delivery_failure_returns_502(
+    client: AsyncClient, test_user, monkeypatch
+):
     import src.api.services.webhook_service
 
     async def mock_deliver_failure(*args, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from sqlalchemy.pool import StaticPool
 
 # Set environment before any imports
 os.environ.setdefault("DATABASE_REQUIRED_ON_STARTUP", "false")
-os.environ.setdefault("JWT_SECRET", "test-secret-key")
+os.environ.setdefault("JWT_SECRET", "test-secret-key-that-is-at-least-32-chars")
 
 # Use an isolated SQLite database for tests by default.
 # Do not inherit DATABASE_URL from the shell, or tests can accidentally hit a

--- a/tests/test_cli_agents_contract.py
+++ b/tests/test_cli_agents_contract.py
@@ -344,6 +344,7 @@ def test_agents_delete_requires_confirmation_without_force(monkeypatch) -> None:
     assert result.exit_code == 0
     assert "Are you sure you want to delete agent" in result.output
 
+
 def test_agents_list_with_table_format(monkeypatch) -> None:
     """Test that table format outputs properly formatted table"""
     captured: dict[str, Any] = {}
@@ -415,4 +416,3 @@ def test_agents_list_with_simple_format(monkeypatch) -> None:
     assert result.exit_code == 0
     assert " | " in result.output
     assert agent_id in result.output
-

--- a/tests/test_cli_clawhub_contract.py
+++ b/tests/test_cli_clawhub_contract.py
@@ -101,9 +101,7 @@ def test_clawhub_install_hits_canonical_route(monkeypatch) -> None:
     )
 
     runner = CliRunner()
-    result = runner.invoke(
-        cli, ["clawhub", "install", "-a", agent_id, "-s", skill_id]
-    )
+    result = runner.invoke(cli, ["clawhub", "install", "-a", agent_id, "-s", skill_id])
 
     assert result.exit_code == 0
     assert captured["path"] == "/v1/clawhub/install"
@@ -111,7 +109,9 @@ def test_clawhub_install_hits_canonical_route(monkeypatch) -> None:
         "agent_id": agent_id,
         "skill_id": skill_id,
     }
-    assert f"Successfully initiated installation of '{skill_id}' for agent {agent_id}" in result.output
+    assert (
+        f"Successfully initiated installation of '{skill_id}' for agent {agent_id}" in result.output
+    )
 
 
 def test_clawhub_install_agent_not_found(monkeypatch) -> None:
@@ -127,9 +127,7 @@ def test_clawhub_install_agent_not_found(monkeypatch) -> None:
     )
 
     runner = CliRunner()
-    result = runner.invoke(
-        cli, ["clawhub", "install", "-a", agent_id, "-s", skill_id]
-    )
+    result = runner.invoke(cli, ["clawhub", "install", "-a", agent_id, "-s", skill_id])
 
     assert result.exit_code == 0
     assert f"Error: Agent {agent_id} not found" in result.output
@@ -151,9 +149,7 @@ def test_clawhub_uninstall_hits_canonical_route(monkeypatch) -> None:
     )
 
     runner = CliRunner()
-    result = runner.invoke(
-        cli, ["clawhub", "uninstall", "-a", agent_id, "-s", skill_id]
-    )
+    result = runner.invoke(cli, ["clawhub", "uninstall", "-a", agent_id, "-s", skill_id])
 
     assert result.exit_code == 0
     assert captured["path"] == "/v1/clawhub/uninstall"
@@ -177,9 +173,7 @@ def test_clawhub_uninstall_agent_not_found(monkeypatch) -> None:
     )
 
     runner = CliRunner()
-    result = runner.invoke(
-        cli, ["clawhub", "uninstall", "-a", agent_id, "-s", skill_id]
-    )
+    result = runner.invoke(cli, ["clawhub", "uninstall", "-a", agent_id, "-s", skill_id])
 
     assert result.exit_code == 0
     assert f"Error: Agent {agent_id} not found" in result.output

--- a/tests/test_sdk_agent_runtime_contract.py
+++ b/tests/test_sdk_agent_runtime_contract.py
@@ -403,9 +403,7 @@ async def test_create_agent_client_registers_new_agent():
         mock_instance.headers = {}
 
         with patch("mutx.agent_runtime.MutxAgentClient._get_client", return_value=mock_instance):
-            client = await create_agent_client(
-                mutx_url="https://api.test", agent_name="new-agent"
-            )
+            client = await create_agent_client(mutx_url="https://api.test", agent_name="new-agent")
 
     assert client.agent_id == agent_id
     assert client.api_key == api_key


### PR DESCRIPTION
Implements issue #988

Adds agent versioning and rollback support with the following endpoints:
- GET /agents/{id}/versions - List all versions
- GET /agents/{id}/versions/{version_id} - Get specific version  
- POST /agents/{id}/versions - Create a new version snapshot
- POST /agents/{id}/rollback - Rollback to a specific version

All 44 agent tests pass.
