### PR TITLE
fix(pico): add next-intl middleware for locale switching

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -1,0 +1,11 @@
+import createMiddleware from 'next-intl/middleware'
+import { routing } from '@/i18n/routing'
+
+export default createMiddleware({
+  locales: routing.locales,
+  defaultLocale: routing.defaultLocale,
+})
+
+export const config = {
+  matcher: ['/', '/(en|es|fr|de|it|pt|ja|ko|zh|ar)/:path*']
+}


### PR DESCRIPTION
## What
Adds missing `app/middleware.ts` to handle cookie-based locale switching for the Pico landing page.

## Why
The `PicoLangSwitcher` sets `NEXT_LOCALE` cookie and calls `router.refresh()`, but without a next-intl middleware to intercept the cookie and propagate the locale, App Router pages never re-read the new locale on navigation.

## How
`createMiddleware` from `next-intl/routing` intercepts requests, reads the `NEXT_LOCALE` cookie, and makes `getLocale()` / `useLocale()` return the correct value server-side.

@codex please review