### PR TITLE
fix(test): add missing getRefreshToken mock in refresh token test

### DIFF
--- a/tests/unit/authRoutes.test.ts
+++ b/tests/unit/authRoutes.test.ts
@@ -321,6 +321,7 @@ describe('auth route handlers', () => {
           expires_in: 1800,
         }),
       })
+      getRefreshToken.mockReturnValue('matching_token')
       const { POST } = await import('../../app/api/auth/refresh/route')
 
       const response = await POST({
@@ -330,12 +331,15 @@ describe('auth route handlers', () => {
         },
       } as unknown as NextRequest)
 
-      expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/v1/auth/refresh', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ refresh_token: 'matching_token' }),
-        cache: 'no-store',
-      })
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:8000/v1/auth/refresh',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refresh_token: 'matching_token' }),
+          cache: 'no-store',
+        }),
+      )
       expect(response.status).toBe(200)
       await expect(response.json()).resolves.toEqual({
         access_token: 'new_access_token',


### PR DESCRIPTION
## What
Fix the failing test 'refreshes tokens when refresh cookie matches body token' in tests/unit/authRoutes.test.ts by adding the missing getRefreshToken.mockReturnValue(...) call after beforeEach mockReset().

## Why
The test was added in PR #1202 but was missing the mock setup for getRefreshToken. Since beforeEach calls mockReset(), the mocked getRefreshToken returned undefined, causing the route handler to return 401 Unauthorized without calling fetch. This broke the CI validation suite on main.

## How
1. Added getRefreshToken.mockReturnValue('matching_token') before calling POST
2. Updated the fetch assertion to use expect.objectContaining to account for the AbortController signal injected by fetchWithTimeout

## Testing
- [x] All 28 tests in authRoutes.test.ts pass
- [x] No new lint errors introduced
- [ ] CI passes

## Labels
ci-fix, test, auth

## Task
task-1701