### PR TITLE
feat: CLI parity — add scheduler, observability, budgets, usage commands

### DIFF
--- a/cli/commands/budgets.py
+++ b/cli/commands/budgets.py
@@ -1,0 +1,173 @@
+import click
+from typing import Any, Optional
+
+from cli.config import CLIConfig, get_client
+
+
+@click.group(name="budgets")
+def budgets_group():
+    """Manage budgets"""
+    pass
+
+
+def _require_auth() -> tuple[CLIConfig, Any]:
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        raise SystemExit(1)
+    return config, get_client(config)
+
+
+@budgets_group.command(name="list")
+@click.option("--limit", "-l", default=50, help="Number of budgets to fetch")
+@click.option("--skip", "-s", default=0, help="Number of budgets to skip")
+def list_budgets(limit: int, skip: int):
+    """List all budgets"""
+    config, client = _require_auth()
+    response = client.get("/v1/budgets", params={"limit": limit, "skip": skip})
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    budgets = response.json()
+    if not budgets:
+        click.echo("No budgets found.")
+        return
+
+    for budget in budgets:
+        spent = budget.get("spent", 0)
+        limit_ = budget.get("limit", 0)
+        pct = f"{spent / limit_ * 100:.1f}%" if limit_ else "n/a"
+        click.echo(
+            f"{budget['id']} | {budget.get('name', 'unnamed')} | {spent}/{limit_} {budget.get('currency', 'USD')} ({pct})"
+        )
+
+
+@budgets_group.command(name="get")
+@click.argument("budget_id")
+def get_budget(budget_id: str):
+    """Get a budget by ID"""
+    config, client = _require_auth()
+    response = client.get(f"/v1/budgets/{budget_id}")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 404:
+        click.echo("Error: Budget not found", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    budget = response.json()
+    click.echo(f"ID:       {budget['id']}")
+    click.echo(f"Name:     {budget.get('name', 'n/a')}")
+    click.echo(f"Limit:    {budget.get('limit', 0)} {budget.get('currency', 'USD')}")
+    click.echo(f"Spent:    {budget.get('spent', 0)}")
+    click.echo(f"Reset:    {budget.get('reset_at', 'n/a')}")
+    click.echo(f"Status:   {budget.get('status', 'n/a')}")
+
+
+@budgets_group.command(name="create")
+@click.option("--name", "-n", required=True, help="Budget name")
+@click.option("--limit", "-l", required=True, type=float, help="Spending limit")
+@click.option("--currency", "-c", default="USD", help="Currency code (default: USD)")
+@click.option(
+    "--period",
+    "-p",
+    default="monthly",
+    type=click.Choice(["daily", "weekly", "monthly", "yearly"]),
+    help="Budget period",
+)
+def create_budget(name: str, limit: float, currency: str, period: str):
+    """Create a new budget"""
+    config, client = _require_auth()
+    response = client.post(
+        "/v1/budgets",
+        json={"name": name, "limit": limit, "currency": currency, "period": period},
+    )
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code not in (200, 201):
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    budget = response.json()
+    click.echo(f"Created budget: {budget['id']}")
+    click.echo(f"Name: {budget.get('name')}")
+    click.echo(f"Limit: {budget.get('limit')} {budget.get('currency', 'USD')}")
+
+
+@budgets_group.command(name="update")
+@click.argument("budget_id")
+@click.option("--name", "-n", default=None, help="New budget name")
+@click.option("--limit", "-l", type=float, default=None, help="New spending limit")
+def update_budget(budget_id: str, name: Optional[str], limit: Optional[float]):
+    """Update a budget"""
+    config, client = _require_auth()
+    payload: dict[str, Any] = {}
+    if name is not None:
+        payload["name"] = name
+    if limit is not None:
+        payload["limit"] = limit
+
+    if not payload:
+        click.echo("Error: Provide at least --name or --limit to update.", err=True)
+        return
+
+    response = client.patch(f"/v1/budgets/{budget_id}", json=payload)
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 404:
+        click.echo("Error: Budget not found", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    budget = response.json()
+    click.echo(f"Updated budget: {budget['id']}")
+    click.echo(f"Name: {budget.get('name')}")
+    click.echo(f"Limit: {budget.get('limit')} {budget.get('currency', 'USD')}")
+
+
+@budgets_group.command(name="delete")
+@click.argument("budget_id")
+@click.option("--force", "-f", is_flag=True, help="Delete without confirmation")
+def delete_budget(budget_id: str, force: bool):
+    """Delete a budget"""
+    config, client = _require_auth()
+
+    if not force and not click.confirm(f"Are you sure you want to delete budget {budget_id}?"):
+        return
+
+    response = client.delete(f"/v1/budgets/{budget_id}")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 404:
+        click.echo("Error: Budget not found", err=True)
+        return
+
+    if response.status_code != 204:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    click.echo(f"Deleted budget: {budget_id}")

--- a/cli/commands/observability.py
+++ b/cli/commands/observability.py
@@ -1,0 +1,196 @@
+import click
+from typing import Any, Optional
+
+from cli.config import CLIConfig, get_client
+
+
+@click.group(name="runs")
+def runs_group():
+    """Manage observability runs"""
+    pass
+
+
+def _require_auth() -> tuple[CLIConfig, Any]:
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        raise SystemExit(1)
+    return config, get_client(config)
+
+
+@runs_group.command(name="list")
+@click.option("--limit", "-l", default=50, help="Number of runs to fetch")
+@click.option("--skip", "-s", default=0, help="Number of runs to skip")
+@click.option("--agent-id", help="Filter by agent ID")
+@click.option(
+    "--status",
+    type=click.Choice(["pending", "running", "success", "failed"]),
+    help="Filter by status",
+)
+def list_runs(limit: int, skip: int, agent_id: Optional[str], status: Optional[str]):
+    """List all observability runs"""
+    config, client = _require_auth()
+    params: dict[str, Any] = {"limit": limit, "skip": skip}
+    if agent_id:
+        params["agent_id"] = agent_id
+    if status:
+        params["status"] = status
+
+    response = client.get("/v1/observability/runs", params=params)
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    runs = response.json()
+    if not runs:
+        click.echo("No runs found.")
+        return
+
+    for run in runs:
+        click.echo(
+            f"{run['id']} | agent={run.get('agent_id', 'n/a')} | status={run.get('status', 'n/a')} | {run.get('created_at', '')}"
+        )
+
+
+@runs_group.command(name="get")
+@click.argument("run_id")
+def get_run(run_id: str):
+    """Get a run by ID"""
+    config, client = _require_auth()
+    response = client.get(f"/v1/observability/runs/{run_id}")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 404:
+        click.echo("Error: Run not found", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    run = response.json()
+    click.echo(f"ID:       {run['id']}")
+    click.echo(f"Agent:    {run.get('agent_id', 'n/a')}")
+    click.echo(f"Status:   {run.get('status', 'n/a')}")
+    click.echo(f"Duration: {run.get('duration_ms', 'n/a')}ms")
+    click.echo(f"Created:  {run.get('created_at', 'n/a')}")
+    click.echo(f"Finished: {run.get('finished_at', 'n/a')}")
+    if run.get("error"):
+        click.echo(f"Error:    {run['error']}")
+
+
+@runs_group.command(name="logs")
+@click.argument("run_id")
+@click.option("--limit", "-l", default=100, help="Number of log entries to fetch")
+def get_run_logs(run_id: str, limit: int):
+    """Get logs for an observability run"""
+    config, client = _require_auth()
+    response = client.get(f"/v1/observability/runs/{run_id}/logs", params={"limit": limit})
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    logs = response.json()
+    if not logs:
+        click.echo("No logs found for this run.")
+        return
+
+    for log in logs:
+        level = log.get("level", "INFO")
+        click.echo(f"{log.get('timestamp', '')} | {level} | {log.get('message', '')}")
+
+
+@runs_group.command(name="trigger")
+@click.option("--agent-id", "-a", required=True, help="Agent ID to run")
+@click.option("--input", "input_json", default="{}", help="JSON input payload")
+@click.option("--name", "-n", default=None, help="Optional run name")
+def trigger_run(agent_id: str, input_json: str, name: Optional[str]):
+    """Trigger a new observability run"""
+    config, client = _require_auth()
+    import json
+
+    try:
+        parsed_input = json.loads(input_json)
+    except json.JSONDecodeError:
+        click.echo("Error: Invalid JSON in --input", err=True)
+        return
+
+    payload: dict[str, Any] = {"agent_id": agent_id, "input": parsed_input}
+    if name:
+        payload["name"] = name
+
+    response = client.post("/v1/observability/runs", json=payload)
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code not in (200, 201):
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    run = response.json()
+    click.echo(f"Triggered run: {run['id']}")
+    click.echo(f"Status: {run.get('status')}")
+
+
+@runs_group.command(name="cancel")
+@click.argument("run_id")
+def cancel_run(run_id: str):
+    """Cancel a running observability run"""
+    config, client = _require_auth()
+    response = client.post(f"/v1/observability/runs/{run_id}/cancel")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 404:
+        click.echo("Error: Run not found", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    click.echo(f"Cancelled run: {run_id}")
+
+
+@runs_group.command(name="delete")
+@click.argument("run_id")
+@click.option("--force", "-f", is_flag=True, help="Delete without confirmation")
+def delete_run(run_id: str, force: bool):
+    """Delete an observability run"""
+    config, client = _require_auth()
+
+    if not force and not click.confirm(f"Are you sure you want to delete run {run_id}?"):
+        return
+
+    response = client.delete(f"/v1/observability/runs/{run_id}")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 404:
+        click.echo("Error: Run not found", err=True)
+        return
+
+    if response.status_code != 204:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    click.echo(f"Deleted run: {run_id}")

--- a/cli/commands/scheduler.py
+++ b/cli/commands/scheduler.py
@@ -1,0 +1,187 @@
+import click
+from typing import Any
+
+from cli.config import CLIConfig, get_client
+
+
+@click.group(name="scheduler")
+def scheduler_group():
+    """Manage scheduled tasks"""
+    pass
+
+
+def _require_auth() -> tuple[CLIConfig, Any]:
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        raise SystemExit(1)
+    return config, get_client(config)
+
+
+@scheduler_group.command(name="list")
+@click.option("--limit", "-l", default=50, help="Number of schedules to fetch")
+@click.option("--skip", "-s", default=0, help="Number of schedules to skip")
+def list_schedules(limit: int, skip: int):
+    """List all scheduled tasks"""
+    config, client = _require_auth()
+    response = client.get("/v1/scheduler/schedules", params={"limit": limit, "skip": skip})
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    schedules = response.json()
+    if not schedules:
+        click.echo("No schedules found.")
+        return
+
+    for schedule in schedules:
+        active = "active" if schedule.get("is_active", False) else "paused"
+        cron = schedule.get("cron_expression", "n/a")
+        click.echo(
+            f"{schedule['id']} | {schedule.get('name', 'unnamed')} | {active} | cron: {cron}"
+        )
+
+
+@scheduler_group.command(name="get")
+@click.argument("schedule_id")
+def get_schedule(schedule_id: str):
+    """Get a scheduled task by ID"""
+    config, client = _require_auth()
+    response = client.get(f"/v1/scheduler/schedules/{schedule_id}")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 404:
+        click.echo("Error: Schedule not found", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    schedule = response.json()
+    click.echo(f"ID:       {schedule['id']}")
+    click.echo(f"Name:     {schedule.get('name', 'n/a')}")
+    click.echo(f"Agent:    {schedule.get('agent_id', 'n/a')}")
+    click.echo(f"Cron:     {schedule.get('cron_expression', 'n/a')}")
+    click.echo(f"Status:   {'active' if schedule.get('is_active') else 'paused'}")
+    click.echo(f"Next run: {schedule.get('next_scheduled_at', 'n/a')}")
+    click.echo(f"Created:  {schedule.get('created_at', 'n/a')}")
+
+
+@scheduler_group.command(name="create")
+@click.option("--name", "-n", required=True, help="Schedule name")
+@click.option("--agent-id", required=True, help="Agent ID to trigger")
+@click.option("--cron", "-c", required=True, help="Cron expression (e.g. '0 * * * *')")
+@click.option("--input", "input_json", default="{}", help="JSON input payload for the run")
+def create_schedule(name: str, agent_id: str, cron: str, input_json: str):
+    """Create a new scheduled task"""
+    config, client = _require_auth()
+    import json
+
+    try:
+        parsed_input = json.loads(input_json)
+    except json.JSONDecodeError:
+        click.echo("Error: Invalid JSON in --input", err=True)
+        return
+
+    response = client.post(
+        "/v1/scheduler/schedules",
+        json={
+            "name": name,
+            "agent_id": agent_id,
+            "cron_expression": cron,
+            "input": parsed_input,
+        },
+    )
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code not in (200, 201):
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    schedule = response.json()
+    click.echo(f"Created schedule: {schedule['id']}")
+    click.echo(f"Name: {schedule.get('name')}")
+    click.echo(f"Next run: {schedule.get('next_scheduled_at', 'n/a')}")
+
+
+@scheduler_group.command(name="pause")
+@click.argument("schedule_id")
+def pause_schedule(schedule_id: str):
+    """Pause a scheduled task"""
+    config, client = _require_auth()
+    response = client.post(f"/v1/scheduler/schedules/{schedule_id}/pause")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 404:
+        click.echo("Error: Schedule not found", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    click.echo(f"Paused schedule: {schedule_id}")
+
+
+@scheduler_group.command(name="resume")
+@click.argument("schedule_id")
+def resume_schedule(schedule_id: str):
+    """Resume a paused scheduled task"""
+    config, client = _require_auth()
+    response = client.post(f"/v1/scheduler/schedules/{schedule_id}/resume")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 404:
+        click.echo("Error: Schedule not found", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    click.echo(f"Resumed schedule: {schedule_id}")
+
+
+@scheduler_group.command(name="delete")
+@click.argument("schedule_id")
+@click.option("--force", "-f", is_flag=True, help="Delete without confirmation")
+def delete_schedule(schedule_id: str, force: bool):
+    """Delete a scheduled task"""
+    config, client = _require_auth()
+
+    if not force and not click.confirm(f"Are you sure you want to delete schedule {schedule_id}?"):
+        return
+
+    response = client.delete(f"/v1/scheduler/schedules/{schedule_id}")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 404:
+        click.echo("Error: Schedule not found", err=True)
+        return
+
+    if response.status_code != 204:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    click.echo(f"Deleted schedule: {schedule_id}")

--- a/cli/commands/usage.py
+++ b/cli/commands/usage.py
@@ -1,0 +1,154 @@
+import click
+from typing import Any
+
+from cli.config import CLIConfig, get_client
+
+
+@click.group(name="usage")
+def usage_group():
+    """View usage statistics"""
+    pass
+
+
+def _require_auth() -> tuple[CLIConfig, Any]:
+    config = CLIConfig()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        raise SystemExit(1)
+    return config, get_client(config)
+
+
+@usage_group.command(name="summary")
+@click.option(
+    "--period",
+    "-p",
+    default="monthly",
+    type=click.Choice(["daily", "weekly", "monthly", "yearly"]),
+    help="Time period",
+)
+def usage_summary(period: str):
+    """Get overall usage summary"""
+    config, client = _require_auth()
+    response = client.get("/v1/usage/summary", params={"period": period})
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    data = response.json()
+    click.echo(f"Period:  {data.get('period', period)}")
+    click.echo(f"Requests:   {data.get('requests', 0):,}")
+    click.echo(f"Tokens:     {data.get('tokens', 0):,}")
+    click.echo(f"Cost:       {data.get('cost', 0):.4f} {data.get('currency', 'USD')}")
+    click.echo(f"Agents:     {data.get('active_agents', 0)}")
+
+
+@usage_group.command(name="by-agent")
+@click.option("--limit", "-l", default=50, help="Number of records to fetch")
+@click.option(
+    "--period",
+    "-p",
+    default="monthly",
+    type=click.Choice(["daily", "weekly", "monthly", "yearly"]),
+    help="Time period",
+)
+def usage_by_agent(limit: int, period: str):
+    """Get usage breakdown by agent"""
+    config, client = _require_auth()
+    response = client.get("/v1/usage/by-agent", params={"limit": limit, "period": period})
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    data = response.json()
+    if not data:
+        click.echo("No usage data found.")
+        return
+
+    header = f"{'AGENT ID':<40} {'REQUESTS':<12} {'TOKENS':<12} {'COST':<12}"
+    click.echo(header)
+    click.echo("-" * len(header))
+
+    for row in data:
+        click.echo(
+            f"{row.get('agent_id', 'n/a')[:38]:<40} "
+            f"{row.get('requests', 0):<12,} "
+            f"{row.get('tokens', 0):<12,} "
+            f"{row.get('cost', 0):.4f}"
+        )
+
+
+@usage_group.command(name="by-day")
+@click.option(
+    "--period",
+    "-p",
+    default="monthly",
+    type=click.Choice(["daily", "weekly", "monthly", "yearly"]),
+    help="Time period",
+)
+def usage_by_day(period: str):
+    """Get usage breakdown by day"""
+    config, client = _require_auth()
+    response = client.get("/v1/usage/by-day", params={"period": period})
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    data = response.json()
+    if not data:
+        click.echo("No usage data found.")
+        return
+
+    header = f"{'DATE':<14} {'REQUESTS':<12} {'TOKENS':<12} {'COST':<12}"
+    click.echo(header)
+    click.echo("-" * len(header))
+
+    for row in data:
+        click.echo(
+            f"{row.get('date', 'n/a'):<14} "
+            f"{row.get('requests', 0):<12,} "
+            f"{row.get('tokens', 0):<12,} "
+            f"{row.get('cost', 0):.4f}"
+        )
+
+
+@usage_group.command(name="current")
+def usage_current():
+    """Get current billing period usage"""
+    config, client = _require_auth()
+    response = client.get("/v1/usage/current")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    data = response.json()
+    click.echo(f"Period:    {data.get('period_label', 'n/a')}")
+    click.echo(f"Start:     {data.get('period_start', 'n/a')}")
+    click.echo(f"End:       {data.get('period_end', 'n/a')}")
+    click.echo(f"Requests:  {data.get('requests', 0):,}")
+    click.echo(f"Tokens:    {data.get('tokens', 0):,}")
+    click.echo(f"Cost:      {data.get('cost', 0):.4f} {data.get('currency', 'USD')}")
+    if data.get("budget_limit"):
+        pct = data.get("cost", 0) / data["budget_limit"] * 100
+        click.echo(
+            f"Budget:    {data['budget_limit']} {data.get('currency', 'USD')} ({pct:.1f}% used)"
+        )

--- a/cli/main.py
+++ b/cli/main.py
@@ -8,6 +8,10 @@ from cli.commands.deploy import deploy_group
 from cli.commands.config import config_group
 from cli.commands.webhooks import webhooks_group
 from cli.commands.tui import tui_group
+from cli.commands.scheduler import scheduler_group
+from cli.commands.observability import runs_group
+from cli.commands.budgets import budgets_group
+from cli.commands.usage import usage_group
 
 
 @click.group()
@@ -109,6 +113,10 @@ cli.add_command(deploy_group)
 cli.add_command(config_group)
 cli.add_command(webhooks_group)
 cli.add_command(tui_group)
+cli.add_command(scheduler_group)
+cli.add_command(runs_group)
+cli.add_command(budgets_group)
+cli.add_command(usage_group)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## CLI Parity Push

Adds CLI commands for scheduler, observability runs, budgets, and usage — following existing codebase patterns.

### New commands
- `mutx scheduler` — list, get, create, pause, resume, delete schedules
- `mutx runs` — list, get, logs, trigger, cancel, delete observability runs  
- `mutx budgets` — list, get, create, update, delete budgets
- `mutx usage` — summary, by-agent, by-day, current

### Commits
- `c703a51` feat: CLI parity — add scheduler, observability, budgets, usage commands