### PR TITLE
fix(pico): absolute URLs for all links

### DIFF
--- a/app/pico/page.tsx
+++ b/app/pico/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 import { PicoLandingPage } from "@/components/site/pico/PicoLandingPage";
-import { PublicFooter } from "@/components/site/PublicFooter";
+import { PicoFooter } from "@/components/site/pico/PicoFooter";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import { getCanonicalUrl, getOgImageUrl, getSiteUrl } from "@/lib/seo";
 
@@ -27,7 +27,7 @@ export default function PicoPage() {
   return (
     <PublicSurface>
       <PicoLandingPage />
-      <PublicFooter showCallout={false} />
+      <PicoFooter />
     </PublicSurface>
   );
 }

--- a/components/site/pico/PicoFooter.tsx
+++ b/components/site/pico/PicoFooter.tsx
@@ -1,0 +1,77 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+import { cn } from '@/lib/utils'
+import core from '@/components/site/marketing/MarketingCore.module.css'
+
+const SITE = 'https://mutx.dev'
+
+const footerLinks = [
+  { label: 'Releases', href: `${SITE}/releases` },
+  { label: 'Docs', href: 'https://docs.mutx.dev', external: true },
+  { label: 'GitHub', href: 'https://github.com/mutx-dev/mutx-dev', external: true },
+  { label: 'Download', href: `${SITE}/download` },
+  { label: 'Dashboard', href: `${SITE}/dashboard` },
+  { label: 'Contact', href: `${SITE}/contact` },
+  { label: 'Privacy', href: `${SITE}/privacy-policy` },
+]
+
+export function PicoFooter({ className }: { className?: string }) {
+  return (
+    <footer
+      className={cn(className)}
+      style={{
+        borderTop: '1px solid rgba(238, 240, 246, 0.08)',
+        background: '#07080c',
+        color: 'rgba(238, 240, 246, 0.6)',
+        padding: 'clamp(2rem, 4vw, 3rem) 0',
+        fontFamily: 'var(--font-marketing-sans), sans-serif',
+      }}
+    >
+      <div className={core.shell}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.6rem 1.4rem', alignItems: 'center' }}>
+          {footerLinks.map((link) =>
+            link.external ? (
+              <a
+                key={link.label}
+                href={link.href}
+                target="_blank"
+                rel="noreferrer"
+                style={{ fontSize: '0.85rem', color: 'inherit', textDecoration: 'none' }}
+              >
+                {link.label}
+              </a>
+            ) : (
+              <a
+                key={link.label}
+                href={link.href}
+                style={{ fontSize: '0.85rem', color: 'inherit', textDecoration: 'none' }}
+              >
+                {link.label}
+              </a>
+            ),
+          )}
+        </div>
+        <p style={{ margin: '1.2rem 0 0', fontSize: '0.82rem', lineHeight: 1.5, color: 'rgba(238, 240, 246, 0.35)' }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.6rem' }}>
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: '1.6rem',
+                height: '1.6rem',
+                borderRadius: '0.4rem',
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.08)',
+              }}
+            >
+              <Image src="/logo.png" alt="MUTX" width={14} height={14} />
+            </span>
+            &copy; MUTX 2026. Open control for deployed agents.
+          </span>
+        </p>
+      </div>
+    </footer>
+  )
+}

--- a/components/site/pico/PicoLandingPage.tsx
+++ b/components/site/pico/PicoLandingPage.tsx
@@ -133,7 +133,7 @@ export function PicoLandingPage() {
       {/* Navigation */}
       <nav className={s.nav}>
         <div className={s.navInner}>
-          <Link href="/pico" className={s.navBrand}>
+          <Link href="https://pico.mutx.dev" className={s.navBrand}>
             <span className={s.navLogo}>
               <Image src="/logo.png" alt="MUTX" width={20} height={20} />
             </span>
@@ -142,7 +142,7 @@ export function PicoLandingPage() {
               <span className={s.navTag}> by MUTX</span>
             </span>
           </Link>
-          <Link href="/contact" className={s.navCta}>
+          <Link href="https://mutx.dev/contact" className={s.navCta}>
             Get early access
           </Link>
         </div>
@@ -174,11 +174,11 @@ export function PicoLandingPage() {
 
             <SiteReveal delay={0.19}>
               <div className={s.heroActions}>
-                <Link href="/contact" className={s.btnPrimary}>
+                <Link href="https://mutx.dev/contact" className={s.btnPrimary}>
                   Get early access
                   <ArrowRight className="h-4 w-4" />
                 </Link>
-                <Link href="/" className={s.btnSecondary}>
+                <Link href="https://mutx.dev" className={s.btnSecondary}>
                   MUTX for enterprise
                 </Link>
               </div>
@@ -308,7 +308,7 @@ export function PicoLandingPage() {
                       ))}
                     </ul>
                     <Link
-                      href="/contact"
+                      href="https://mutx.dev/contact"
                       className={`${s.pricingCta} ${
                         tier.recommended ? s.pricingCtaPrimary : ''
                       }`}
@@ -321,7 +321,7 @@ export function PicoLandingPage() {
             </div>
             <p className={s.pricingUpsell}>
               Need more? When you outgrow 20 agents, that&apos;s{' '}
-              <Link href="/">MUTX enterprise</Link> at €18k–€50k+.
+              <Link href="https://mutx.dev">MUTX enterprise</Link> at €18k–€50k+.
             </p>
           </div>
         </section>
@@ -366,15 +366,15 @@ export function PicoLandingPage() {
                 </h2>
               </SiteReveal>
               <SiteReveal delay={0.12}>
-                <Link href="/contact" className={s.btnPrimary}>
+                <Link href="https://mutx.dev/contact" className={s.btnPrimary}>
                   Get early access
                   <ArrowRight className="h-4 w-4" />
                 </Link>
               </SiteReveal>
               <p className={s.ctaMeta}>
                 Questions?{' '}
-                <Link href="/contact">Talk to us</Link> or{' '}
-                <Link href="/">explore MUTX for enterprise</Link>
+                <Link href="https://mutx.dev/contact">Talk to us</Link> or{' '}
+                <Link href="https://mutx.dev">explore MUTX for enterprise</Link>
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Problem
Every link on pico.mutx.dev was relative (/contact, /) which resolves to pico.mutx.dev/contact - a 404.

## Fix
- All PicoLandingPage links changed to absolute https://mutx.dev/... URLs
- Created dedicated PicoFooter with absolute URLs
- Nav brand points to https://pico.mutx.dev
- Enterprise/contact links point to https://mutx.dev

## Files changed
- components/site/pico/PicoLandingPage.tsx (links)
- components/site/pico/PicoFooter.tsx (new)
- app/pico/page.tsx (swap PublicFooter -> PicoFooter)