### PR TITLE
Route /api/v1/leads through protected Next.js leads API

### DIFF
--- a/app/api/v1/leads/route.ts
+++ b/app/api/v1/leads/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '../../leads/route'


### PR DESCRIPTION
### Motivation
- A global rewrite in `next.config.js` forwarded every `/api/:path*` to the backend, which allowed unhandled paths like `/api/v1/leads` to bypass the honeypot/validation in the Next.js handler and reach the public backend `/v1/leads` endpoint directly.

### Description
- Add a minimal filesystem route at `app/api/v1/leads/route.ts` that re-exports the existing `POST` handler from `app/api/leads/route.ts`, ensuring `/api/v1/leads` is resolved by Next.js (and goes through honeypot/validation) instead of falling through to the rewrite.

### Testing
- Ran `npm run lint` and `npm run test:app`, and the lint step completed with no errors and all unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7bde245d8832a93f178fc3c9d5811)