### PR TITLE
Harden installer by removing unverified CLI overlay fallback

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -5,7 +5,6 @@ TAP="${MUTX_TAP:-mutx-dev/homebrew-tap}"
 FORMULA="${MUTX_FORMULA:-mutx}"
 OPEN_TUI="${MUTX_OPEN_TUI:-1}"
 MUTX_HOME_DIR="${MUTX_HOME_DIR:-$HOME/.mutx}"
-MUTX_CLI_SOURCE_REF="${MUTX_CLI_SOURCE_REF:-https://github.com/mutx-dev/mutx-dev/archive/refs/heads/main.tar.gz}"
 MUTX_NO_ANIMATION="${MUTX_NO_ANIMATION:-0}"
 NO_ONBOARD="${MUTX_NO_ONBOARD:-0}"
 NO_PROMPT="${MUTX_NO_PROMPT:-0}"
@@ -157,7 +156,6 @@ Environment:
   MUTX_NO_ANIMATION=1      Disable animated installer output
   MUTX_NO_ONBOARD=1        Skip the setup wizard handoff
   MUTX_NO_PROMPT=1         Disable prompts and finish with next-step commands
-  MUTX_CLI_SOURCE_REF=...  Override the fallback source runtime reference
 EOF
 }
 
@@ -248,7 +246,7 @@ show_install_plan() {
   ui_section "Install plan"
   ui_kv "OS" "${OS_NAME}"
   ui_kv "Package lane" "homebrew"
-  ui_kv "Runtime fallback" "source overlay if packaged CLI is stale"
+  ui_kv "Runtime fallback" "none (requires packaged CLI commands)"
   ui_kv "Onboarding" "${onboarding_mode}"
   ui_kv "Prompt mode" "${prompt_mode}"
   ui_kv "TUI" "${tui_mode}"
@@ -651,52 +649,8 @@ show_surface_status() {
   return 1
 }
 
-resolve_python_bin() {
-  if command -v python3 >/dev/null 2>&1; then
-    command -v python3
-    return 0
-  fi
-
-  local brew_python_prefix=""
-  brew_python_prefix="$(brew --prefix python@3.12 2>>"${INSTALL_LOG}" || true)"
-  if [[ -n "${brew_python_prefix}" ]]; then
-    if [[ -x "${brew_python_prefix}/bin/python3" ]]; then
-      printf '%s\n' "${brew_python_prefix}/bin/python3"
-      return 0
-    fi
-    if [[ -x "${brew_python_prefix}/bin/python3.12" ]]; then
-      printf '%s\n' "${brew_python_prefix}/bin/python3.12"
-      return 0
-    fi
-  fi
-
-  return 1
-}
-
 upgrade_or_keep_formula() {
   brew upgrade "${FORMULA}" || true
-}
-
-install_source_overlay() {
-  local python_bin=""
-  python_bin="$(resolve_python_bin)" || return 1
-
-  local overlay_root="${MUTX_HOME_DIR}/runtime/source-cli"
-  local final_venv="${overlay_root}/venv"
-  local brew_prefix=""
-
-  mkdir -p "${overlay_root}"
-  rm -rf "${final_venv}"
-
-  "${python_bin}" -m venv "${final_venv}"
-  "${final_venv}/bin/pip" install --disable-pip-version-check --quiet --upgrade pip setuptools wheel
-  "${final_venv}/bin/pip" install --disable-pip-version-check --quiet --upgrade "${MUTX_CLI_SOURCE_REF}"
-  "${final_venv}/bin/pip" install --disable-pip-version-check --quiet --upgrade "textual>=0.58.0,<2.0.0"
-
-  brew_prefix="$(brew --prefix)"
-  mkdir -p "${brew_prefix}/bin"
-  ln -sf "${final_venv}/bin/mutx" "${brew_prefix}/bin/mutx"
-  hash -r 2>/dev/null || true
 }
 
 ensure_assistant_first_surface() {
@@ -704,17 +658,7 @@ ensure_assistant_first_surface() {
     return 0
   fi
 
-  note "The packaged CLI is older than this installer. Pulling a fresh MUTX runtime."
-  run_stage "Recovering current CLI surface" install_source_overlay
-  SOURCE_OVERLAY_USED=1
-  resolve_mutx_bin
-
-  if show_surface_status "Rechecking onboarding surface"; then
-    note "mutx now resolves to ${MUTX_BIN}"
-    return 0
-  fi
-
-  die "The installed CLI is still missing required commands: ${CLI_MISSING_COMMANDS}"
+  die "The installed CLI is missing required commands: ${CLI_MISSING_COMMANDS}. Upgrade ${FORMULA} from ${TAP} and re-run this installer."
 }
 
 run_setup_handoff() {

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -19,75 +19,7 @@ def write_executable(path: Path, content: str) -> None:
     path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def build_fake_cli_package(package_dir: Path) -> Path:
-    package_dir.mkdir(parents=True, exist_ok=True)
-    (package_dir / "pyproject.toml").write_text(
-        inspect.cleandoc(
-            """
-            [build-system]
-            requires = ["setuptools>=61.0", "wheel"]
-            build-backend = "setuptools.build_meta"
-
-            [project]
-            name = "mutx"
-            version = "9.9.9"
-
-            [project.scripts]
-            mutx = "fakecli:main"
-            """
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    (package_dir / "fakecli.py").write_text(
-        inspect.cleandoc(
-            """
-            from __future__ import annotations
-
-            import sys
-
-
-            def main() -> None:
-                args = sys.argv[1:]
-                if not args or args == ["--help"]:
-                    print("Usage: mutx [OPTIONS] COMMAND [ARGS]...")
-                    print("")
-                    print("Commands:")
-                    print("  doctor")
-                    print("  setup")
-                    print("  status")
-                    print("  tui")
-                    return
-
-                if args in (
-                    ["setup", "--help"],
-                    ["setup", "hosted", "--help"],
-                    ["setup", "local", "--help"],
-                    ["doctor", "--help"],
-                    ["tui", "--help"],
-                ):
-                    return
-
-                if args[:2] == ["setup", "hosted"]:
-                    print("HOSTED SETUP", " ".join(args[2:]).strip())
-                    return
-
-                if args[:2] == ["setup", "local"]:
-                    print("LOCAL SETUP", " ".join(args[2:]).strip())
-                    return
-
-                if args and args[0] == "doctor":
-                    print("doctor ok")
-                    return
-            """
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    return package_dir
-
-
-def build_install_env(tmp_path: Path, *, source_ref: str | None = None) -> tuple[dict[str, str], Path]:
+def build_install_env(tmp_path: Path) -> tuple[dict[str, str], Path]:
     brew_prefix = tmp_path / "brew-prefix"
     brew_bin = brew_prefix / "bin"
     brew_bin.mkdir(parents=True, exist_ok=True)
@@ -133,9 +65,6 @@ def build_install_env(tmp_path: Path, *, source_ref: str | None = None) -> tuple
     env["HOMEBREW_NO_AUTO_UPDATE"] = "1"
     env["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
     env["PATH"] = f"{brew_bin}:{env['PATH']}"
-    if source_ref is not None:
-      env["MUTX_CLI_SOURCE_REF"] = source_ref
-
     return env, brew_prefix
 
 
@@ -143,10 +72,9 @@ def run_install_script(
     tmp_path: Path,
     *,
     mutx_script: str,
-    source_ref: str | None = None,
     args: list[str] | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
-    env, brew_prefix = build_install_env(tmp_path, source_ref=source_ref)
+    env, brew_prefix = build_install_env(tmp_path)
     write_executable(brew_prefix / "bin" / "mutx", mutx_script)
 
     result = subprocess.run(
@@ -164,11 +92,10 @@ def run_install_script_in_tty(
     tmp_path: Path,
     *,
     mutx_script: str,
-    source_ref: str,
     replies: list[tuple[str, str]],
     timeout_seconds: float = 45.0,
 ) -> tuple[int, str, Path]:
-    env, brew_prefix = build_install_env(tmp_path, source_ref=source_ref)
+    env, brew_prefix = build_install_env(tmp_path)
     env["MUTX_OPEN_TUI"] = "1"
     env["TERM"] = "xterm-256color"
     write_executable(brew_prefix / "bin" / "mutx", mutx_script)
@@ -282,26 +209,13 @@ exit 0
 """
 
 
-def test_install_script_bootstraps_current_cli_when_packaged_binary_is_stale(tmp_path: Path) -> None:
-    source_ref = str(build_fake_cli_package(tmp_path / "source-cli"))
-    result, brew_prefix = run_install_script(tmp_path, mutx_script=STALE_MUTX_SCRIPT, source_ref=source_ref)
+def test_install_script_fails_when_packaged_binary_is_stale(tmp_path: Path) -> None:
+    result, _ = run_install_script(tmp_path, mutx_script=STALE_MUTX_SCRIPT)
 
-    assert result.returncode == 0
-    assert "Recovering current CLI surface" in result.stdout
-    assert "Install complete" in result.stdout
-    assert "mutx setup hosted" in result.stdout
-    assert "mutx setup local" in result.stdout
-    assert "mutx-dev/homebrew-tap" not in result.stdout
-    assert "formula:" not in result.stdout
-    assert result.stderr == ""
-
-    setup_help = subprocess.run(
-        [str(brew_prefix / "bin" / "mutx"), "setup", "--help"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert setup_help.returncode == 0
+    assert result.returncode != 0
+    assert "Checking onboarding surface" in result.stdout
+    assert "Recovering current CLI surface" not in result.stdout
+    assert "missing required commands" in result.stderr
 
 
 def test_install_script_allows_assistant_first_cli_surface_without_recovery(tmp_path: Path) -> None:
@@ -339,31 +253,16 @@ def test_install_script_no_onboard_skips_wizard_and_prints_next_steps(tmp_path: 
     assert "mutx setup local" in result.stdout
 
 
-def test_install_script_tty_can_skip_hosted_and_launch_local_setup_after_recovery(tmp_path: Path) -> None:
-    source_ref = str(build_fake_cli_package(tmp_path / "source-cli"))
-    exit_code, transcript, brew_prefix = run_install_script_in_tty(
+def test_install_script_tty_fails_fast_when_packaged_binary_is_stale(tmp_path: Path) -> None:
+    exit_code, transcript, _ = run_install_script_in_tty(
         tmp_path,
         mutx_script=STALE_MUTX_SCRIPT,
-        source_ref=source_ref,
         replies=[
             ("Select a lane [1/2/3]", "2\n"),
         ],
     )
 
-    assert exit_code == 0
-    assert "Recovering current CLI surface" in transcript
-    assert "Setup Wizard" in transcript
-    assert "Select a lane [1/2/3]" in transcript
-    assert "Hosted lane" in transcript
-    assert "Local lane" in transcript
-    assert "Launching:" in transcript
-    assert "LOCAL SETUP --open-tui" in transcript
-    assert "No such command 'setup'" not in transcript
-
-    setup_help = subprocess.run(
-        [str(brew_prefix / "bin" / "mutx"), "setup", "local", "--help"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert setup_help.returncode == 0
+    assert exit_code != 0
+    assert "Recovering current CLI surface" not in transcript
+    assert "Setup Wizard" not in transcript
+    assert "missing required commands" in transcript


### PR DESCRIPTION
### Motivation
- The installer previously auto-fetched a mutable, unpinned GitHub tarball and installed it via `pip`, creating a supply-chain risk that allows arbitrary code execution if the upstream source or transport is compromised.
- The intent of this change is to eliminate that unverified network fallback and keep installs limited to the packaged, Homebrew-managed CLI surface.

### Description
- Removed the `MUTX_CLI_SOURCE_REF` default and all logic that created a Python venv and ran `pip install` of the source overlay (the `install_source_overlay` flow and its Python resolver were removed). 
- Updated the install help and `show_install_plan` to reflect that there is no automatic runtime/source fallback and the runtime requires the packaged CLI commands.
- Replaced the recovery path in `ensure_assistant_first_surface` with a fast fail that emits a clear error instructing the user to upgrade the Homebrew `FORMULA` from `TAP` and re-run the installer.
- Updated `tests/test_install_script.py` to remove the fake source-package plumbing and changed tests to assert that a stale packaged CLI now fails fast (both non-TTY and TTY flows).

### Testing
- `bash -n public/install.sh` completed successfully (shell syntax check passed).
- `python -m py_compile tests/test_install_script.py` completed successfully (test file compiles).
- `pytest -q tests/test_install_script.py` was attempted but did not run to completion in this environment due to a missing test dependency (`pytest_asyncio`) reported by `tests/conftest.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd1b39b2d8832a899325fbcdcd0cae)