### PR TITLE
fix(sdk): use explicit re-exports to satisfy F401 lint

### DIFF
--- a/sdk/mutx/__init__.py
+++ b/sdk/mutx/__init__.py
@@ -5,16 +5,25 @@ import httpx
 from mutx.agent_runtime import (
     AgentInfo,
     AgentMetrics,
-    Command,
-    MutxAgentClient,
-    MutxAgentSyncClient,
-    create_agent_client,
+)
+from mutx.agent_runtime import (
+    Command as Command,
+)
+from mutx.agent_runtime import (
+    MutxAgentClient as MutxAgentClient,
+)
+from mutx.agent_runtime import (
+    MutxAgentSyncClient as MutxAgentSyncClient,
+)
+from mutx.agent_runtime import (
+    create_agent_client as create_agent_client,
 )
 from mutx.agents import Agents
 from mutx.api_keys import APIKeys
 from mutx.clawhub import ClawHub
 from mutx.deployments import Deployments
-from mutx.leads import Contacts, Leads
+from mutx.leads import Contacts as Contacts
+from mutx.leads import Leads
 from mutx.webhooks import Webhooks
 
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -256,6 +256,7 @@ async def root(request: Request):
     user_id = getattr(request.state, "auth_user_id", None)
     if user_id:
         from fastapi.responses import RedirectResponse
+
         return RedirectResponse(url="https://app.mutx.dev", status_code=302)
     return {"message": "mutx.dev API", "version": "1.0.0"}
 

--- a/src/api/models/migrations/versions/3a8f2b1c4d6e_add_meta_data_to_agent_logs.py
+++ b/src/api/models/migrations/versions/3a8f2b1c4d6e_add_meta_data_to_agent_logs.py
@@ -4,20 +4,21 @@ Revision ID: 3a8f2b1c4d6e
 Revises: f7e2a1c8d9b4
 Create Date: 2026-03-18
 """
+
 from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = '3a8f2b1c4d6e'
-down_revision: Union[str, None] = 'f7e2a1c8d9b4'
+revision: str = "3a8f2b1c4d6e"
+down_revision: Union[str, None] = "f7e2a1c8d9b4"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.add_column('agent_logs', sa.Column('meta_data', sa.Text(), nullable=True))
+    op.add_column("agent_logs", sa.Column("meta_data", sa.Text(), nullable=True))
 
 
 def downgrade() -> None:
-    op.drop_column('agent_logs', 'meta_data')
+    op.drop_column("agent_logs", "meta_data")

--- a/src/api/models/migrations/versions/f7e2a1c8d9b4_add_usage_events_table.py
+++ b/src/api/models/migrations/versions/f7e2a1c8d9b4_add_usage_events_table.py
@@ -1,16 +1,17 @@
 """Add usage_events table for telemetry and quota enforcement
 
 Revision ID: f7e2a1c8d9b4
-Revises: 
+Revises:
 Create Date: 2026-03-18
 """
+
 from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID
 
-revision: str = 'f7e2a1c8d9b4'
+revision: str = "f7e2a1c8d9b4"
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -18,21 +19,29 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     op.create_table(
-        'usage_events',
-        sa.Column('id', UUID(as_uuid=True), primary_key=True, nullable=False),
-        sa.Column('event_type', sa.String(100), nullable=False, index=True),
-        sa.Column('user_id', UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=False, index=True),
-        sa.Column('resource_type', sa.String(100), nullable=True, index=True),
-        sa.Column('resource_id', sa.String(255), nullable=True),
-        sa.Column('credits_used', sa.Float(), nullable=False, server_default='1.0'),
-        sa.Column('event_metadata', sa.Text(), nullable=True),
-        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False, index=True),
+        "usage_events",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("event_type", sa.String(100), nullable=False, index=True),
+        sa.Column(
+            "user_id", UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=False, index=True
+        ),
+        sa.Column("resource_type", sa.String(100), nullable=True, index=True),
+        sa.Column("resource_id", sa.String(255), nullable=True),
+        sa.Column("credits_used", sa.Float(), nullable=False, server_default="1.0"),
+        sa.Column("event_metadata", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, index=True),
     )
-    op.create_index(op.f('ix_usage_events_created_at'), 'usage_events', ['created_at'], unique=False)
-    op.create_index(op.f('ix_usage_events_event_type'), 'usage_events', ['event_type'], unique=False)
-    op.create_index(op.f('ix_usage_events_user_id'), 'usage_events', ['user_id'], unique=False)
-    op.create_index(op.f('ix_usage_events_resource_type'), 'usage_events', ['resource_type'], unique=False)
+    op.create_index(
+        op.f("ix_usage_events_created_at"), "usage_events", ["created_at"], unique=False
+    )
+    op.create_index(
+        op.f("ix_usage_events_event_type"), "usage_events", ["event_type"], unique=False
+    )
+    op.create_index(op.f("ix_usage_events_user_id"), "usage_events", ["user_id"], unique=False)
+    op.create_index(
+        op.f("ix_usage_events_resource_type"), "usage_events", ["resource_type"], unique=False
+    )
 
 
 def downgrade() -> None:
-    op.drop_table('usage_events')
+    op.drop_table("usage_events")

--- a/src/api/services/monitoring.py
+++ b/src/api/services/monitoring.py
@@ -191,6 +191,7 @@ async def monitor_agent_health(session: AsyncSession):
                 session.add(log)
             except Exception as e:
                 import logging
+
                 logging.getLogger(__name__).warning(f"AgentLog insert skipped: {e}")
 
             deployment = await _get_latest_deployment(session, agent.id)
@@ -258,6 +259,7 @@ async def monitor_agent_health(session: AsyncSession):
                 session.add(heal_log)
             except Exception as e:
                 import logging
+
                 logging.getLogger(__name__).warning(f"AgentLog recovery insert skipped: {e}")
 
             deployment = await _get_latest_deployment(session, agent.id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,15 +2,21 @@
 Pytest configuration and fixtures for MUTX API tests.
 """
 
+import asyncio
+from datetime import datetime, timezone
+from collections.abc import AsyncGenerator
 import os
+import uuid
 
-from fastapi import FastAPI
 import pytest
 import pytest_asyncio
-from typing import AsyncGenerator
-
+from httpx import ASGITransport, AsyncClient
+from fastapi import FastAPI
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 # Set environment before any imports
 os.environ.setdefault("DATABASE_REQUIRED_ON_STARTUP", "false")


### PR DESCRIPTION
Fix F401 lint errors in sdk/mutx/__init__.py. Also formats 4 files with pre-existing format drift (src/api/main.py, migration files, monitoring.py) that were blocking CI validation.

Unblocks PR #1229, PR #1219, and main branch CI.