### PR TITLE
fix(format): lint/format drift on 3 files

### DIFF
--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -22,7 +22,7 @@ async function fetchWithTimeout(url: string, options: RequestInit = {}): Promise
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  return withErrorHandling(async (req: Request) => {
+  return withErrorHandling(async () => {
     const refreshToken = getRefreshToken(request)
     if (!refreshToken) {
       return NextResponse.json({ detail: 'Unauthorized' }, { status: 401 })

--- a/tests/api/test_governance_supervision.py
+++ b/tests/api/test_governance_supervision.py
@@ -13,7 +13,9 @@ class _MockSupervisor:
     def get_agent_status(self, agent_id):
         return {"agent_id": agent_id, "state": "running"}
 
-    def prepare_launch_request(self, agent_id, command=None, env=None, faramesh_policy=None, profile_name=None):
+    def prepare_launch_request(
+        self, agent_id, command=None, env=None, faramesh_policy=None, profile_name=None
+    ):
         return _MockPreparedLaunch(agent_id)
 
     async def start_prepared_agent(self, prepared):
@@ -39,7 +41,9 @@ async def test_start_supervised_agent_forbidden_for_non_internal_user(
 ):
     from src.api.routes import governance_supervision
 
-    monkeypatch.setattr(governance_supervision, "get_faramesh_supervisor", lambda: _MockSupervisor())
+    monkeypatch.setattr(
+        governance_supervision, "get_faramesh_supervisor", lambda: _MockSupervisor()
+    )
 
     response = await other_user_client.post(
         "/v1/runtime/governance/supervised/start",
@@ -53,7 +57,9 @@ async def test_start_supervised_agent_forbidden_for_non_internal_user(
 async def test_start_supervised_agent_allowed_for_internal_user(client, monkeypatch):
     from src.api.routes import governance_supervision
 
-    monkeypatch.setattr(governance_supervision, "get_faramesh_supervisor", lambda: _MockSupervisor())
+    monkeypatch.setattr(
+        governance_supervision, "get_faramesh_supervisor", lambda: _MockSupervisor()
+    )
 
     response = await client.post(
         "/v1/runtime/governance/supervised/start",

--- a/tests/test_cli_setup_and_doctor.py
+++ b/tests/test_cli_setup_and_doctor.py
@@ -47,8 +47,6 @@ def wizard_result_payload(*, reused_existing_assistant: bool = False) -> SimpleN
     )
 
 
-
-
 def test_setup_faramesh_does_not_auto_install(monkeypatch) -> None:
     from cli.commands import setup as setup_module
 
@@ -64,6 +62,7 @@ def test_setup_faramesh_does_not_auto_install(monkeypatch) -> None:
     setup_module._install_faramesh_governance()
 
     assert captured == {"install_if_missing": False, "non_interactive": True}
+
 
 def test_setup_hosted_deploys_personal_assistant(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, object] = {}
@@ -375,7 +374,9 @@ def test_doctor_json_reports_assistant_state(monkeypatch, tmp_path: Path) -> Non
     }
 
 
-def test_setup_hosted_no_input_requires_explicit_openclaw_install(monkeypatch, tmp_path: Path) -> None:
+def test_setup_hosted_no_input_requires_explicit_openclaw_install(
+    monkeypatch, tmp_path: Path
+) -> None:
     config = CLIConfig(config_path=tmp_path / "config.json")
 
     class DummyAuth:
@@ -423,7 +424,9 @@ def test_setup_hosted_uses_import_action_when_openclaw_exists(monkeypatch, tmp_p
             return None
 
     monkeypatch.setattr("cli.main.CLIConfig", lambda: config)
-    monkeypatch.setattr("cli.commands.setup.find_openclaw_bin", lambda: "/opt/homebrew/bin/openclaw")
+    monkeypatch.setattr(
+        "cli.commands.setup.find_openclaw_bin", lambda: "/opt/homebrew/bin/openclaw"
+    )
     monkeypatch.setattr("cli.commands.setup._auth_service", lambda: DummyAuth())
     monkeypatch.setattr("cli.commands.setup.mark_auth_completed", lambda **kwargs: None)
     monkeypatch.setattr(
@@ -459,7 +462,9 @@ def test_setup_hosted_interactive_can_choose_openclaw_tui(monkeypatch, tmp_path:
             return None
 
     monkeypatch.setattr("cli.main.CLIConfig", lambda: config)
-    monkeypatch.setattr("cli.commands.setup.find_openclaw_bin", lambda: "/opt/homebrew/bin/openclaw")
+    monkeypatch.setattr(
+        "cli.commands.setup.find_openclaw_bin", lambda: "/opt/homebrew/bin/openclaw"
+    )
     monkeypatch.setattr("cli.commands.setup._auth_service", lambda: DummyAuth())
     monkeypatch.setattr("cli.commands.setup.mark_auth_completed", lambda **kwargs: None)
     monkeypatch.setattr(
@@ -496,7 +501,9 @@ def test_setup_hosted_interactive_can_choose_repair(monkeypatch, tmp_path: Path)
             return None
 
     monkeypatch.setattr("cli.main.CLIConfig", lambda: config)
-    monkeypatch.setattr("cli.commands.setup.find_openclaw_bin", lambda: "/opt/homebrew/bin/openclaw")
+    monkeypatch.setattr(
+        "cli.commands.setup.find_openclaw_bin", lambda: "/opt/homebrew/bin/openclaw"
+    )
     monkeypatch.setattr("cli.commands.setup._auth_service", lambda: DummyAuth())
     monkeypatch.setattr("cli.commands.setup.mark_auth_completed", lambda **kwargs: None)
     monkeypatch.setattr(


### PR DESCRIPTION
## What
Fix lint/format drift on 3 files that had drifted from origin/main formatting standards.

## Changes
- **app/api/auth/refresh/route.ts**: Removed unused `req` parameter in `withErrorHandling` callback
- **tests/api/test_governance_supervision.py**: Line-length formatting for `prepare_launch_request` and `monkeypatch.setattr` calls
- **tests/test_cli_setup_and_doctor.py**: Removed extra blank lines; line-length formatting for long function signatures and `monkeypatch.setattr` calls

## Already compliant
These files from the original drift list were already correctly formatted: app/api/v1/leads/route.ts, app/types/api.ts, src/api/routes/analytics.py, tests/api/test_governance_credentials_authz.py, cli/commands/setup.py

## Testing
- [x] ruff check: all clean
- [x] ruff format: applied
- [x] eslint on TypeScript files: clean

## Labels
lint-fix, formatting

## Task
task-1704