### PR TITLE
fix(sdk): use explicit re-exports to satisfy F401 lint

### DIFF
--- a/sdk/mutx/__init__.py
+++ b/sdk/mutx/__init__.py
@@ -1,14 +1,22 @@
-import warnings
-
 import httpx
 
 from mutx.agent_runtime import (
-    AgentInfo,
-    AgentMetrics,
-    Command,
-    MutxAgentClient,
-    MutxAgentSyncClient,
-    create_agent_client,
+    AgentInfo as AgentInfo,
+)
+from mutx.agent_runtime import (
+    AgentMetrics as AgentMetrics,
+)
+from mutx.agent_runtime import (
+    Command as Command,
+)
+from mutx.agent_runtime import (
+    MutxAgentClient as MutxAgentClient,
+)
+from mutx.agent_runtime import (
+    MutxAgentSyncClient as MutxAgentSyncClient,
+)
+from mutx.agent_runtime import (
+    create_agent_client as create_agent_client,
 )
 from mutx.agents import Agents
 from mutx.analytics import Analytics
@@ -20,7 +28,8 @@ from mutx.deployments import Deployments
 from mutx.governance_credentials import GovernanceCredentials
 from mutx.governance_supervision import GovernanceSupervision
 from mutx.ingest import Ingest
-from mutx.leads import Contacts, Leads
+from mutx.leads import Contacts as Contacts
+from mutx.leads import Leads
 from mutx.newsletter import Newsletter
 from mutx.observability import Observability
 from mutx.onboarding import Onboarding


### PR DESCRIPTION
## Summary
Fix F401 (imported but unused) lint errors in `sdk/mutx/__init__.py` by using explicit re-export syntax (`X as X`).

Fixed symbols:
- AgentInfo, AgentMetrics, Command, MutxAgentClient, MutxAgentSyncClient, create_agent_client, Contacts

Also removes unused `import warnings`.

## Effect
Once merged, unblocks:
- PR #1229 (xmldom dep bump)
- PR #1219 (pygments dep bump)
- Main branch CI