### PR TITLE
fix(auth): bind refresh endpoint to existing refresh cookie

### DIFF
--- a/tests/unit/authRoutes.test.ts
+++ b/tests/unit/authRoutes.test.ts
@@ -279,6 +279,74 @@ describe('auth route handlers', () => {
     })
   })
 
+
+  describe('POST /api/auth/refresh', () => {
+    it('returns 401 when refresh cookie is missing', async () => {
+      const { POST } = await import('../../app/api/auth/refresh/route')
+
+      const response = await POST({
+        json: async () => ({ refresh_token: 'body_token' }),
+        cookies: {
+          get: () => undefined,
+        },
+      } as unknown as NextRequest)
+
+      expect(response.status).toBe(401)
+      await expect(response.json()).resolves.toEqual({ detail: 'Unauthorized' })
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 when refresh cookie does not match body token', async () => {
+      const { POST } = await import('../../app/api/auth/refresh/route')
+
+      const response = await POST({
+        json: async () => ({ refresh_token: 'body_token' }),
+        cookies: {
+          get: () => ({ value: 'different_cookie_token' }),
+        },
+      } as unknown as NextRequest)
+
+      expect(response.status).toBe(401)
+      await expect(response.json()).resolves.toEqual({ detail: 'Unauthorized' })
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+    it('refreshes tokens when refresh cookie matches body token', async () => {
+      ;(global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: 'new_access_token',
+          refresh_token: 'new_refresh_token',
+          expires_in: 1800,
+        }),
+      })
+      const { POST } = await import('../../app/api/auth/refresh/route')
+
+      const response = await POST({
+        json: async () => ({ refresh_token: 'matching_token' }),
+        cookies: {
+          get: () => ({ value: 'matching_token' }),
+        },
+      } as unknown as NextRequest)
+
+      expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/auth/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: 'matching_token' }),
+        cache: 'no-store',
+      })
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({
+        access_token: 'new_access_token',
+        expires_in: 1800,
+      })
+      const setCookieHeader = response.headers.get('set-cookie')
+      expect(setCookieHeader).toContain('access_token=')
+      expect(setCookieHeader).toContain('refresh_token=')
+    })
+  })
+
   describe('POST /api/auth/logout', () => {
     it('returns 200 with success payload', async () => {
       const { POST } = await import('../../app/api/auth/logout/route')


### PR DESCRIPTION
### Motivation
- The refresh route accepted a `refresh_token` from the request body and unconditionally set auth cookies, which allowed session-fixation/login CSRF when a cross-site POST supplied an attacker token. 
- The intent is to ensure refreshes are bound to the existing HttpOnly refresh cookie so an attacker cannot overwrite a victim’s session by supplying a body token.

### Description
- Require the request to include a `refresh_token` cookie and compare it to the body `refresh_token` by reading `request.cookies.get('refresh_token')?.value` and returning `401` if missing or mismatched. 
- Preserve the existing upstream call to `POST ${API_BASE_URL}/v1/auth/refresh` and the sliding-expiry cookie setting when the cookie/body token match. 
- Add focused unit tests in `tests/unit/authRoutes.test.ts` that cover missing cookie, mismatched cookie/body token, and successful refresh when the cookie matches. 
- Files modified: `app/api/auth/refresh/route.ts` and `tests/unit/authRoutes.test.ts`.

### Testing
- Running the full suite for the auth tests with `npm run test:app -- authRoutes.test.ts` initially reported a failure due to a pre-existing expectation and an early test setup mismatch. 
- Focused tests for the refresh handler were run with `npx jest --runInBand tests/unit/authRoutes.test.ts -t "POST /api/auth/refresh"` and succeeded (all refresh-related tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b84e282b8c832aa59cdbb9380c482e)