### PR TITLE
feat(pico): premium landing page redesign

### DIFF
--- a/components/site/pico/PicoLanding.module.css
+++ b/components/site/pico/PicoLanding.module.css
@@ -1,0 +1,842 @@
+/* ===================================================================
+   PicoMUTX Landing Page — Premium Design System
+   =================================================================== */
+
+/* --- Design tokens ------------------------------------------------ */
+:root {
+  --pico-bg: #07080c;
+  --pico-bg-raised: #0d0f15;
+  --pico-bg-surface: rgba(255, 255, 255, 0.03);
+  --pico-bg-surface-hover: rgba(255, 255, 255, 0.06);
+  --pico-text: #eef0f6;
+  --pico-text-secondary: rgba(238, 240, 246, 0.68);
+  --pico-text-muted: rgba(238, 240, 246, 0.38);
+  --pico-border: rgba(238, 240, 246, 0.08);
+  --pico-border-hover: rgba(238, 240, 246, 0.16);
+  --pico-accent: #4ade80;
+  --pico-accent-soft: rgba(74, 222, 128, 0.12);
+  --pico-accent-glow: rgba(74, 222, 128, 0.06);
+  --pico-blue: #4b8dff;
+  --pico-blue-soft: rgba(75, 141, 255, 0.12);
+  --pico-blue-glow: rgba(75, 141, 255, 0.06);
+  --pico-red: #ef4444;
+  --pico-red-soft: rgba(239, 68, 68, 0.1);
+  --pico-font-accent: var(--font-marketing-accent), sans-serif;
+  --pico-font-display: var(--font-marketing-display), serif;
+  --pico-font-body: var(--font-marketing-sans), sans-serif;
+  --pico-radius-sm: 0.75rem;
+  --pico-radius: 1.2rem;
+  --pico-radius-lg: 1.6rem;
+  --pico-radius-full: 999px;
+  --pico-shell: min(100% - 2.5rem, 72rem);
+}
+
+/* --- Page shell --------------------------------------------------- */
+.page {
+  position: relative;
+  min-height: 100vh;
+  background: var(--pico-bg);
+  color: var(--pico-text);
+  font-family: var(--pico-font-body);
+  overflow-x: hidden;
+}
+
+.page *,
+.page *::before,
+.page *::after {
+  box-sizing: border-box;
+}
+
+.page a {
+  color: inherit;
+}
+
+.shell {
+  width: var(--pico-shell);
+  margin: 0 auto;
+}
+
+.main {
+  display: block;
+  position: relative;
+}
+
+/* --- Navigation --------------------------------------------------- */
+.nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 40;
+  padding: 0;
+  background: rgba(7, 8, 12, 0.72);
+  backdrop-filter: blur(16px) saturate(1.4);
+  border-bottom: 1px solid var(--pico-border);
+}
+
+.navInner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: var(--pico-shell);
+  margin: 0 auto;
+  min-height: 3.6rem;
+}
+
+.navBrand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  text-decoration: none;
+}
+
+.navLogo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.5rem;
+  background: linear-gradient(135deg, rgba(74, 222, 128, 0.16), rgba(75, 141, 255, 0.16));
+  border: 1px solid var(--pico-border);
+}
+
+.navLogo img {
+  width: 1.2rem;
+  height: 1.2rem;
+  object-fit: contain;
+}
+
+.navName {
+  font-family: var(--pico-font-accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--pico-text);
+}
+
+.navTag {
+  display: none;
+}
+
+@media (min-width: 640px) {
+  .navTag {
+    display: inline;
+    font-family: var(--pico-font-body);
+    font-size: 0.82rem;
+    color: var(--pico-text-muted);
+    font-weight: 400;
+    letter-spacing: 0;
+    text-transform: none;
+    margin-left: 0.2rem;
+  }
+}
+
+.navCta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 2.2rem;
+  padding: 0 1rem;
+  border-radius: var(--pico-radius-full);
+  background: linear-gradient(135deg, #4ade80, #22c55e);
+  color: #052e16;
+  font-family: var(--pico-font-body);
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+  box-shadow: 0 8px 24px rgba(74, 222, 128, 0.18);
+}
+
+.navCta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 32px rgba(74, 222, 128, 0.24);
+}
+
+/* --- Hero --------------------------------------------------------- */
+.hero {
+  position: relative;
+  min-height: max(100dvh, 48rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding-top: 5rem;
+  overflow: clip;
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 20%, rgba(74, 222, 128, 0.08), transparent),
+    radial-gradient(ellipse 60% 50% at 70% 10%, rgba(75, 141, 255, 0.06), transparent),
+    var(--pico-bg);
+}
+
+.heroGrid {
+  position: relative;
+  z-index: 1;
+  width: var(--pico-shell);
+  margin: 0 auto;
+  padding: clamp(5rem, 10vh, 8rem) 0 clamp(4rem, 8vh, 6rem);
+  display: grid;
+  gap: 1.4rem;
+  justify-items: center;
+  max-width: 42rem;
+}
+
+.heroBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 2rem;
+  padding: 0 1rem;
+  border-radius: var(--pico-radius-full);
+  border: 1px solid var(--pico-border);
+  background: var(--pico-bg-surface);
+  font-family: var(--pico-font-accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pico-accent);
+}
+
+.heroBadgeDot {
+  width: 0.35rem;
+  height: 0.35rem;
+  border-radius: 50%;
+  background: var(--pico-accent);
+  box-shadow: 0 0 8px rgba(74, 222, 128, 0.5);
+}
+
+.heroTitle {
+  margin: 0;
+  font-family: var(--pico-font-display);
+  font-size: clamp(2.8rem, 7vw, 4.8rem);
+  font-weight: 300;
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+  max-width: 14ch;
+}
+
+.heroTitleAccent {
+  color: var(--pico-accent);
+}
+
+.heroSub {
+  margin: 0;
+  color: var(--pico-text-secondary);
+  font-size: clamp(1.02rem, 1rem + 0.3vw, 1.18rem);
+  line-height: 1.55;
+  max-width: 32rem;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  align-items: center;
+  justify-content: center;
+  padding-top: 0.4rem;
+}
+
+.heroMeta {
+  margin: 0;
+  color: var(--pico-text-muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
+  max-width: 26rem;
+}
+
+/* --- Buttons ------------------------------------------------------ */
+.btnPrimary {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 3.1rem;
+  padding: 0 1.6rem;
+  border-radius: var(--pico-radius-sm);
+  background: linear-gradient(135deg, #4ade80, #22c55e);
+  color: #052e16;
+  font-family: var(--pico-font-body);
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+  box-shadow:
+    0 0 0 1px rgba(74, 222, 128, 0.2),
+    0 12px 32px rgba(74, 222, 128, 0.18);
+}
+
+.btnPrimary:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    0 0 0 1px rgba(74, 222, 128, 0.3),
+    0 18px 42px rgba(74, 222, 128, 0.24);
+}
+
+.btnSecondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 3.1rem;
+  padding: 0 1.6rem;
+  border-radius: var(--pico-radius-sm);
+  background: var(--pico-bg-surface);
+  color: var(--pico-text);
+  font-family: var(--pico-font-body);
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1;
+  text-decoration: none;
+  border: 1px solid var(--pico-border);
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.btnSecondary:hover {
+  transform: translateY(-1px);
+  background: var(--pico-bg-surface-hover);
+  border-color: var(--pico-border-hover);
+}
+
+/* --- Section shared ---------------------------------------------- */
+.section {
+  padding: clamp(5.5rem, 10vw, 8rem) 0;
+  position: relative;
+}
+
+.sectionDark {
+  background:
+    radial-gradient(ellipse 50% 40% at 20% 30%, rgba(74, 222, 128, 0.04), transparent),
+    var(--pico-bg);
+}
+
+.sectionAlt {
+  background: var(--pico-bg-raised);
+  border-top: 1px solid var(--pico-border);
+  border-bottom: 1px solid var(--pico-border);
+}
+
+.sectionHeader {
+  display: grid;
+  gap: 0.7rem;
+  max-width: 36rem;
+  margin-bottom: clamp(2.5rem, 4vw, 3.5rem);
+}
+
+.sectionHeaderCenter {
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--pico-font-accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pico-accent);
+}
+
+.eyebrowBlue {
+  color: var(--pico-blue);
+}
+
+.sectionTitle {
+  margin: 0;
+  font-family: var(--pico-font-display);
+  font-size: clamp(2rem, 4.5vw, 3.2rem);
+  font-weight: 300;
+  line-height: 1.02;
+  letter-spacing: -0.045em;
+  color: var(--pico-text);
+}
+
+.sectionBody {
+  margin: 0;
+  font-size: clamp(0.98rem, 0.96rem + 0.2vw, 1.1rem);
+  line-height: 1.55;
+  color: var(--pico-text-secondary);
+}
+
+/* --- Before/After cards ------------------------------------------ */
+.baGrid {
+  display: grid;
+  gap: 1rem;
+}
+
+.baCard {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border-radius: var(--pico-radius);
+  border: 1px solid var(--pico-border);
+  background: var(--pico-bg-surface);
+  overflow: hidden;
+  transition: border-color 200ms ease, transform 200ms ease;
+}
+
+.baCard:hover {
+  border-color: var(--pico-border-hover);
+  transform: translateY(-2px);
+}
+
+@media (max-width: 639px) {
+  .baCard {
+    grid-template-columns: 1fr;
+  }
+}
+
+.baSide {
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+  display: grid;
+  gap: 0.4rem;
+  align-content: start;
+}
+
+.baBefore {
+  border-right: 1px solid var(--pico-border);
+}
+
+@media (max-width: 639px) {
+  .baBefore {
+    border-right: none;
+    border-bottom: 1px solid var(--pico-border);
+  }
+}
+
+.baLabel {
+  margin: 0;
+  font-family: var(--pico-font-accent);
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.baLabelBefore {
+  color: var(--pico-red);
+}
+
+.baLabelAfter {
+  color: var(--pico-accent);
+}
+
+.baText {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.52;
+  color: var(--pico-text-secondary);
+}
+
+.baTextAfter {
+  color: var(--pico-text);
+  font-weight: 600;
+}
+
+/* --- Feature grid ------------------------------------------------ */
+.featureGrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+@media (min-width: 768px) {
+  .featureGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.featureCard {
+  display: grid;
+  gap: 0.6rem;
+  padding: clamp(1.3rem, 3vw, 1.8rem);
+  border-radius: var(--pico-radius);
+  border: 1px solid var(--pico-border);
+  background: var(--pico-bg-surface);
+  transition: border-color 200ms ease, background 200ms ease, transform 200ms ease;
+}
+
+.featureCard:hover {
+  border-color: var(--pico-border-hover);
+  background: var(--pico-bg-surface-hover);
+  transform: translateY(-2px);
+}
+
+.featureNum {
+  margin: 0;
+  font-family: var(--pico-font-accent);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--pico-accent);
+  opacity: 0.7;
+}
+
+.featureTitle {
+  margin: 0;
+  font-family: var(--pico-font-body);
+  font-size: clamp(1.1rem, 1.8vw, 1.4rem);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  color: var(--pico-text);
+}
+
+.featureBody {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: var(--pico-text-secondary);
+}
+
+/* --- Pricing ----------------------------------------------------- */
+.pricingGrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+@media (min-width: 768px) {
+  .pricingGrid {
+    grid-template-columns: repeat(3, 1fr);
+    align-items: start;
+  }
+}
+
+.pricingCard {
+  display: grid;
+  gap: 0.85rem;
+  padding: clamp(1.4rem, 3vw, 2rem);
+  border-radius: var(--pico-radius-lg);
+  border: 1px solid var(--pico-border);
+  background: var(--pico-bg-surface);
+  position: relative;
+  transition: border-color 200ms ease, transform 200ms ease;
+}
+
+.pricingCard:hover {
+  border-color: var(--pico-border-hover);
+  transform: translateY(-2px);
+}
+
+.pricingCardRecommended {
+  border-color: rgba(74, 222, 128, 0.3);
+  background:
+    linear-gradient(180deg, rgba(74, 222, 128, 0.04), var(--pico-bg-surface));
+  box-shadow:
+    0 0 0 1px rgba(74, 222, 128, 0.08),
+    0 20px 50px rgba(74, 222, 128, 0.06);
+}
+
+.pricingBadge {
+  position: absolute;
+  top: -0.7rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.5rem;
+  padding: 0 0.8rem;
+  border-radius: var(--pico-radius-full);
+  background: var(--pico-accent);
+  color: #052e16;
+  font-family: var(--pico-font-accent);
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.pricingName {
+  margin: 0;
+  font-family: var(--pico-font-accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pico-text-muted);
+}
+
+.pricingPrice {
+  display: flex;
+  align-items: baseline;
+  gap: 0.2rem;
+}
+
+.pricingAmount {
+  font-family: var(--pico-font-display);
+  font-size: clamp(2rem, 3.5vw, 2.8rem);
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: var(--pico-text);
+}
+
+.pricingPeriod {
+  font-size: 0.88rem;
+  color: var(--pico-text-muted);
+}
+
+.pricingAgents {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--pico-text-secondary);
+}
+
+.pricingFeatures {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.pricingFeature {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  font-size: 0.88rem;
+  line-height: 1.42;
+  color: var(--pico-text-secondary);
+}
+
+.pricingFeatureCheck {
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--pico-accent-soft);
+  color: var(--pico-accent);
+  font-size: 0.65rem;
+  font-weight: 800;
+  margin-top: 0.1rem;
+}
+
+.pricingCta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.8rem;
+  padding: 0 1.2rem;
+  border-radius: var(--pico-radius-sm);
+  font-family: var(--pico-font-body);
+  font-size: 0.88rem;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+  border: 1px solid var(--pico-border);
+  background: var(--pico-bg-surface-hover);
+  color: var(--pico-text);
+}
+
+.pricingCta:hover {
+  transform: translateY(-1px);
+  border-color: var(--pico-border-hover);
+}
+
+.pricingCtaPrimary {
+  background: linear-gradient(135deg, #4ade80, #22c55e);
+  color: #052e16;
+  border-color: transparent;
+  box-shadow: 0 8px 24px rgba(74, 222, 128, 0.16);
+}
+
+.pricingCtaPrimary:hover {
+  box-shadow: 0 12px 32px rgba(74, 222, 128, 0.22);
+}
+
+.pricingUpsell {
+  margin: clamp(1.4rem, 2vw, 2rem) 0 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--pico-text-muted);
+  text-align: center;
+}
+
+.pricingUpsell a {
+  color: var(--pico-blue);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* --- Setup timeline ---------------------------------------------- */
+.setupGrid {
+  display: grid;
+  gap: 0;
+  max-width: 36rem;
+  margin: 0 auto;
+  position: relative;
+}
+
+.setupGrid::before {
+  content: "";
+  position: absolute;
+  left: 1.3rem;
+  top: 2.5rem;
+  bottom: 2.5rem;
+  width: 1px;
+  background: linear-gradient(180deg, var(--pico-accent), var(--pico-border));
+  opacity: 0.3;
+}
+
+.setupStep {
+  display: grid;
+  grid-template-columns: 2.6rem 1fr;
+  gap: 1rem;
+  padding: 1.2rem 0;
+}
+
+.setupMarker {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+}
+
+.setupDot {
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 50%;
+  border: 1px solid var(--pico-accent);
+  background: var(--pico-accent-soft);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--pico-font-accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  color: var(--pico-accent);
+  flex-shrink: 0;
+}
+
+.setupContent {
+  display: grid;
+  gap: 0.35rem;
+  padding-top: 0.15rem;
+}
+
+.setupTime {
+  font-family: var(--pico-font-accent);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--pico-accent);
+  opacity: 0.6;
+}
+
+.setupTitle {
+  margin: 0;
+  font-size: clamp(1.05rem, 1.6vw, 1.3rem);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--pico-text);
+}
+
+.setupBody {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--pico-text-secondary);
+}
+
+/* --- Final CTA --------------------------------------------------- */
+.ctaSection {
+  padding: clamp(5.5rem, 10vw, 8rem) 0;
+  position: relative;
+  text-align: center;
+  background:
+    radial-gradient(ellipse 60% 50% at 50% 50%, rgba(74, 222, 128, 0.06), transparent),
+    var(--pico-bg);
+}
+
+.ctaSection::before {
+  content: "";
+  position: absolute;
+  inset: auto 0 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(74, 222, 128, 0.2),
+    transparent
+  );
+}
+
+.ctaStack {
+  display: grid;
+  gap: 1.2rem;
+  justify-items: center;
+  max-width: 34rem;
+  margin: 0 auto;
+}
+
+.ctaTitle {
+  margin: 0;
+  font-family: var(--pico-font-display);
+  font-size: clamp(2rem, 4.5vw, 3.2rem);
+  font-weight: 300;
+  line-height: 1.02;
+  letter-spacing: -0.045em;
+  color: var(--pico-text);
+}
+
+.ctaBody {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--pico-text-secondary);
+}
+
+.ctaMeta {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--pico-text-muted);
+}
+
+.ctaMeta a {
+  color: var(--pico-blue);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* --- Animations -------------------------------------------------- */
+@keyframes ambientShift {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}
+
+@keyframes fadeUpIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/components/site/pico/PicoLandingPage.tsx
+++ b/components/site/pico/PicoLandingPage.tsx
@@ -1,36 +1,68 @@
 'use client'
 
+import Image from 'next/image'
 import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
 import { motion, useReducedMotion } from 'framer-motion'
 
-import core from '../marketing/MarketingCore.module.css'
+import s from './PicoLanding.module.css'
 import { SiteReveal } from '../SiteReveal'
+
+/* ------------------------------------------------------------------ */
+/*  Data                                                               */
+/* ------------------------------------------------------------------ */
+
+const beforeAfter = [
+  {
+    before:
+      'You built an AI agent to save time — now you check on it every hour.',
+    after:
+      'Your agent runs itself. You open the dashboard once a day — and everything is fine.',
+  },
+  {
+    before:
+      'You got a $3,800 API bill last month and spent two days figuring out why.',
+    after:
+      'You set a $500/mo budget cap. Your agent has never exceeded it once.',
+  },
+  {
+    before:
+      'Your boss saw one bad output — now every action needs manual Slack approval.',
+    after:
+      'You defined what your agent can do alone vs what needs approval. Your boss trusts it.',
+  },
+] as const
 
 const features = [
   {
-    id: 'visibility',
+    num: '01',
     title: 'Live visibility dashboard',
-    body: 'See exactly what your agent is doing, what it called, what it returned, and what failed — in real time. No more guessing. No more log archaeology.',
+    body: 'See what your agent is doing, what it called, what it returned, and what failed — in real time. No log archaeology.',
   },
   {
-    id: 'cost',
+    num: '02',
     title: 'Cost watchdog',
-    body: 'Real-time token spend per agent, per workflow, per day. Set budget caps and alerts. Never get a surprise bill again.',
+    body: 'Real-time token spend per agent, per workflow, per day. Budget caps and alerts so you never get a surprise bill.',
   },
   {
-    id: 'approvals',
-    title: 'Smart human approval gates',
-    body: 'Define exactly what your agent can do autonomously vs what needs your sign-off. Approvals via Slack, email, or dashboard — one click.',
+    num: '03',
+    title: 'Smart approval gates',
+    body: 'Define what your agent can do autonomously vs what needs your sign-off. Approve via Slack, email, or dashboard — one click.',
+  },
+  {
+    num: '04',
+    title: 'Failure alerts + audit trail',
+    body: 'Instant alert when something breaks. Full history of every action the agent took — you always know what happened and when.',
   },
 ] as const
 
 const tiers = [
   {
     name: 'Starter',
-    price: '\u20AC49',
+    price: '€49',
     period: '/mo',
     agents: '1 agent',
+    recommended: false,
     features: [
       'Dashboard',
       'Cost alerts',
@@ -40,9 +72,10 @@ const tiers = [
   },
   {
     name: 'Pro',
-    price: '\u20AC149',
+    price: '€149',
     period: '/mo',
-    agents: 'Up to 5',
+    agents: 'Up to 5 agents',
+    recommended: true,
     features: [
       'Full observability',
       'Cost caps + budget governance',
@@ -53,9 +86,10 @@ const tiers = [
   },
   {
     name: 'Team',
-    price: '\u20AC399',
+    price: '€399',
     period: '/mo',
-    agents: 'Up to 20',
+    agents: 'Up to 20 agents',
+    recommended: false,
     features: [
       'Everything in Pro',
       'Multi-user access',
@@ -66,206 +100,127 @@ const tiers = [
   },
 ] as const
 
-const beforeAfter = [
+const setupSteps = [
   {
-    before: 'You built an AI agent to save time — now you check on it every hour.',
-    after: 'Your agent runs by itself — you open the dashboard once a day.',
+    num: '1',
+    time: '5 min',
+    title: 'Connect your existing agent',
+    body: 'LangChain, n8n, Make, custom API — anything with a webhook or SDK wrapper. No rearchitecting.',
   },
   {
-    before: 'You got a $3,800 API bill last month and spent two days figuring out why.',
-    after: 'You set a $500/month budget cap. It has never exceeded it once.',
+    num: '2',
+    time: '10 min',
+    title: 'Set your thresholds',
+    body: 'Cost alerts, failure notifications, which actions require human approval before execution.',
   },
   {
-    before: 'Your boss saw one bad output — now every action needs manual Slack approval.',
-    after: 'You defined what it can do alone vs what needs approval. Your boss trusts it.',
+    num: '3',
+    time: '15 min',
+    title: 'You\'re live.',
+    body: 'Dashboard is running. Your agent works. You only get alerted when it actually needs you.',
   },
 ] as const
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
 
 export function PicoLandingPage() {
   const prefersReducedMotion = useReducedMotion()
 
   return (
-    <div className={`${core.page} ${core.publicPage}`}>
-      <main className={core.main}>
-        {/* Hero */}
-        <section
-          style={{
-            position: 'relative',
-            minHeight: 'max(100dvh, 44rem)',
-            overflow: 'clip',
-            color: '#f7f4ef',
-            background:
-              'radial-gradient(circle at 60% 22%, rgba(34, 197, 94, 0.14), transparent 24rem), linear-gradient(180deg, #06080d 0 44rem, #0f1015 44rem 50rem, #f8f6f3 50rem 100%)',
-            display: 'flex',
-            alignItems: 'center',
-          }}
-        >
-          <div
-            style={{
-              position: 'relative',
-              zIndex: 1,
-              width: 'min(100% - 2.5rem, 64rem)',
-              margin: '0 auto',
-              paddingTop: 'clamp(5rem, 10vh, 7rem)',
-              paddingBottom: 'clamp(4rem, 8vh, 6rem)',
-              display: 'grid',
-              gap: '1.4rem',
-              maxWidth: '38rem',
-            }}
-          >
-            <p
-              style={{
-                margin: 0,
-                width: 'fit-content',
-                minHeight: '2.2rem',
-                display: 'inline-flex',
-                alignItems: 'center',
-                padding: '0 0.92rem',
-                borderRadius: 999,
-                border: '1px solid rgba(247, 244, 239, 0.16)',
-                background: 'rgba(255, 255, 255, 0.04)',
-                fontFamily: 'var(--font-marketing-accent), sans-serif',
-                fontSize: '0.8rem',
-                fontWeight: 800,
-                letterSpacing: '0.12em',
-                textTransform: 'uppercase',
-              }}
-            >
-              by MUTX
-            </p>
-            <h1
-              style={{
-                margin: 0,
-                fontFamily: 'var(--font-marketing-display), serif',
-                fontSize: 'clamp(3.2rem, 7vw, 5.2rem)',
-                fontWeight: 300,
-                lineHeight: 0.92,
-                letterSpacing: '-0.06em',
-                maxWidth: '12ch',
-              }}
-            >
-              Stop babysitting your AI.
-            </h1>
-            <p
-              style={{
-                margin: 0,
-                color: 'rgba(247, 244, 239, 0.82)',
-                fontSize: 'clamp(1.05rem, 1rem + 0.25vw, 1.18rem)',
-                lineHeight: 1.5,
-                maxWidth: '28rem',
-              }}
-            >
-              You built an AI agent that was supposed to save you time, but now you spend more time
-              watching it than doing the work it was supposed to replace. PicoMUTX fixes that in 30
-              minutes.
-            </p>
-            <div
-              style={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                gap: '0.9rem',
-                alignItems: 'center',
-                paddingTop: '0.5rem',
-              }}
-            >
-              {/* TODO: Wire to sign-up flow when ready */}
-              <span
-                className={core.buttonPrimary}
-                style={{ opacity: 0.6, cursor: 'not-allowed' }}
-              >
-                Get started
-                <ArrowRight className="h-4 w-4" />
-              </span>
-              <Link href="/" className={core.buttonGhost}>
-                MUTX for enterprise
-              </Link>
-            </div>
-            <p
-              style={{
-                margin: 0,
-                color: 'rgba(247, 244, 239, 0.48)',
-                fontSize: '0.85rem',
-                lineHeight: 1.4,
-              }}
-            >
-              Live in 30 minutes. Works on top of whatever you already built. No new infrastructure
-              required.
+    <div className={s.page}>
+      {/* Navigation */}
+      <nav className={s.nav}>
+        <div className={s.navInner}>
+          <Link href="/pico" className={s.navBrand}>
+            <span className={s.navLogo}>
+              <Image src="/logo.png" alt="MUTX" width={20} height={20} />
+            </span>
+            <span className={s.navName}>
+              PicoMUTX
+              <span className={s.navTag}> by MUTX</span>
+            </span>
+          </Link>
+          <Link href="/contact" className={s.navCta}>
+            Get early access
+          </Link>
+        </div>
+      </nav>
+
+      <main className={s.main}>
+        {/* ---- Hero ---- */}
+        <section className={s.hero}>
+          <div className={s.heroGrid}>
+            <span className={s.heroBadge}>
+              <span className={s.heroBadgeDot} />
+              Now in early access
+            </span>
+
+            <SiteReveal delay={0.05}>
+              <h1 className={s.heroTitle}>
+                Stop babysitting{' '}
+                <span className={s.heroTitleAccent}>your AI.</span>
+              </h1>
+            </SiteReveal>
+
+            <SiteReveal delay={0.12}>
+              <p className={s.heroSub}>
+                You built an AI agent to save time. Now you spend more time
+                watching it than doing the work it was supposed to replace.
+                PicoMUTX fixes that in 30 minutes.
+              </p>
+            </SiteReveal>
+
+            <SiteReveal delay={0.19}>
+              <div className={s.heroActions}>
+                <Link href="/contact" className={s.btnPrimary}>
+                  Get early access
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+                <Link href="/" className={s.btnSecondary}>
+                  MUTX for enterprise
+                </Link>
+              </div>
+            </SiteReveal>
+
+            <p className={s.heroMeta}>
+              Live in 30 minutes. Works on top of whatever you already built.
+              No new infrastructure required.
             </p>
           </div>
         </section>
 
-        {/* The problem */}
-        <section
-          style={{
-            padding: 'clamp(4.4rem, 8vw, 6.6rem) 0',
-            borderTop: '1px solid rgba(19, 26, 36, 0.08)',
-          }}
-        >
-          <div className={core.shell}>
-            <div style={{ display: 'grid', gap: '0.85rem', maxWidth: '42rem' }}>
-              <p className={core.sectionTitle} style={{ color: '#131a24' }}>
-                Before and after PicoMUTX
-              </p>
+        {/* ---- Before / After ---- */}
+        <section className={`${s.section} ${s.sectionAlt}`}>
+          <div className={s.shell}>
+            <div className={s.sectionHeader}>
+              <span className={s.eyebrow}>The shift</span>
+              <h2 className={s.sectionTitle}>
+                Before PicoMUTX vs. after
+              </h2>
             </div>
-            <div
-              style={{
-                display: 'grid',
-                gap: '1.35rem',
-                marginTop: '2rem',
-              }}
-            >
+            <div className={s.baGrid}>
               {beforeAfter.map((item, i) => (
                 <SiteReveal key={i} delay={i * 0.07}>
                   <motion.div
                     whileHover={
-                      prefersReducedMotion ? undefined : { y: -4, scale: 1.005 }
+                      prefersReducedMotion ? undefined : { y: -3 }
                     }
                     transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
-                    style={{
-                      display: 'grid',
-                      gap: '1rem',
-                      padding: '1.15rem',
-                      borderRadius: '1.4rem',
-                      border: '1px solid rgba(19, 26, 36, 0.1)',
-                      background:
-                        'linear-gradient(180deg, rgba(255,255,255,0.82), rgba(255,255,255,0.68))',
-                    }}
+                    className={s.baCard}
                   >
-                    <div>
-                      <p
-                        style={{
-                          margin: 0,
-                          fontFamily: 'var(--font-marketing-accent), sans-serif',
-                          fontSize: '0.72rem',
-                          fontWeight: 800,
-                          letterSpacing: '0.12em',
-                          textTransform: 'uppercase',
-                          color: '#ef4444',
-                          marginBottom: '0.35rem',
-                        }}
-                      >
+                    <div className={`${s.baSide} ${s.baBefore}`}>
+                      <p className={`${s.baLabel} ${s.baLabelBefore}`}>
                         Before
                       </p>
-                      <p style={{ margin: 0, lineHeight: 1.56, color: 'rgba(19,26,36,0.72)' }}>
-                        {item.before}
-                      </p>
+                      <p className={s.baText}>{item.before}</p>
                     </div>
-                    <div>
-                      <p
-                        style={{
-                          margin: 0,
-                          fontFamily: 'var(--font-marketing-accent), sans-serif',
-                          fontSize: '0.72rem',
-                          fontWeight: 800,
-                          letterSpacing: '0.12em',
-                          textTransform: 'uppercase',
-                          color: '#22c55e',
-                          marginBottom: '0.35rem',
-                        }}
-                      >
+                    <div className={s.baSide}>
+                      <p className={`${s.baLabel} ${s.baLabelAfter}`}>
                         After
                       </p>
-                      <p style={{ margin: 0, lineHeight: 1.56, color: '#131a24', fontWeight: 600 }}>
+                      <p className={`${s.baText} ${s.baTextAfter}`}>
                         {item.after}
                       </p>
                     </div>
@@ -276,403 +231,124 @@ export function PicoLandingPage() {
           </div>
         </section>
 
-        {/* Features */}
-        <section
-          style={{
-            padding: 'clamp(4.4rem, 8vw, 6.6rem) 0',
-            borderTop: '1px solid rgba(247, 244, 239, 0.08)',
-            color: '#f7f4ef',
-            background:
-              'radial-gradient(circle at 16% 18%, rgba(34, 197, 94, 0.1), transparent 18rem), linear-gradient(180deg, rgba(9, 11, 16, 1), rgba(5, 6, 9, 1))',
-          }}
-        >
-          <div className={core.shell}>
-            <div style={{ display: 'grid', gap: '0.85rem', maxWidth: '42rem' }}>
-              <p
-                style={{
-                  margin: 0,
-                  width: 'fit-content',
-                  minHeight: '2.2rem',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  padding: '0 0.92rem',
-                  borderRadius: 999,
-                  border: '1px solid rgba(247, 244, 239, 0.14)',
-                  background: 'rgba(255, 255, 255, 0.04)',
-                  fontFamily: 'var(--font-marketing-accent), sans-serif',
-                  fontSize: '0.8rem',
-                  fontWeight: 800,
-                  letterSpacing: '0.12em',
-                  textTransform: 'uppercase',
-                  color: '#f7f4ef',
-                }}
-              >
-                How it works
-              </p>
-              <p className={core.sectionTitle} style={{ color: '#f7f4ef' }}>
-                Four things between you and an agent that runs itself.
-              </p>
+        {/* ---- Features ---- */}
+        <section className={`${s.section} ${s.sectionDark}`}>
+          <div className={s.shell}>
+            <div className={s.sectionHeader}>
+              <span className={s.eyebrow}>How it works</span>
+              <h2 className={s.sectionTitle}>
+                Four things between you and an agent that runs itself
+              </h2>
             </div>
-            <div
-              style={{
-                display: 'grid',
-                gap: '1.35rem',
-                marginTop: '2rem',
-              }}
-            >
+            <div className={s.featureGrid}>
               {features.map((f, i) => (
-                <SiteReveal key={f.id} delay={i * 0.07}>
+                <SiteReveal key={f.num} delay={i * 0.06}>
                   <motion.div
                     whileHover={
-                      prefersReducedMotion ? undefined : { y: -4, scale: 1.005 }
+                      prefersReducedMotion ? undefined : { y: -3 }
                     }
                     transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
-                    style={{
-                      display: 'grid',
-                      gap: '0.65rem',
-                      padding: '1.15rem',
-                      borderRadius: '1.4rem',
-                      border: '1px solid rgba(247, 244, 239, 0.08)',
-                      background:
-                        'linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.03))',
-                    }}
+                    className={s.featureCard}
                   >
-                    <p
-                      style={{
-                        margin: 0,
-                        fontFamily: 'var(--font-marketing-accent), sans-serif',
-                        fontSize: '0.72rem',
-                        fontWeight: 800,
-                        letterSpacing: '0.12em',
-                        textTransform: 'uppercase',
-                        color: '#4ade80',
-                      }}
-                    >
-                      0{i + 1}
-                    </p>
-                    <h3
-                      style={{
-                        margin: 0,
-                        fontSize: 'clamp(1.2rem, 1.9vw, 1.55rem)',
-                        fontWeight: 600,
-                        lineHeight: 1.06,
-                        letterSpacing: '-0.04em',
-                        color: '#f7f4ef',
-                      }}
-                    >
-                      {f.title}
-                    </h3>
-                    <p style={{ margin: 0, lineHeight: 1.56, color: 'rgba(247,244,239,0.74)' }}>
-                      {f.body}
-                    </p>
+                    <p className={s.featureNum}>{f.num}</p>
+                    <h3 className={s.featureTitle}>{f.title}</h3>
+                    <p className={s.featureBody}>{f.body}</p>
                   </motion.div>
                 </SiteReveal>
               ))}
-              {/* 04 - Failure alerts + audit trail */}
-              <SiteReveal delay={0.21}>
-                <motion.div
-                  whileHover={prefersReducedMotion ? undefined : { y: -4, scale: 1.005 }}
-                  transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
-                  style={{
-                    display: 'grid',
-                    gap: '0.65rem',
-                    padding: '1.15rem',
-                    borderRadius: '1.4rem',
-                    border: '1px solid rgba(247, 244, 239, 0.08)',
-                    background:
-                      'linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.03))',
-                  }}
-                >
-                  <p
-                    style={{
-                      margin: 0,
-                      fontFamily: 'var(--font-marketing-accent), sans-serif',
-                      fontSize: '0.72rem',
-                      fontWeight: 800,
-                      letterSpacing: '0.12em',
-                      textTransform: 'uppercase',
-                      color: '#4ade80',
-                    }}
-                  >
-                    04
-                  </p>
-                  <h3
-                    style={{
-                      margin: 0,
-                      fontSize: 'clamp(1.2rem, 1.9vw, 1.55rem)',
-                      fontWeight: 600,
-                      lineHeight: 1.06,
-                      letterSpacing: '-0.04em',
-                      color: '#f7f4ef',
-                    }}
-                  >
-                    Failure alerts + audit trail
-                  </h3>
-                  <p style={{ margin: 0, lineHeight: 1.56, color: 'rgba(247,244,239,0.74)' }}>
-                    Instant alert when something breaks. Full history of every action the agent
-                    took. When something goes wrong — and it will — you know exactly what happened
-                    and when.
-                  </p>
-                </motion.div>
-              </SiteReveal>
             </div>
           </div>
         </section>
 
-        {/* Pricing */}
-        <section
-          style={{
-            padding: 'clamp(4.4rem, 8vw, 6.6rem) 0',
-            borderTop: '1px solid rgba(19, 26, 36, 0.08)',
-          }}
-        >
-          <div className={core.shell}>
-            <div style={{ display: 'grid', gap: '0.85rem', maxWidth: '42rem' }}>
-              <p className={core.sectionTitle} style={{ color: '#131a24' }}>
-                Self-serve pricing. No sales call required.
-              </p>
-              <p style={{ margin: 0, fontSize: '1rem', lineHeight: 1.58, color: 'rgba(19,26,36,0.72)' }}>
-                {/* TODO: Wire pricing cards to payment/sign-up flow when ready */}
-                Start with one agent. Upgrade when you need more. Every PicoMUTX customer is a
-                potential MUTX enterprise client in the making.
+        {/* ---- Pricing ---- */}
+        <section className={`${s.section} ${s.sectionAlt}`}>
+          <div className={s.shell}>
+            <div
+              className={`${s.sectionHeader} ${s.sectionHeaderCenter}`}
+            >
+              <span className={`${s.eyebrow} ${s.eyebrowBlue}`}>
+                Pricing
+              </span>
+              <h2 className={s.sectionTitle}>
+                Self-serve. No sales call required.
+              </h2>
+              <p className={s.sectionBody}>
+                Start with one agent. Scale when you need more.
               </p>
             </div>
-            <div
-              style={{
-                display: 'grid',
-                gap: '1.35rem',
-                marginTop: '2rem',
-                gridTemplateColumns: 'repeat(auto-fit, minmax(16rem, 1fr))',
-              }}
-            >
+            <div className={s.pricingGrid}>
               {tiers.map((tier, i) => (
                 <SiteReveal key={tier.name} delay={i * 0.07}>
                   <motion.div
                     whileHover={
-                      prefersReducedMotion ? undefined : { y: -4, scale: 1.005 }
+                      prefersReducedMotion ? undefined : { y: -3 }
                     }
                     transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
-                    style={{
-                      display: 'grid',
-                      gap: '0.85rem',
-                      padding: '1.4rem',
-                      borderRadius: '1.4rem',
-                      border:
-                        tier.name === 'Pro'
-                          ? '2px solid rgba(75, 141, 255, 0.4)'
-                          : '1px solid rgba(19, 26, 36, 0.1)',
-                      background:
-                        tier.name === 'Pro'
-                          ? 'linear-gradient(180deg, rgba(75,141,255,0.06), rgba(255,255,255,0.82))'
-                          : 'linear-gradient(180deg, rgba(255,255,255,0.82), rgba(255,255,255,0.68))',
-                      boxShadow:
-                        tier.name === 'Pro'
-                          ? '0 18px 42px rgba(75, 141, 255, 0.12)'
-                          : '0 24px 60px rgba(13,19,32,0.08)',
-                    }}
+                    className={`${s.pricingCard} ${
+                      tier.recommended ? s.pricingCardRecommended : ''
+                    }`}
                   >
-                    <p
-                      style={{
-                        margin: 0,
-                        fontFamily: 'var(--font-marketing-accent), sans-serif',
-                        fontSize: '0.72rem',
-                        fontWeight: 800,
-                        letterSpacing: '0.12em',
-                        textTransform: 'uppercase',
-                        color: 'rgba(19,26,36,0.5)',
-                      }}
-                    >
-                      {tier.name}
-                    </p>
-                    <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.15rem' }}>
-                      <span
-                        style={{
-                          fontSize: 'clamp(1.8rem, 3vw, 2.4rem)',
-                          fontWeight: 700,
-                          lineHeight: 1,
-                          letterSpacing: '-0.04em',
-                        }}
-                      >
-                        {tier.price}
-                      </span>
-                      <span style={{ fontSize: '0.9rem', color: 'rgba(19,26,36,0.5)' }}>
-                        {tier.period}
-                      </span>
+                    {tier.recommended && (
+                      <span className={s.pricingBadge}>Recommended</span>
+                    )}
+                    <p className={s.pricingName}>{tier.name}</p>
+                    <div className={s.pricingPrice}>
+                      <span className={s.pricingAmount}>{tier.price}</span>
+                      <span className={s.pricingPeriod}>{tier.period}</span>
                     </div>
-                    <p
-                      style={{
-                        margin: 0,
-                        fontSize: '0.85rem',
-                        fontWeight: 600,
-                        color: 'rgba(19,26,36,0.6)',
-                      }}
-                    >
-                      {tier.agents}
-                    </p>
-                    <ul
-                      style={{
-                        margin: 0,
-                        padding: 0,
-                        listStyle: 'none',
-                        display: 'grid',
-                        gap: '0.45rem',
-                      }}
-                    >
+                    <p className={s.pricingAgents}>{tier.agents}</p>
+                    <ul className={s.pricingFeatures}>
                       {tier.features.map((f) => (
-                        <li
-                          key={f}
-                          style={{
-                            fontSize: '0.9rem',
-                            lineHeight: 1.45,
-                            color: 'rgba(19,26,36,0.78)',
-                            paddingLeft: '1rem',
-                            position: 'relative',
-                          }}
-                        >
-                          <span
-                            style={{
-                              position: 'absolute',
-                              left: 0,
-                              color: '#22c55e',
-                            }}
-                          >
+                        <li key={f} className={s.pricingFeature}>
+                          <span className={s.pricingFeatureCheck}>
                             +
                           </span>
                           {f}
                         </li>
                       ))}
                     </ul>
-                    {/* TODO: Wire CTA to sign-up/payment flow */}
-                    <span
-                      className={core.buttonSecondary}
-                      style={{ opacity: 0.6, cursor: 'not-allowed', textAlign: 'center' }}
+                    <Link
+                      href="/contact"
+                      className={`${s.pricingCta} ${
+                        tier.recommended ? s.pricingCtaPrimary : ''
+                      }`}
                     >
-                      Coming soon
-                    </span>
+                      {tier.recommended ? 'Get started' : 'Get started'}
+                    </Link>
                   </motion.div>
                 </SiteReveal>
               ))}
             </div>
-            <p
-              style={{
-                margin: '1.4rem 0 0',
-                fontSize: '0.88rem',
-                lineHeight: 1.5,
-                color: 'rgba(19,26,36,0.5)',
-              }}
-            >
-              Need more? When you ask &ldquo;can we do this for all 50+ agents across the
-              company?&rdquo; — that&rsquo;s{' '}
-              <Link href="/" style={{ color: '#4b8dff', textDecoration: 'underline' }}>
-                MUTX
-              </Link>{' '}
-              at &euro;18k&ndash;&euro;50k+.
+            <p className={s.pricingUpsell}>
+              Need more? When you outgrow 20 agents, that&apos;s{' '}
+              <Link href="/">MUTX enterprise</Link> at €18k–€50k+.
             </p>
           </div>
         </section>
 
-        {/* Setup */}
-        <section
-          style={{
-            padding: 'clamp(4.4rem, 8vw, 6.6rem) 0',
-            borderTop: '1px solid rgba(247, 244, 239, 0.08)',
-            color: '#f7f4ef',
-            background:
-              'radial-gradient(circle at 78% 26%, rgba(34, 197, 94, 0.12), transparent 20rem), linear-gradient(180deg, rgba(7, 9, 13, 1), rgba(5, 6, 9, 1))',
-          }}
-        >
-          <div className={core.shell}>
-            <div style={{ display: 'grid', gap: '0.85rem', maxWidth: '42rem' }}>
-              <p className={core.sectionTitle} style={{ color: '#f7f4ef' }}>
-                Live in 30 minutes. Three steps.
-              </p>
-            </div>
+        {/* ---- Setup timeline ---- */}
+        <section className={`${s.section} ${s.sectionDark}`}>
+          <div className={s.shell}>
             <div
-              style={{
-                display: 'grid',
-                gap: '1.35rem',
-                marginTop: '2rem',
-                maxWidth: '36rem',
-              }}
+              className={`${s.sectionHeader} ${s.sectionHeaderCenter}`}
             >
-              {[
-                {
-                  step: '01',
-                  time: '5 min',
-                  title: 'Connect your existing agent',
-                  body: 'LangChain, n8n, Make, custom API, anything with a webhook or SDK wrapper. No rearchitecting. Nothing to rebuild.',
-                },
-                {
-                  step: '02',
-                  time: '10 min',
-                  title: 'Set your thresholds',
-                  body: 'Cost alerts, failure notifications, which actions require human approval before execution.',
-                },
-                {
-                  step: '03',
-                  time: '15 min',
-                  title: 'Done.',
-                  body: 'Dashboard is live. Your agent runs. You get alerted only when it actually needs you.',
-                },
-              ].map((s, i) => (
-                <SiteReveal key={s.step} delay={i * 0.07}>
-                  <div
-                    style={{
-                      display: 'grid',
-                      gap: '0.5rem',
-                      padding: '1.15rem',
-                      borderRadius: '1.2rem',
-                      border: '1px solid rgba(247, 244, 239, 0.08)',
-                      background: 'rgba(255,255,255,0.03)',
-                    }}
-                  >
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.8rem',
-                      }}
-                    >
-                      <span
-                        style={{
-                          fontFamily: 'var(--font-marketing-accent), sans-serif',
-                          fontSize: '0.72rem',
-                          fontWeight: 800,
-                          letterSpacing: '0.12em',
-                          textTransform: 'uppercase',
-                          color: '#4ade80',
-                        }}
-                      >
-                        {s.step}
-                      </span>
-                      <span
-                        style={{
-                          fontFamily: 'var(--font-marketing-accent), sans-serif',
-                          fontSize: '0.68rem',
-                          fontWeight: 700,
-                          color: 'rgba(247,244,239,0.4)',
-                          textTransform: 'uppercase',
-                          letterSpacing: '0.08em',
-                        }}
-                      >
-                        {s.time}
-                      </span>
+              <span className={s.eyebrow}>Setup</span>
+              <h2 className={s.sectionTitle}>
+                Live in 30 minutes. Three steps.
+              </h2>
+            </div>
+            <div className={s.setupGrid}>
+              {setupSteps.map((step, i) => (
+                <SiteReveal key={step.num} delay={i * 0.08}>
+                  <div className={s.setupStep}>
+                    <div className={s.setupMarker}>
+                      <span className={s.setupDot}>{step.num}</span>
                     </div>
-                    <h3
-                      style={{
-                        margin: 0,
-                        fontSize: 'clamp(1.1rem, 1.6vw, 1.35rem)',
-                        fontWeight: 600,
-                        lineHeight: 1.1,
-                        letterSpacing: '-0.03em',
-                        color: '#f7f4ef',
-                      }}
-                    >
-                      {s.title}
-                    </h3>
-                    <p style={{ margin: 0, lineHeight: 1.56, color: 'rgba(247,244,239,0.68)' }}>
-                      {s.body}
-                    </p>
+                    <div className={s.setupContent}>
+                      <span className={s.setupTime}>{step.time}</span>
+                      <h3 className={s.setupTitle}>{step.title}</h3>
+                      <p className={s.setupBody}>{step.body}</p>
+                    </div>
                   </div>
                 </SiteReveal>
               ))}
@@ -680,42 +356,27 @@ export function PicoLandingPage() {
           </div>
         </section>
 
-        {/* CTA */}
-        <section
-          style={{
-            padding: 'clamp(4.4rem, 8vw, 6.6rem) 0',
-            borderTop: '1px solid rgba(19, 26, 36, 0.08)',
-            textAlign: 'center',
-          }}
-        >
-          <div
-            className={core.shell}
-            style={{
-              display: 'grid',
-              gap: '1rem',
-              justifyItems: 'center',
-              maxWidth: '32rem',
-              margin: '0 auto',
-            }}
-          >
-            <p className={core.sectionTitle} style={{ color: '#131a24' }}>
-              Your AI should work for you. Not the other way around.
-            </p>
-            {/* TODO: Wire to sign-up flow */}
-            <span
-              className={core.buttonPrimary}
-              style={{ opacity: 0.6, cursor: 'not-allowed' }}
-            >
-              Get started
-              <ArrowRight className="h-4 w-4" />
-            </span>
-            <p style={{ margin: 0, fontSize: '0.85rem', color: 'rgba(19,26,36,0.45)' }}>
-              {/* STUB: Payment flow not yet wired */}
-              Sign-up coming soon.{' '}
-              <Link href="/" style={{ color: '#4b8dff' }}>
-                Explore MUTX for enterprise
-              </Link>
-            </p>
+        {/* ---- Final CTA ---- */}
+        <section className={s.ctaSection}>
+          <div className={s.shell}>
+            <div className={s.ctaStack}>
+              <SiteReveal delay={0.05}>
+                <h2 className={s.ctaTitle}>
+                  Your AI should work for you. Not the other way around.
+                </h2>
+              </SiteReveal>
+              <SiteReveal delay={0.12}>
+                <Link href="/contact" className={s.btnPrimary}>
+                  Get early access
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </SiteReveal>
+              <p className={s.ctaMeta}>
+                Questions?{' '}
+                <Link href="/contact">Talk to us</Link> or{' '}
+                <Link href="/">explore MUTX for enterprise</Link>
+              </p>
+            </div>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## What changed

Complete redesign of the `pico.mutx.dev` landing page from prototype-quality to premium, conversion-focused product site.

### Design system
- **New `PicoLanding.module.css`** -- dedicated CSS module with proper design tokens, replacing 724 lines of inline `style={{}}` props
- Dark theme throughout (`#07080c` base) with green accent system
- Consistent spacing, typography hierarchy, and responsive breakpoints

### Structural changes
- **Sticky navigation** with MUTX logo, PicoMUTX branding, and "Get early access" CTA
- **Full-bleed dark hero** with centered headline, green accent on "your AI", and dual CTAs
- **Before/After section** as split-panel cards (side-by-side on desktop, stacked on mobile)
- **Feature grid** as 2x2 layout with numbered cards instead of single-column stack
- **Pricing** with "Recommended" badge on Pro tier, green primary CTA, stronger card differentiation
- **Setup timeline** with visual step connector (vertical line + numbered dots)
- **Final CTA section** with radial gradient glow and clear conversion path

### Copy improvements
- Hero subhead tightened for punch
- All "Coming soon" / disabled CTAs replaced with active `/contact` links
- Pricing upsell copy cleaned up
- Section headers more direct

### Validation
- `npm run build` -- clean
- `npx tsc --noEmit` -- zero errors
- `npx eslint` -- zero errors

### Files changed
- `components/site/pico/PicoLanding.module.css` (new)
- `components/site/pico/PicoLandingPage.tsx` (rewritten)

### Preserved
- `pico/page.tsx` routing unchanged
- `PublicSurface` font wrapper unchanged
- `PublicFooter` unchanged
- All existing SEO metadata preserved