### PR TITLE
fix(governance): restrict credential broker endpoints to internal users

### DIFF
--- a/tests/api/test_governance_credentials_authz.py
+++ b/tests/api/test_governance_credentials_authz.py
@@ -1,0 +1,21 @@
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_list_credential_backends_internal_user(client: AsyncClient):
+    response = await client.get("/v1/governance/credentials/backends")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+@pytest.mark.asyncio
+async def test_list_credential_backends_non_internal_forbidden(other_user_client: AsyncClient):
+    response = await other_user_client.get("/v1/governance/credentials/backends")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_credential_non_internal_forbidden(other_user_client: AsyncClient):
+    response = await other_user_client.get("/v1/governance/credentials/get/vault:/secret/test")
+    assert response.status_code == 403


### PR DESCRIPTION
### Motivation
- Prevent unauthorized access to the global credential broker which allowed any authenticated user to list/register/unregister backends and retrieve secret values, causing an IDOR/cross-tenant secret disclosure risk.

### Description
- Added `_assert_internal_user` to `src/api/routes/governance_credentials.py` which verifies `current_user.is_email_verified` and that the user email domain is in `get_settings().internal_user_email_domains`.
- Enforced the internal-user guard on all governance credential broker endpoints (`/backends`, register/unregister, `/backends/{name}/health`, `/health`, and `/get/{full_path}`) to prevent non-internal users from accessing or modifying broker configuration or secrets.
- Added tests in `tests/api/test_governance_credentials_authz.py` asserting that internal users can list backends and non-internal users receive `403` for list and get operations.

### Testing
- Ran `python -m compileall src/api/routes/governance_credentials.py tests/api/test_governance_credentials_authz.py`, which succeeded.
- Attempted to run targeted tests with `pytest -q tests/api/test_governance_credentials_authz.py tests/api/test_leads.py::test_list_leads_non_internal_forbidden`, but test collection failed in this environment due to missing test dependency (`ModuleNotFoundError: No module named 'pytest_asyncio'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d100ee10832a9dc6cb64c7b94c69)