### PR TITLE
fix: center first-load logo animation on mobile

### DIFF
--- a/components/site/marketing/MarketingLoader.tsx
+++ b/components/site/marketing/MarketingLoader.tsx
@@ -411,7 +411,7 @@ export function MarketingLoader() {
         ref={stageRef}
         data-testid="marketing-loader-stage"
         className={`${styles.loaderStage} ${styles.loaderMarkShell}`}
-        initial={{ opacity: 0, scale: 0.82, y: 18 }}
+        initial={{ opacity: 0, scale: 0.82, y: 0 }}
         animate={
           loaderState === "handoff"
             ? canHandoffToTarget


### PR DESCRIPTION
### Motivation
- The landing-page logo appeared vertically off-center on first mobile page load because the loader stage animation applied a downward Y offset.

### Description
- Updated `components/site/marketing/MarketingLoader.tsx` to remove the initial vertical offset by changing the `initial` motion from `{ opacity: 0, scale: 0.82, y: 18 }` to `{ opacity: 0, scale: 0.82, y: 0 }`, preserving existing scale/opacity and handoff behaviors.

### Testing
- Ran `npx eslint components/site/marketing/MarketingLoader.tsx`, which failed in this environment due to a missing `@next/eslint-plugin-next` dependency, so linting could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74d92b358832ab65812eede784292)