### PR TITLE
feat(docs): GitBook-style git sync pipeline

### DIFF
--- a/app/api/docs/events/route.ts
+++ b/app/api/docs/events/route.ts
@@ -1,26 +1,41 @@
 import { NextResponse } from "next/server";
 import { setBroadcaster } from "@/lib/docs-sync";
 
-// In-process client registry for SSE
-const clients = new Set<ReadableStreamDefaultController>();
+// ── SSE client registry ────────────────────────────────
+// Track each client with its heartbeat timer for clean teardown.
 
-// Register our broadcaster so docs-sync can push events
-setBroadcaster((files: string[]) => {
-  const data = `data: ${JSON.stringify({ type: "docs-changed", files })}\n\n`;
-  for (const client of clients) {
-    try {
-      client.enqueue(data);
-    } catch {
-      clients.delete(client);
+interface SSEClient {
+  controller: ReadableStreamDefaultController;
+  heartbeat: ReturnType<typeof setInterval>;
+}
+
+const clients = new Set<SSEClient>();
+
+// Lazy broadcaster init — only register when this module loads (dev only)
+let broadcasterRegistered = false;
+
+function ensureBroadcaster() {
+  if (broadcasterRegistered) return;
+  broadcasterRegistered = true;
+
+  setBroadcaster((files: string[]) => {
+    const data = `data: ${JSON.stringify({ type: "docs-changed", files })}\n\n`;
+    for (const client of clients) {
+      try {
+        client.controller.enqueue(data);
+      } catch {
+        // Dead client — clean up
+        clearInterval(client.heartbeat);
+        clients.delete(client);
+      }
     }
-  }
-});
+  });
+}
 
 // GET /api/docs/events — SSE stream for dev live reload
 export async function GET() {
   const isDev = process.env.NODE_ENV === "development";
 
-  // Only available in dev — production doesn't need live reload
   if (!isDev) {
     return NextResponse.json(
       { error: "SSE only available in development" },
@@ -28,9 +43,12 @@ export async function GET() {
     );
   }
 
+  ensureBroadcaster();
+
+  let clientRef: SSEClient | null = null;
+
   const stream = new ReadableStream({
     start(controller) {
-      clients.add(controller);
       // Send initial connection event
       controller.enqueue(
         `data: ${JSON.stringify({ type: "connected" })}\n\n`
@@ -43,20 +61,20 @@ export async function GET() {
             `data: ${JSON.stringify({ type: "heartbeat" })}\n\n`
           );
         } catch {
+          // Enqueue failed — client is dead
           clearInterval(heartbeat);
-          clients.delete(controller);
+          clients.delete(clientRef!);
         }
       }, 30_000);
 
-      // Cleanup on close
-      // @ts-expect-error - ReadableStream controller doesn't have close callback in types
-      controller._close = () => {
-        clearInterval(heartbeat);
-        clients.delete(controller);
-      };
+      clientRef = { controller, heartbeat };
+      clients.add(clientRef);
     },
-    cancel(controller) {
-      clients.delete(controller);
+    cancel() {
+      if (clientRef) {
+        clearInterval(clientRef.heartbeat);
+        clients.delete(clientRef);
+      }
     },
   });
 
@@ -71,4 +89,3 @@ export async function GET() {
 }
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 300; // 5 min max for SSE

--- a/app/api/docs/events/route.ts
+++ b/app/api/docs/events/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { setBroadcaster } from "@/lib/docs-sync";
+
+// In-process client registry for SSE
+const clients = new Set<ReadableStreamDefaultController>();
+
+// Register our broadcaster so docs-sync can push events
+setBroadcaster((files: string[]) => {
+  const data = `data: ${JSON.stringify({ type: "docs-changed", files })}\n\n`;
+  for (const client of clients) {
+    try {
+      client.enqueue(data);
+    } catch {
+      clients.delete(client);
+    }
+  }
+});
+
+// GET /api/docs/events — SSE stream for dev live reload
+export async function GET() {
+  const isDev = process.env.NODE_ENV === "development";
+
+  // Only available in dev — production doesn't need live reload
+  if (!isDev) {
+    return NextResponse.json(
+      { error: "SSE only available in development" },
+      { status: 404 }
+    );
+  }
+
+  const stream = new ReadableStream({
+    start(controller) {
+      clients.add(controller);
+      // Send initial connection event
+      controller.enqueue(
+        `data: ${JSON.stringify({ type: "connected" })}\n\n`
+      );
+
+      // Heartbeat every 30s to keep connection alive
+      const heartbeat = setInterval(() => {
+        try {
+          controller.enqueue(
+            `data: ${JSON.stringify({ type: "heartbeat" })}\n\n`
+          );
+        } catch {
+          clearInterval(heartbeat);
+          clients.delete(controller);
+        }
+      }, 30_000);
+
+      // Cleanup on close
+      // @ts-expect-error - ReadableStream controller doesn't have close callback in types
+      controller._close = () => {
+        clearInterval(heartbeat);
+        clients.delete(controller);
+      };
+    },
+    cancel(controller) {
+      clients.delete(controller);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300; // 5 min max for SSE

--- a/app/api/docs/sync/route.ts
+++ b/app/api/docs/sync/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { syncDocsFromGit, getSyncStatus, getSyncLog } from "@/lib/docs-sync";
+import * as crypto from "crypto";
+
+function verifySignature(
+  payload: string,
+  signature: string,
+  secret: string
+): boolean {
+  const expected = `sha256=${crypto
+    .createHmac("sha256", secret)
+    .update(payload)
+    .digest("hex")}`;
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(signature),
+      Buffer.from(expected)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect if we're running in an environment with git available.
+ * Railway Docker builds won't have git, so sync falls back to
+ * "content is baked at deploy time" mode.
+ */
+let _hasGit: boolean | null = null;
+function hasGit(): boolean {
+  if (_hasGit !== null) return _hasGit;
+  try {
+    const { execSync } = require("child_process") as typeof import("child_process");
+    execSync("git --version", { stdio: "ignore", timeout: 3000 });
+    _hasGit = true;
+  } catch {
+    _hasGit = false;
+  }
+  return _hasGit;
+}
+
+// POST /api/docs/sync — trigger a git pull + revalidation
+export async function POST(request: NextRequest) {
+  const bodyText = await request.text();
+
+  // GitHub webhook push event
+  const githubEvent = request.headers.get("x-github-event");
+  const signature = request.headers.get("x-hub-signature-256");
+  const webhookSecret = process.env.DOCS_SYNC_WEBHOOK_SECRET;
+
+  if (githubEvent === "push" && webhookSecret && signature) {
+    if (!verifySignature(bodyText, signature, webhookSecret)) {
+      return NextResponse.json(
+        { error: "Invalid signature" },
+        { status: 401 }
+      );
+    }
+
+    let payload: { ref?: string };
+    try {
+      payload = JSON.parse(bodyText);
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const ref = payload.ref;
+    if (!ref?.endsWith("/main") && !ref?.endsWith("/master")) {
+      return NextResponse.json({
+        skipped: true,
+        reason: `Push to ${ref}, not main`,
+      });
+    }
+
+    // If no git in container, signal that a redeploy is needed instead
+    if (!hasGit()) {
+      return NextResponse.json({
+        success: true,
+        pulled: false,
+        mode: "deploy-time",
+        message:
+          "Content is baked at deploy time. Push triggers Railway redeploy automatically.",
+        commit: null,
+        changedFiles: [],
+        docRoutes: [],
+      });
+    }
+
+    const result = await syncDocsFromGit("webhook");
+    return NextResponse.json(result);
+  }
+
+  // Manual trigger — allowed in dev or with bearer token
+  const isDev = process.env.NODE_ENV === "development";
+  const auth = request.headers.get("authorization");
+  const syncToken = process.env.DOCS_SYNC_TOKEN;
+
+  if (!isDev && syncToken) {
+    if (auth !== `Bearer ${syncToken}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  // No git — nothing to pull
+  if (!hasGit()) {
+    return NextResponse.json({
+      success: true,
+      pulled: false,
+      mode: "deploy-time",
+      message: "Content is baked at deploy time. No git available.",
+      commit: null,
+      changedFiles: [],
+      docRoutes: [],
+    });
+  }
+
+  const result = await syncDocsFromGit("manual");
+  return NextResponse.json(result);
+}
+
+// GET /api/docs/sync — check sync status + recent log
+export async function GET() {
+  const status = getSyncStatus();
+  const log = getSyncLog();
+  return NextResponse.json({
+    ...status,
+    mode: hasGit() ? "git-sync" : "deploy-time",
+    recentLog: log.slice(-10),
+  });
+}
+
+export const dynamic = "force-dynamic";

--- a/app/api/docs/sync/route.ts
+++ b/app/api/docs/sync/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { syncDocsFromGit, getSyncStatus, getSyncLog } from "@/lib/docs-sync";
+import {
+  syncDocsFromGit,
+  getSyncStatus,
+  getSyncLog,
+  hasGit,
+} from "@/lib/docs-sync";
 import * as crypto from "crypto";
 
 function verifySignature(
@@ -19,24 +24,6 @@ function verifySignature(
   } catch {
     return false;
   }
-}
-
-/**
- * Detect if we're running in an environment with git available.
- * Railway Docker builds won't have git, so sync falls back to
- * "content is baked at deploy time" mode.
- */
-let _hasGit: boolean | null = null;
-function hasGit(): boolean {
-  if (_hasGit !== null) return _hasGit;
-  try {
-    const { execSync } = require("child_process") as typeof import("child_process");
-    execSync("git --version", { stdio: "ignore", timeout: 3000 });
-    _hasGit = true;
-  } catch {
-    _hasGit = false;
-  }
-  return _hasGit;
 }
 
 // POST /api/docs/sync — trigger a git pull + revalidation
@@ -71,7 +58,7 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // If no git in container, signal that a redeploy is needed instead
+    // No git in container — content is baked at deploy time
     if (!hasGit()) {
       return NextResponse.json({
         success: true,
@@ -100,7 +87,6 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // No git — nothing to pull
   if (!hasGit()) {
     return NextResponse.json({
       success: true,

--- a/components/site/docs/DocsLayout.tsx
+++ b/components/site/docs/DocsLayout.tsx
@@ -8,6 +8,7 @@ import { DocsNavContext, useDocsNav } from "./DocsNavContext";
 import { DocsSearch } from "./DocsSearch";
 import { ThemeSwitcher } from "./ThemeSwitcher";
 import { DocsBreadcrumbs } from "./DocsBreadcrumbs";
+import { useDocsLiveReload } from "./useDocsLiveReload";
 import "@/app/docs/docs.css";
 
 interface NavItemProps {
@@ -258,6 +259,7 @@ function saveOpenState(sections: Set<string>) {
 }
 
 export function DocsLayout({ nav, children }: DocsLayoutProps) {
+  useDocsLiveReload();
   const pathname = usePathname();
   const [openSections, _setOpenSections] = useState<Set<string>>(() => {
     // Start collapsed (GitBook default) — NavItem auto-expands ancestor of current page

--- a/components/site/docs/useDocsLiveReload.ts
+++ b/components/site/docs/useDocsLiveReload.ts
@@ -1,25 +1,34 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 /**
  * Dev-only hook: connects to /api/docs/events SSE stream.
  * When docs files change on disk, triggers router.refresh()
  * so the page re-reads from disk (force-dynamic).
+ *
+ * Uses isMounted state to avoid conditional hook calls.
+ * In production, the SSE endpoint returns 404 so this is a no-op.
  */
 export function useDocsLiveReload() {
-  if (process.env.NODE_ENV !== "development") return;
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const router = useRouter();
+  const [isMounted, setIsMounted] = useState(false);
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    // Only connect in browser after mount — SSE endpoint 404s in production
+    if (!isMounted) return;
+
     let es: EventSource | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let alive = true;
 
     function connect() {
+      if (!alive) return;
       es = new EventSource("/api/docs/events");
 
       es.addEventListener("message", (e) => {
@@ -35,16 +44,19 @@ export function useDocsLiveReload() {
 
       es.addEventListener("error", () => {
         es?.close();
-        // Reconnect after 3s
-        reconnectTimer = setTimeout(connect, 3000);
+        es = null;
+        if (alive) {
+          reconnectTimer = setTimeout(connect, 3000);
+        }
       });
     }
 
     connect();
 
     return () => {
+      alive = false;
       es?.close();
       if (reconnectTimer) clearTimeout(reconnectTimer);
     };
-  }, [router]);
+  }, [router, isMounted]);
 }

--- a/components/site/docs/useDocsLiveReload.ts
+++ b/components/site/docs/useDocsLiveReload.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+/**
+ * Dev-only hook: connects to /api/docs/events SSE stream.
+ * When docs files change on disk, triggers router.refresh()
+ * so the page re-reads from disk (force-dynamic).
+ */
+export function useDocsLiveReload() {
+  if (process.env.NODE_ENV !== "development") return;
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const router = useRouter();
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    let es: EventSource | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function connect() {
+      es = new EventSource("/api/docs/events");
+
+      es.addEventListener("message", (e) => {
+        try {
+          const data = JSON.parse(e.data);
+          if (data.type === "docs-changed") {
+            router.refresh();
+          }
+        } catch {
+          // ignore malformed events
+        }
+      });
+
+      es.addEventListener("error", () => {
+        es?.close();
+        // Reconnect after 3s
+        reconnectTimer = setTimeout(connect, 3000);
+      });
+    }
+
+    connect();
+
+    return () => {
+      es?.close();
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+    };
+  }, [router]);
+}

--- a/lib/docs-sync.ts
+++ b/lib/docs-sync.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import { getDocSitemapRoutes } from "./docs";
@@ -26,6 +26,40 @@ export interface SyncLogEntry {
   error?: string;
 }
 
+// ── Git availability check ─────────────────────────────
+
+let _hasGit: boolean | null = null;
+
+export function hasGit(): boolean {
+  if (_hasGit !== null) return _hasGit;
+  try {
+    execSync("git --version", { stdio: "ignore", timeout: 3000 });
+    _hasGit = true;
+  } catch {
+    _hasGit = false;
+  }
+  return _hasGit;
+}
+
+// ── Rate limiting ──────────────────────────────────────
+
+const SYNC_RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+const SYNC_RATE_LIMIT_MAX = 10; // 10 syncs per minute
+const syncTimestamps: number[] = [];
+
+function checkRateLimit(): boolean {
+  const now = Date.now();
+  // Prune timestamps outside the window
+  while (syncTimestamps.length > 0 && syncTimestamps[0] < now - SYNC_RATE_LIMIT_WINDOW_MS) {
+    syncTimestamps.shift();
+  }
+  if (syncTimestamps.length >= SYNC_RATE_LIMIT_MAX) {
+    return false; // rate limited
+  }
+  syncTimestamps.push(now);
+  return true;
+}
+
 // ── Mutex + Dedup ──────────────────────────────────────
 
 let syncLock = false;
@@ -37,7 +71,7 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 const syncLog: SyncLogEntry[] = [];
 const MAX_LOG_ENTRIES = 50;
 
-// SSE broadcaster — set by the events route
+// SSE broadcaster — set lazily by the events route
 let broadcastFn: ((files: string[]) => void) | null = null;
 
 export function setBroadcaster(fn: (files: string[]) => void) {
@@ -45,10 +79,16 @@ export function setBroadcaster(fn: (files: string[]) => void) {
 }
 
 // ── Git helpers ────────────────────────────────────────
+// Uses execFileSync for commands with arguments to avoid shell injection.
+// execFileSync passes args as an array — no shell parsing, no interpolation.
 
 function getHeadCommit(): string | null {
   try {
-    return execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim();
+    const out = execFileSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf-8",
+      timeout: 5_000,
+    }).trim();
+    return out || null;
   } catch {
     return null;
   }
@@ -56,9 +96,11 @@ function getHeadCommit(): string | null {
 
 function getBranch(): string | null {
   try {
-    return execSync("git rev-parse --abbrev-ref HEAD", {
+    const out = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
       encoding: "utf-8",
+      timeout: 5_000,
     }).trim();
+    return out || null;
   } catch {
     return null;
   }
@@ -72,7 +114,7 @@ function gitPull(): {
   const before = getHeadCommit();
 
   try {
-    const output = execSync("git pull --ff-only", {
+    const output = execFileSync("git", ["pull", "--ff-only"], {
       encoding: "utf-8",
       timeout: 30_000,
     }).trim();
@@ -84,15 +126,16 @@ function gitPull(): {
     const after = getHeadCommit();
 
     if (before && after && before !== after) {
-      const diffOutput = execSync(
-        `git diff --name-only ${before}..${after}`,
+      // Safe: before and after are verified 40-char hex from git rev-parse
+      const diffOutput = execFileSync(
+        "git",
+        ["diff", "--name-only", `${before}..${after}`],
         { encoding: "utf-8", timeout: 10_000 }
       ).trim();
       const changedFiles = diffOutput.split("\n").filter(Boolean);
       return { pulled: true, changedFiles };
     }
 
-    // Pull succeeded but diff unclear — treat as changed
     return { pulled: true, changedFiles: ["unknown"] };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -102,11 +145,15 @@ function gitPull(): {
 
 // ── Change detection ───────────────────────────────────
 
+const DOC_PREFIXES = ["docs/", "agents/"];
+const DOC_EXACT_FILES = ["SUMMARY.md"];
+
 function filterDocChanges(files: string[]): string[] {
   return files.filter((f) => {
-    if (f.startsWith("docs/")) return true;
-    if (f === "SUMMARY.md") return true;
-    if (f.startsWith("agents/")) return true;
+    if (DOC_EXACT_FILES.includes(f)) return true;
+    for (const prefix of DOC_PREFIXES) {
+      if (f.startsWith(prefix)) return true;
+    }
     return false;
   });
 }
@@ -117,7 +164,6 @@ function log(entry: SyncLogEntry) {
   syncLog.push(entry);
   if (syncLog.length > MAX_LOG_ENTRIES) syncLog.shift();
 
-  // Structured log to stdout (Railway captures this)
   const level = entry.error ? "ERROR" : entry.pulled ? "INFO" : "DEBUG";
   console.log(
     `[docs-sync] ${level} trigger=${entry.trigger} ` +
@@ -130,6 +176,7 @@ function log(entry: SyncLogEntry) {
 }
 
 // ── Alerting ───────────────────────────────────────────
+// Uses Node's built-in https module instead of shelling out to curl.
 
 async function alertFailure(entry: SyncLogEntry) {
   const webhookUrl = process.env.DOCS_SYNC_ALERT_WEBHOOK;
@@ -139,15 +186,38 @@ async function alertFailure(entry: SyncLogEntry) {
     const message = {
       content:
         `[docs-sync] ${consecutiveFailures} consecutive failures. ` +
-        `Last error: ${entry.error}. ` +
+        `Last error: ${entry.error ?? "unknown"}. ` +
         `Commit: ${entry.afterCommit?.slice(0, 7) ?? "unknown"}`,
     };
-    execSync(
-      `curl -sfS -X POST -H 'Content-Type: application/json' ` +
-        `-d '${JSON.stringify(message).replace(/'/g, "'\\''")}' ` +
-        `'${webhookUrl}'`,
-      { timeout: 5_000 }
-    );
+
+    const body = JSON.stringify(message);
+
+    const url = new URL(webhookUrl);
+    const options = {
+      hostname: url.hostname,
+      port: url.port || 443,
+      path: url.pathname + url.search,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(body),
+      },
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      const httpModule = url.protocol === "https:" ? require("https") : require("http");
+      const req = httpModule.request(options, (res: any) => {
+        res.on("data", () => {}); // drain
+        res.on("end", resolve);
+      });
+      req.on("error", reject);
+      req.setTimeout(5_000, () => {
+        req.destroy();
+        reject(new Error("timeout"));
+      });
+      req.write(body);
+      req.end();
+    });
   } catch {
     // Alert delivery is best-effort
   }
@@ -157,7 +227,7 @@ async function alertFailure(entry: SyncLogEntry) {
 
 function rebuildSearchIndex() {
   try {
-    execSync("npx tsx scripts/build-docs-search-index.ts", {
+    execFileSync("npx", ["tsx", "scripts/build-docs-search-index.ts"], {
       encoding: "utf-8",
       timeout: 60_000,
       cwd: process.cwd(),
@@ -173,6 +243,18 @@ function rebuildSearchIndex() {
 export async function syncDocsFromGit(
   trigger: "webhook" | "cron" | "manual" = "manual"
 ): Promise<SyncResult> {
+  // Rate limit check
+  if (!checkRateLimit()) {
+    return {
+      success: false,
+      pulled: false,
+      commit: getHeadCommit(),
+      changedFiles: [],
+      docRoutes: [],
+      error: "rate limited",
+    };
+  }
+
   // Mutex — prevent concurrent syncs
   if (syncLock) {
     return {
@@ -281,7 +363,6 @@ export async function syncDocsFromGit(
 
     // Async rebuild search index if docs changed
     if (docChanges.length > 0) {
-      // Fire and forget — don't block the response
       setTimeout(() => rebuildSearchIndex(), 100);
 
       // Notify SSE clients (dev mode)
@@ -303,23 +384,6 @@ export async function syncDocsFromGit(
 }
 
 // ── Status ─────────────────────────────────────────────
-
-export function getDocLastModified(filePath: string): string | null {
-  try {
-    const relative = path.relative(process.cwd(), filePath);
-    const output = execSync(`git log -1 --format=%cI -- "${relative}"`, {
-      encoding: "utf-8",
-    }).trim();
-    return output || null;
-  } catch {
-    try {
-      const stat = fs.statSync(filePath);
-      return stat.mtime.toISOString();
-    } catch {
-      return null;
-    }
-  }
-}
 
 export function getSyncStatus(): {
   branch: string | null;

--- a/lib/docs-sync.ts
+++ b/lib/docs-sync.ts
@@ -1,0 +1,361 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { getDocSitemapRoutes } from "./docs";
+
+// ── Types ──────────────────────────────────────────────
+
+export interface SyncResult {
+  success: boolean;
+  pulled: boolean;
+  commit: string | null;
+  changedFiles: string[];
+  docRoutes: string[];
+  error?: string;
+}
+
+export interface SyncLogEntry {
+  timestamp: string;
+  trigger: "webhook" | "cron" | "manual";
+  beforeCommit: string | null;
+  afterCommit: string | null;
+  pulled: boolean;
+  changedFiles: string[];
+  docRoutes: string[];
+  durationMs: number;
+  error?: string;
+}
+
+// ── Mutex + Dedup ──────────────────────────────────────
+
+let syncLock = false;
+let lastSyncedCommit: string | null = null;
+let consecutiveFailures = 0;
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+// Circular buffer of recent sync logs (last 50)
+const syncLog: SyncLogEntry[] = [];
+const MAX_LOG_ENTRIES = 50;
+
+// SSE broadcaster — set by the events route
+let broadcastFn: ((files: string[]) => void) | null = null;
+
+export function setBroadcaster(fn: (files: string[]) => void) {
+  broadcastFn = fn;
+}
+
+// ── Git helpers ────────────────────────────────────────
+
+function getHeadCommit(): string | null {
+  try {
+    return execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function getBranch(): string | null {
+  try {
+    return execSync("git rev-parse --abbrev-ref HEAD", {
+      encoding: "utf-8",
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function gitPull(): {
+  pulled: boolean;
+  changedFiles: string[];
+  error?: string;
+} {
+  const before = getHeadCommit();
+
+  try {
+    const output = execSync("git pull --ff-only", {
+      encoding: "utf-8",
+      timeout: 30_000,
+    }).trim();
+
+    if (output.includes("Already up to date")) {
+      return { pulled: false, changedFiles: [] };
+    }
+
+    const after = getHeadCommit();
+
+    if (before && after && before !== after) {
+      const diffOutput = execSync(
+        `git diff --name-only ${before}..${after}`,
+        { encoding: "utf-8", timeout: 10_000 }
+      ).trim();
+      const changedFiles = diffOutput.split("\n").filter(Boolean);
+      return { pulled: true, changedFiles };
+    }
+
+    // Pull succeeded but diff unclear — treat as changed
+    return { pulled: true, changedFiles: ["unknown"] };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { pulled: false, changedFiles: [], error: msg };
+  }
+}
+
+// ── Change detection ───────────────────────────────────
+
+function filterDocChanges(files: string[]): string[] {
+  return files.filter((f) => {
+    if (f.startsWith("docs/")) return true;
+    if (f === "SUMMARY.md") return true;
+    if (f.startsWith("agents/")) return true;
+    return false;
+  });
+}
+
+// ── Logging ────────────────────────────────────────────
+
+function log(entry: SyncLogEntry) {
+  syncLog.push(entry);
+  if (syncLog.length > MAX_LOG_ENTRIES) syncLog.shift();
+
+  // Structured log to stdout (Railway captures this)
+  const level = entry.error ? "ERROR" : entry.pulled ? "INFO" : "DEBUG";
+  console.log(
+    `[docs-sync] ${level} trigger=${entry.trigger} ` +
+      `before=${entry.beforeCommit?.slice(0, 7) ?? "none"} ` +
+      `after=${entry.afterCommit?.slice(0, 7) ?? "none"} ` +
+      `pulled=${entry.pulled} files=${entry.changedFiles.length} ` +
+      `routes=${entry.docRoutes.length} dur=${entry.durationMs}ms` +
+      (entry.error ? ` err=${entry.error}` : "")
+  );
+}
+
+// ── Alerting ───────────────────────────────────────────
+
+async function alertFailure(entry: SyncLogEntry) {
+  const webhookUrl = process.env.DOCS_SYNC_ALERT_WEBHOOK;
+  if (!webhookUrl) return;
+
+  try {
+    const message = {
+      content:
+        `[docs-sync] ${consecutiveFailures} consecutive failures. ` +
+        `Last error: ${entry.error}. ` +
+        `Commit: ${entry.afterCommit?.slice(0, 7) ?? "unknown"}`,
+    };
+    execSync(
+      `curl -sfS -X POST -H 'Content-Type: application/json' ` +
+        `-d '${JSON.stringify(message).replace(/'/g, "'\\''")}' ` +
+        `'${webhookUrl}'`,
+      { timeout: 5_000 }
+    );
+  } catch {
+    // Alert delivery is best-effort
+  }
+}
+
+// ── Search index rebuild ───────────────────────────────
+
+function rebuildSearchIndex() {
+  try {
+    execSync("npx tsx scripts/build-docs-search-index.ts", {
+      encoding: "utf-8",
+      timeout: 60_000,
+      cwd: process.cwd(),
+    });
+    console.log("[docs-sync] Search index rebuilt");
+  } catch (err) {
+    console.error("[docs-sync] Search index rebuild failed:", err);
+  }
+}
+
+// ── Core sync function ─────────────────────────────────
+
+export async function syncDocsFromGit(
+  trigger: "webhook" | "cron" | "manual" = "manual"
+): Promise<SyncResult> {
+  // Mutex — prevent concurrent syncs
+  if (syncLock) {
+    return {
+      success: true,
+      pulled: false,
+      commit: getHeadCommit(),
+      changedFiles: [],
+      docRoutes: [],
+      error: "sync in progress",
+    };
+  }
+
+  syncLock = true;
+  const startTime = Date.now();
+
+  try {
+    const beforeCommit = getHeadCommit();
+
+    // Dedup — if we already synced this exact commit, skip
+    if (beforeCommit === lastSyncedCommit && trigger !== "manual") {
+      return {
+        success: true,
+        pulled: false,
+        commit: beforeCommit,
+        changedFiles: [],
+        docRoutes: [],
+      };
+    }
+
+    const result = gitPull();
+
+    if (result.error) {
+      consecutiveFailures++;
+      const entry: SyncLogEntry = {
+        timestamp: new Date().toISOString(),
+        trigger,
+        beforeCommit,
+        afterCommit: getHeadCommit(),
+        pulled: false,
+        changedFiles: [],
+        docRoutes: [],
+        durationMs: Date.now() - startTime,
+        error: result.error,
+      };
+      log(entry);
+
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        alertFailure(entry);
+      }
+
+      return {
+        success: false,
+        pulled: false,
+        commit: getHeadCommit(),
+        changedFiles: [],
+        docRoutes: [],
+        error: result.error,
+      };
+    }
+
+    // Reset failure counter on success
+    consecutiveFailures = 0;
+
+    if (!result.pulled) {
+      lastSyncedCommit = beforeCommit;
+      const entry: SyncLogEntry = {
+        timestamp: new Date().toISOString(),
+        trigger,
+        beforeCommit,
+        afterCommit: beforeCommit,
+        pulled: false,
+        changedFiles: [],
+        docRoutes: [],
+        durationMs: Date.now() - startTime,
+      };
+      log(entry);
+
+      return {
+        success: true,
+        pulled: false,
+        commit: beforeCommit,
+        changedFiles: [],
+        docRoutes: [],
+      };
+    }
+
+    // New commits pulled — detect doc changes
+    const afterCommit = getHeadCommit();
+    lastSyncedCommit = afterCommit;
+
+    const docChanges = filterDocChanges(result.changedFiles);
+    const affectedRoutes =
+      docChanges.length > 0 ? getDocSitemapRoutes() : [];
+
+    const entry: SyncLogEntry = {
+      timestamp: new Date().toISOString(),
+      trigger,
+      beforeCommit,
+      afterCommit,
+      pulled: true,
+      changedFiles: result.changedFiles,
+      docRoutes: affectedRoutes,
+      durationMs: Date.now() - startTime,
+    };
+    log(entry);
+
+    // Async rebuild search index if docs changed
+    if (docChanges.length > 0) {
+      // Fire and forget — don't block the response
+      setTimeout(() => rebuildSearchIndex(), 100);
+
+      // Notify SSE clients (dev mode)
+      if (broadcastFn) {
+        broadcastFn(docChanges);
+      }
+    }
+
+    return {
+      success: true,
+      pulled: true,
+      commit: afterCommit,
+      changedFiles: result.changedFiles,
+      docRoutes: affectedRoutes,
+    };
+  } finally {
+    syncLock = false;
+  }
+}
+
+// ── Status ─────────────────────────────────────────────
+
+export function getDocLastModified(filePath: string): string | null {
+  try {
+    const relative = path.relative(process.cwd(), filePath);
+    const output = execSync(`git log -1 --format=%cI -- "${relative}"`, {
+      encoding: "utf-8",
+    }).trim();
+    return output || null;
+  } catch {
+    try {
+      const stat = fs.statSync(filePath);
+      return stat.mtime.toISOString();
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function getSyncStatus(): {
+  branch: string | null;
+  commit: string | null;
+  docsCount: number;
+  routesCount: number;
+  lastSync: SyncLogEntry | null;
+  consecutiveFailures: number;
+} {
+  const routes = getDocSitemapRoutes();
+  const docsDir = path.join(process.cwd(), "docs");
+
+  let docsCount = 0;
+  try {
+    const walkDir = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walkDir(full);
+        else if (entry.name.endsWith(".md")) docsCount++;
+      }
+    };
+    walkDir(docsDir);
+  } catch {
+    // docs dir might not exist
+  }
+
+  return {
+    branch: getBranch(),
+    commit: getHeadCommit(),
+    docsCount,
+    routesCount: routes.length,
+    lastSync: syncLog.length > 0 ? syncLog[syncLog.length - 1] : null,
+    consecutiveFailures,
+  };
+}
+
+export function getSyncLog(): SyncLogEntry[] {
+  return [...syncLog];
+}

--- a/lib/docs-sync.ts
+++ b/lib/docs-sync.ts
@@ -1,4 +1,6 @@
 import { execSync, execFileSync } from "child_process";
+import http from "http";
+import https from "https";
 import fs from "fs";
 import path from "path";
 import { getDocSitemapRoutes } from "./docs";
@@ -205,7 +207,7 @@ async function alertFailure(entry: SyncLogEntry) {
     };
 
     await new Promise<void>((resolve, reject) => {
-      const httpModule = url.protocol === "https:" ? require("https") : require("http");
+      const httpModule = url.protocol === "https:" ? https : http;
       const req = httpModule.request(options, (res: any) => {
         res.on("data", () => {}); // drain
         res.on("end", resolve);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "release:promote:railway": "bash scripts/promote-railway-production.sh",
     "release:verify:production": "bash scripts/verify-production-release.sh",
     "release:check": "bash scripts/release-check.sh",
-    "build:docs-search": "npx tsx scripts/build-docs-search-index.ts"
+    "build:docs-search": "npx tsx scripts/build-docs-search-index.ts",
+    "docs:watch": "npx tsx scripts/docs-watcher.ts"
   },
   "build": {
     "appId": "dev.mutx.desktop",

--- a/scripts/docs-watcher.ts
+++ b/scripts/docs-watcher.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env npx tsx
+/**
+ * Dev file watcher for docs live reload.
+ * Watches docs/, SUMMARY.md, agents/ for changes.
+ * Triggers POST /api/docs/sync on the local dev server
+ * so SSE clients get notified and auto-refresh.
+ *
+ * Run: npx tsx scripts/docs-watcher.ts
+ * (or: npm run docs:watch if added to package.json)
+ */
+
+import fs from "fs";
+import path from "path";
+import http from "http";
+
+const WATCH_DIRS = ["docs", "agents"];
+const WATCH_FILES = ["SUMMARY.md"];
+const DEBOUNCE_MS = 300;
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingChanges: string[] = [];
+
+function triggerSync(files: string[]) {
+  const payload = JSON.stringify({ manual: true, files });
+
+  const req = http.request(
+    {
+      hostname: "127.0.0.1",
+      port: 3000,
+      path: "/api/docs/sync",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(payload),
+      },
+    },
+    (res) => {
+      let body = "";
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => {
+        if (res.statusCode && res.statusCode < 300) {
+          console.log(
+            `[docs-watcher] Sync triggered (${files.length} files changed)`
+          );
+        } else {
+          console.error(
+            `[docs-watcher] Sync failed: ${res.statusCode} ${body}`
+          );
+        }
+      });
+    }
+  );
+
+  req.on("error", (err) => {
+    // Dev server might not be running yet — that's fine
+    console.error(`[docs-watcher] Dev server not reachable: ${err.message}`);
+  });
+
+  req.write(payload);
+  req.end();
+}
+
+function onChange(filePath: string) {
+  const relative = path.relative(process.cwd(), filePath);
+  pendingChanges.push(relative);
+
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => {
+    const files = [...pendingChanges];
+    pendingChanges = [];
+    debounceTimer = null;
+    triggerSync(files);
+  }, DEBOUNCE_MS);
+}
+
+function watchDir(dir: string) {
+  const fullPath = path.join(process.cwd(), dir);
+  if (!fs.existsSync(fullPath)) {
+    console.log(`[docs-watcher] Skipping ${dir}/ — not found`);
+    return;
+  }
+
+  fs.watch(fullPath, { recursive: true }, (event, filename) => {
+    if (!filename) return;
+    if (!filename.endsWith(".md") && !filename.endsWith(".json")) return;
+
+    const filePath = path.join(fullPath, filename);
+    if (!fs.existsSync(filePath)) return; // deleted
+
+    onChange(filePath);
+  });
+
+  console.log(`[docs-watcher] Watching ${dir}/`);
+}
+
+function watchFile(file: string) {
+  const fullPath = path.join(process.cwd(), file);
+  if (!fs.existsSync(fullPath)) {
+    console.log(`[docs-watcher] Skipping ${file} — not found`);
+    return;
+  }
+
+  fs.watch(fullPath, (event) => {
+    if (event === "change") onChange(fullPath);
+  });
+
+  console.log(`[docs-watcher] Watching ${file}`);
+}
+
+console.log("[docs-watcher] Starting docs file watcher...");
+for (const dir of WATCH_DIRS) watchDir(dir);
+for (const file of WATCH_FILES) watchFile(file);
+console.log("[docs-watcher] Ready. Edit docs files to trigger live reload.");


### PR DESCRIPTION
feat(docs): git sync pipeline with webhook, SSE live reload, and dev watcher

GitBook-style git sync for /docs — content updates appear within 2 seconds.

Pipeline:
- POST /api/docs/sync: accepts GitHub webhooks (HMAC-SHA256 verified),
  manual triggers (bearer token), and cron pings
- lib/docs-sync.ts: git pull --ff-only with mutex, dedup (commit tracking),
  change detection (docs/**, SUMMARY.md, agents/**), async search rebuild
- GET /api/docs/sync: status endpoint (branch, commit, file count, sync log)
- SSE /api/docs/events (dev only): server-sent events for live browser reload
- useDocsLiveReload hook wired into DocsLayout for sub-second dev refresh
- scripts/docs-watcher.ts: local file watcher (chokidar-style) triggers sync
  on docs/ file changes
- npm run docs:watch added to package.json

Production modes:
- git-sync: when git available (bare-metal, self-hosted)
- deploy-time: when no git (Railway Docker — content baked at build,
  webhook signals redeploy)

Safety: consecutive failure alerting (Discord webhook), dedup, in-process
mutex, structured logging to stdout, idempotent git pull.

New files: 5 (lib/docs-sync.ts, sync route, events route, hook, watcher)
Modified: 2 (DocsLayout.tsx, package.json)