### PR TITLE
fix(ci): pin Trivy GitHub Action to immutable commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           tags: mutx-app:latest
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: 'image'
           scan-ref: 'mutx-app:latest'


### PR DESCRIPTION
### Motivation
- Mitigate a supply-chain risk by removing the mutable `aquasecurity/trivy-action@master` reference in the `container-scan` job so upstream branch changes cannot inject code into CI.

### Description
- Replace `uses: aquasecurity/trivy-action@master` with `uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0` in `.github/workflows/ci.yml` to pin the action to an immutable commit while preserving the existing scan behavior.

### Testing
- Verified the workflow now contains the pinned reference by inspecting `.github/workflows/ci.yml` and confirmed the pinned SHA maps to an upstream release tag using `git ls-remote --tags https://github.com/aquasecurity/trivy-action.git | tail -n 20`, and the validation commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b84924c730832ab43614edeb373413)