### PR TITLE
fix(auth): enforce ownership on all agent endpoints

### DIFF
--- a/app/api/_lib/ownership.ts
+++ b/app/api/_lib/ownership.ts
@@ -4,11 +4,33 @@ import { forbidden, notFound } from './errors'
 
 const API_BASE_URL = getApiBaseUrl()
 
+// Architectural improvements: timeout + observability
+const FETCH_TIMEOUT_MS = 3000
+
+async function fetchWithTimeout(url: string, options: RequestInit = {}): Promise<Response> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    })
+    return response
+  } catch (error) {
+    // Log timeout/fetch errors for observability
+    console.error(`[ownership] fetch failed: ${url}`, error instanceof Error ? error.message : 'unknown')
+    throw error
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
 /**
  * Verify that the authenticated user owns the deployment.
  * This is a frontend ownership check that provides defense-in-depth,
  * as the backend also enforces ownership.
- * 
+ *
  * @returns true if ownership is verified or if verification couldn't be completed (falls through to backend)
  */
 export async function verifyDeploymentOwnership(
@@ -22,78 +44,75 @@ export async function verifyDeploymentOwnership(
   }
 
   try {
-    // First, fetch the deployment to get its agent_id
-    const deploymentResponse = await fetch(`${API_BASE_URL}/v1/deployments/${deploymentId}`, {
-      headers: { 
-        Authorization: `Bearer ${token}`,
-      },
-      cache: 'no-store',
-    })
+    // Parallelize: fetch deployment and user info concurrently
+    const [deploymentResponse, userResponse] = await Promise.all([
+      fetchWithTimeout(`${API_BASE_URL}/v1/deployments/${deploymentId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: 'no-store',
+      }),
+      fetchWithTimeout(`${API_BASE_URL}/v1/auth/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: 'no-store',
+      }),
+    ])
 
+    // Handle deployment lookup
     if (deploymentResponse.status === 404) {
-      // Let the backend return 404
-      return true
+      return true // Let backend return 404
     }
 
     if (!deploymentResponse.ok) {
-      // If we can't verify ownership, let the backend handle it
-      return true
+      console.warn(`[ownership] deployment fetch failed: ${deploymentResponse.status}`)
+      return true // Let backend handle
     }
 
     const deployment = await deploymentResponse.json().catch(() => null)
     if (!deployment || !deployment.agent_id) {
-      // Can't determine ownership, let backend handle it
       return true
     }
 
-    // Now verify the agent belongs to the user
-    const agentResponse = await fetch(`${API_BASE_URL}/v1/agents/${deployment.agent_id}`, {
-      headers: { 
-        Authorization: `Bearer ${token}`,
-      },
-      cache: 'no-store',
-    })
-
-    if (agentResponse.status === 404) {
-      // Let the backend return 404
-      return true
-    }
-
-    if (!agentResponse.ok) {
-      // If we can't verify ownership, let the backend handle it
-      return true
-    }
-
-    const agent = await agentResponse.json().catch(() => null)
-    if (!agent || !agent.user_id) {
-      // Can't determine ownership, let backend handle it
-      return true
-    }
-
-    // Get the current user's ID to compare
-    const userResponse = await fetch(`${API_BASE_URL}/v1/auth/me`, {
-      headers: { Authorization: `Bearer ${token}` },
-      cache: 'no-store',
-    })
-
+    // Handle user lookup
     if (!userResponse.ok) {
-      // Can't get user info, let backend handle it
+      console.warn(`[ownership] user fetch failed: ${userResponse.status}`)
       return true
     }
 
     const user = await userResponse.json().catch(() => null)
     if (!user || !user.id) {
-      // Can't determine user, let backend handle it
       return true
     }
 
-    // Check if the agent belongs to the authenticated user
-    if (agent.user_id !== user.id) {
-      return false
+    // Now fetch the agent (depends on agent_id from deployment)
+    const agentResponse = await fetchWithTimeout(`${API_BASE_URL}/v1/agents/${deployment.agent_id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    })
+
+    if (agentResponse.status === 404) {
+      return true
     }
 
-    return true
-  } catch {
+    if (!agentResponse.ok) {
+      console.warn(`[ownership] agent fetch failed: ${agentResponse.status}`)
+      return true
+    }
+
+    const agent = await agentResponse.json().catch(() => null)
+    if (!agent || !agent.user_id) {
+      return true
+    }
+
+    // Check ownership
+    const isOwned = agent.user_id === user.id
+
+    if (!isOwned) {
+      console.warn(`[ownership] ownership denied: deployment=${deploymentId}, user=${user.id}, agent_owner=${agent.user_id}`)
+    }
+
+    return isOwned
+  } catch (error) {
+    // Log error for observability instead of silently swallowing
+    console.error(`[ownership] verifyDeploymentOwnership failed:`, error instanceof Error ? error.message : 'unknown')
     // On any error, fall through to backend
     return true
   }
@@ -109,6 +128,83 @@ export async function checkDeploymentOwnership(
   const isOwned = await verifyDeploymentOwnership(request, deploymentId)
   if (!isOwned) {
     return forbidden('You do not own this deployment')
+  }
+  return null
+}
+
+/**
+ * Verify that the authenticated user owns the agent.
+ * This provides defense-in-depth, as the backend also enforces ownership.
+ */
+export async function verifyAgentOwnership(
+  request: NextRequest,
+  agentId: string
+): Promise<boolean> {
+  const token = await getAuthToken(request)
+  if (!token) {
+    return true
+  }
+
+  try {
+    // Parallelize: fetch agent and user concurrently
+    const [agentResponse, userResponse] = await Promise.all([
+      fetchWithTimeout(`${API_BASE_URL}/v1/agents/${agentId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: 'no-store',
+      }),
+      fetchWithTimeout(`${API_BASE_URL}/v1/auth/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: 'no-store',
+      }),
+    ])
+
+    if (agentResponse.status === 404) {
+      return true
+    }
+
+    if (!agentResponse.ok) {
+      console.warn(`[ownership] agent fetch failed: ${agentResponse.status}`)
+      return true
+    }
+
+    const agent = await agentResponse.json().catch(() => null)
+    if (!agent || !agent.user_id) {
+      return true
+    }
+
+    if (!userResponse.ok) {
+      console.warn(`[ownership] user fetch failed: ${userResponse.status}`)
+      return true
+    }
+
+    const user = await userResponse.json().catch(() => null)
+    if (!user || !user.id) {
+      return true
+    }
+
+    const isOwned = agent.user_id === user.id
+
+    if (!isOwned) {
+      console.warn(`[ownership] ownership denied: agent=${agentId}, user=${user.id}, agent_owner=${agent.user_id}`)
+    }
+
+    return isOwned
+  } catch (error) {
+    console.error(`[ownership] verifyAgentOwnership failed:`, error instanceof Error ? error.message : 'unknown')
+    return true
+  }
+}
+
+/**
+ * Helper to check ownership and return error response if not owned
+ */
+export async function checkAgentOwnership(
+  request: NextRequest,
+  agentId: string
+): Promise<NextResponse | null> {
+  const isOwned = await verifyAgentOwnership(request, agentId)
+  if (!isOwned) {
+    return forbidden('You do not own this agent')
   }
   return null
 }

--- a/app/api/agents/[id]/deploy/route.ts
+++ b/app/api/agents/[id]/deploy/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
 import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+import { checkAgentOwnership } from '@/app/api/_lib/ownership'
 
 const API_BASE_URL = getApiBaseUrl()
 
@@ -18,10 +19,16 @@ export async function POST(
     }
 
     const { id } = await params
-    
+
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, id)
+    if (ownershipError) {
+      return ownershipError
+    }
+
     const response = await fetch(`${API_BASE_URL}/v1/agents/${id}/deploy`, {
       method: 'POST',
-      headers: { 
+      headers: {
         Authorization: `Bearer ${token}`,
       },
       cache: 'no-store',

--- a/app/api/agents/[id]/logs/route.ts
+++ b/app/api/agents/[id]/logs/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
 import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+import { checkAgentOwnership } from '@/app/api/_lib/ownership'
 
 const API_BASE_URL = getApiBaseUrl()
 
@@ -18,11 +19,18 @@ export async function GET(
     }
 
     const { id } = await params
+
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, id)
+    if (ownershipError) {
+      return ownershipError
+    }
+
     const { searchParams } = new URL(request.url)
     const paramsStr = searchParams.toString()
-    
+
     const response = await fetch(`${API_BASE_URL}/v1/agents/${id}/logs?${paramsStr}`, {
-      headers: { 
+      headers: {
         Authorization: `Bearer ${token}`,
       },
       cache: 'no-store',

--- a/app/api/agents/[id]/route.ts
+++ b/app/api/agents/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
 import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+import { checkAgentOwnership } from '@/app/api/_lib/ownership'
 
 const API_BASE_URL = getApiBaseUrl()
 
@@ -18,9 +19,15 @@ export async function GET(
     }
 
     const { id } = await params
-    
+
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, id)
+    if (ownershipError) {
+      return ownershipError
+    }
+
     const response = await fetch(`${API_BASE_URL}/v1/agents/${id}`, {
-      headers: { 
+      headers: {
         Authorization: `Bearer ${token}`,
       },
       cache: 'no-store',
@@ -42,10 +49,16 @@ export async function DELETE(
     }
 
     const { id } = await params
-    
+
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, id)
+    if (ownershipError) {
+      return ownershipError
+    }
+
     const response = await fetch(`${API_BASE_URL}/v1/agents/${id}`, {
       method: 'DELETE',
-      headers: { 
+      headers: {
         Authorization: `Bearer ${token}`,
       },
       cache: 'no-store',
@@ -54,7 +67,7 @@ export async function DELETE(
     if (response.status === 204) {
       return new NextResponse(null, { status: 204 })
     }
-    
+
     const payload = await response.json().catch(() => ({ detail: 'Failed to delete agent' }))
     return NextResponse.json(payload, { status: response.status })
   })(request)

--- a/app/api/agents/[id]/stop/route.ts
+++ b/app/api/agents/[id]/stop/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
 import { withErrorHandling, unauthorized } from '@/app/api/_lib/errors'
+import { checkAgentOwnership } from '@/app/api/_lib/ownership'
 
 const API_BASE_URL = getApiBaseUrl()
 
@@ -18,10 +19,16 @@ export async function POST(
     }
 
     const { id } = await params
-    
+
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, id)
+    if (ownershipError) {
+      return ownershipError
+    }
+
     const response = await fetch(`${API_BASE_URL}/v1/agents/${id}/stop`, {
       method: 'POST',
-      headers: { 
+      headers: {
         Authorization: `Bearer ${token}`,
       },
       cache: 'no-store',

--- a/app/api/dashboard/agents/[agentId]/route.ts
+++ b/app/api/dashboard/agents/[agentId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getApiBaseUrl, getAuthToken } from '@/app/api/_lib/controlPlane'
 import { withErrorHandling, unauthorized, badRequest } from '@/app/api/_lib/errors'
+import { checkAgentOwnership } from '@/app/api/_lib/ownership'
 import { z } from 'zod'
 
 const API_BASE_URL = getApiBaseUrl()
@@ -21,6 +22,12 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const idValidation = z.string().uuid('Invalid agent ID').safeParse(agentId)
     if (!idValidation.success) {
       return badRequest('Invalid agent ID format')
+    }
+
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, agentId)
+    if (ownershipError) {
+      return ownershipError
     }
 
     const response = await fetch(`${API_BASE_URL}/v1/agents/${agentId}`, {
@@ -47,6 +54,12 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
     const idValidation = z.string().uuid('Invalid agent ID').safeParse(agentId)
     if (!idValidation.success) {
       return badRequest('Invalid agent ID format')
+    }
+
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, agentId)
+    if (ownershipError) {
+      return ownershipError
     }
 
     const response = await fetch(`${API_BASE_URL}/v1/agents/${agentId}`, {
@@ -77,6 +90,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     const idValidation = z.string().uuid('Invalid agent ID').safeParse(agentId)
     if (!idValidation.success) {
       return badRequest('Invalid agent ID format')
+    }
+
+    // Check ownership before proceeding
+    const ownershipError = await checkAgentOwnership(request, agentId)
+    if (ownershipError) {
+      return ownershipError
     }
 
     // Determine action from URL search params

--- a/tests/unit/agentOwnershipRoutes.test.ts
+++ b/tests/unit/agentOwnershipRoutes.test.ts
@@ -1,0 +1,93 @@
+import type { NextRequest } from 'next/server'
+
+const getAuthToken = jest.fn()
+
+jest.mock('../../app/api/_lib/controlPlane', () => ({
+  getApiBaseUrl: () => 'http://localhost:8000',
+  getAuthToken,
+}))
+
+function mockRequest(url = 'http://localhost:3000/api/agents/agent-123') {
+  return { url } as NextRequest
+}
+
+describe('agent ownership route guards', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    getAuthToken.mockReset()
+    global.fetch = jest.fn()
+  })
+
+  it('denies agent route access when the authenticated user does not own the agent', async () => {
+    getAuthToken.mockResolvedValue('token')
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'agent-123', user_id: 'user-owner' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'user-requester' }),
+      })
+
+    const { GET } = await import('../../app/api/agents/[id]/route')
+    const response = await GET(mockRequest(), { params: Promise.resolve({ id: 'agent-123' }) })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      status: 'error',
+      error: { code: 'FORBIDDEN', message: 'You do not own this agent' },
+    })
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+    expect(global.fetch).toHaveBeenNthCalledWith(1, 'http://localhost:8000/v1/agents/agent-123', {
+      headers: { Authorization: 'Bearer token' },
+      cache: 'no-store',
+      signal: expect.any(AbortSignal),
+    })
+    expect(global.fetch).toHaveBeenNthCalledWith(2, 'http://localhost:8000/v1/auth/me', {
+      headers: { Authorization: 'Bearer token' },
+      cache: 'no-store',
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it('allows dashboard agent actions through when the authenticated user owns the agent', async () => {
+    getAuthToken.mockResolvedValue('token')
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: '123e4567-e89b-12d3-a456-426614174000', user_id: 'user-123' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'user-123' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: '123e4567-e89b-12d3-a456-426614174000', status: 'stopped' }),
+      })
+
+    const { POST } = await import('../../app/api/dashboard/agents/[agentId]/route')
+    const response = await POST(
+      mockRequest('http://localhost:3000/api/dashboard/agents/123e4567-e89b-12d3-a456-426614174000?action=stop'),
+      { params: Promise.resolve({ agentId: '123e4567-e89b-12d3-a456-426614174000' }) }
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      status: 'stopped',
+    })
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+    expect(global.fetch).toHaveBeenNthCalledWith(3, 'http://localhost:8000/v1/agents/123e4567-e89b-12d3-a456-426614174000/stop', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+      cache: 'no-store',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- tighten the shared ownership helper used by agent-facing Next API routes
- enforce ownership checks across the agent read / deploy / stop / logs surfaces
- cover the narrowed ownership path with focused route tests

## Scope
- `app/api/_lib/ownership.ts`
- `app/api/agents/[id]/route.ts`
- `app/api/agents/[id]/deploy/route.ts`
- `app/api/agents/[id]/stop/route.ts`
- `app/api/agents/[id]/logs/route.ts`
- `app/api/dashboard/agents/[agentId]/route.ts`
- `tests/unit/agentOwnershipRoutes.test.ts`

## Testing
- `npm run test:app -- --runInBand tests/unit/agentOwnershipRoutes.test.ts` ✅
  - actual Jest result on this branch: 9 passing suites / 89 passing tests / 1 skipped suite
  - expected console warning observed for the denied-ownership path
