### PR TITLE
fix(ci): add missing GRAFANA_ADMIN_PASSWORD in infrastructure CI env

### DIFF
--- a/.github/workflows/infrastructure-ci.yml
+++ b/.github/workflows/infrastructure-ci.yml
@@ -111,6 +111,7 @@ jobs:
           JWT_SECRET: test-secret-key-that-is-long-enough-32
           DATABASE_URL: postgresql://mutx:testpass@postgres:5432/mutx
           DATABASE_SSL_MODE: disable
+          GRAFANA_ADMIN_PASSWORD: testpass
         run: |
           docker compose -f infrastructure/docker/docker-compose.yml config --quiet
           docker compose -f infrastructure/docker/docker-compose.prod.yml config --quiet


### PR DESCRIPTION
## What
Add missing  environment variable to the infrastructure CI workflow's docker-compose validation step.

## Why
CI run 23715637039 failed because the 'Validate canonical docker-compose files' step runs name: task-1702
services:
  mutx:
    build:
      context: /tmp/mutx-coder/task-1702
      dockerfile: Dockerfile
    depends_on:
      postgres:
        condition: service_healthy
        required: true
      redis:
        condition: service_healthy
        required: true
    environment:
      DATABASE_URL: postgresql://mutx:mutx@postgres:5432/mutx
      NEXTAUTH_SECRET: ""
      NEXTAUTH_URL: http://localhost:3000
      NODE_ENV: production
      REDIS_URL: redis://redis:6379
    healthcheck:
      test:
        - CMD
        - wget
        - -q
        - --spider
        - http://localhost:3000/api/health || exit 1
      timeout: 10s
      interval: 30s
      retries: 3
      start_period: 40s
    networks:
      default: null
    ports:
      - mode: ingress
        target: 3000
        published: "3000"
        protocol: tcp
    restart: unless-stopped
  postgres:
    environment:
      POSTGRES_DB: mutx
      POSTGRES_PASSWORD: mutx
      POSTGRES_USER: mutx
    healthcheck:
      test:
        - CMD-SHELL
        - pg_isready -U mutx -d mutx
      timeout: 5s
      interval: 10s
      retries: 5
      start_period: 10s
    image: postgres:16-alpine
    networks:
      default: null
    restart: unless-stopped
    volumes:
      - type: volume
        source: postgres_data
        target: /var/lib/postgresql/data
        volume: {}
  redis:
    healthcheck:
      test:
        - CMD
        - redis-cli
        - ping
      timeout: 5s
      interval: 10s
      retries: 5
      start_period: 5s
    image: redis:7-alpine
    networks:
      default: null
    restart: unless-stopped
    volumes:
      - type: volume
        source: redis_data
        target: /data
        volume: {}
networks:
  default:
    name: task-1702_default
volumes:
  postgres_data:
    name: task-1702_postgres_data
  redis_data:
    name: task-1702_redis_data on , which requires  via . The env block only set , , , , and , omitting .

## How
Added  to the env block in .

## Testing
- [x] YAML syntax validated
- [x] All docker-compose files remain syntactically valid
- [ ] CI passes

## Labels
ci-fix, infrastructure

## Task
task-1702