### PR TITLE
fix: disable automatic Faramesh installer execution during setup

### DIFF
--- a/cli/commands/setup.py
+++ b/cli/commands/setup.py
@@ -171,9 +171,10 @@ def _install_faramesh_governance() -> None:
     click.echo("")
     click.echo("… Installing Faramesh governance engine")
 
-    installed, bin_path = ensure_faramesh_installed(install_if_missing=True, non_interactive=True)
+    installed, bin_path = ensure_faramesh_installed(install_if_missing=False, non_interactive=True)
     if not installed:
-        click.echo("  ⚠ Faramesh installation skipped (will be available later)")
+        click.echo("  ⚠ Faramesh is not installed; skipping automatic install for security")
+        click.echo("    Install manually via trusted channel, then run: mutx governance start")
         return
 
     click.echo(f"  ✓ Faramesh installed: {bin_path}")

--- a/tests/test_cli_setup_and_doctor.py
+++ b/tests/test_cli_setup_and_doctor.py
@@ -50,6 +50,24 @@ def wizard_result_payload(*, reused_existing_assistant: bool = False) -> SimpleN
     )
 
 
+
+
+def test_setup_faramesh_does_not_auto_install(monkeypatch) -> None:
+    from cli.commands import setup as setup_module
+
+    captured: dict[str, object] = {}
+
+    def fake_ensure(*, install_if_missing: bool, non_interactive: bool):
+        captured["install_if_missing"] = install_if_missing
+        captured["non_interactive"] = non_interactive
+        return False, None
+
+    monkeypatch.setattr(setup_module, "ensure_faramesh_installed", fake_ensure)
+
+    setup_module._install_faramesh_governance()
+
+    assert captured == {"install_if_missing": False, "non_interactive": True}
+
 def test_setup_hosted_deploys_personal_assistant(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, object] = {}
     launched = {"value": False}


### PR DESCRIPTION
### Motivation
- The setup flow previously auto-downloaded and executed a remote Faramesh `install.sh` without integrity checks, creating an RCE risk if the script or transport was compromised.
- The change prevents automatic execution of unverified remote installer code during `mutx setup` while preserving the ability to start Faramesh when it is already installed.

### Description
- Changed `_install_faramesh_governance()` to call `ensure_faramesh_installed(install_if_missing=False, non_interactive=True)` so setup will not fetch/execute the remote installer automatically.
- When Faramesh is missing the code now prints a clear manual-install guidance instead of invoking a network installer script.
- Added `test_setup_faramesh_does_not_auto_install` to `tests/test_cli_setup_and_doctor.py` to assert `_install_faramesh_governance()` requests no automatic install (`install_if_missing=False`).

### Testing
- Compiled modified modules with `python -m compileall cli/commands/setup.py tests/test_cli_setup_and_doctor.py` and compilation succeeded.
- Ran the targeted `pytest` invocation for the new regression and a related setup test but the environment lacks the `pytest_asyncio` dependency, causing `ModuleNotFoundError: No module named 'pytest_asyncio'` so full test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3ba157ab8832a8259d5ddd2cad0b7)