### PR TITLE
fix(api): restrict audit log read endpoints to ADMIN/AUDIT_ADMIN roles

### DIFF
--- a/src/api/routes/audit.py
+++ b/src/api/routes/audit.py
@@ -12,7 +12,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict
 
-from src.api.dependencies import get_current_user, SSOTokenUser
+from src.api.dependencies import get_current_user, require_roles, SSOTokenUser
 from src.api.services.audit_log import (
     AuditEvent,
     AuditEventType,
@@ -61,7 +61,11 @@ class AuditEventsResponse(BaseModel):
     total: int | None = None
 
 
-@router.get("/events", response_model=AuditEventsResponse)
+@router.get(
+    "/events",
+    response_model=AuditEventsResponse,
+    dependencies=[Depends(require_roles("ADMIN", "AUDIT_ADMIN"))],
+)
 async def query_audit_events(
     current_user: Annotated[SSOTokenUser, Depends(get_current_user)],
     agent_id: Annotated[str | None, Query(description="Filter by agent ID")] = None,
@@ -125,7 +129,11 @@ async def query_audit_events(
         )
 
 
-@router.get("/traces/{trace_id}", response_model=AuditEventsResponse)
+@router.get(
+    "/traces/{trace_id}",
+    response_model=AuditEventsResponse,
+    dependencies=[Depends(require_roles("ADMIN", "AUDIT_ADMIN"))],
+)
 async def get_trace_events(
     trace_id: str,
     current_user: Annotated[SSOTokenUser, Depends(get_current_user)],


### PR DESCRIPTION
### Motivation
- Prevent cross-tenant disclosure by ensuring only privileged users can read global audit logs; audit endpoints previously allowed any authenticated user to enumerate all events.

### Description
- Add RBAC enforcement by importing `require_roles` and attaching `Depends(require_roles("ADMIN", "AUDIT_ADMIN"))` to the `/events` and `/traces/{trace_id}` routes in `src/api/routes/audit.py`, preserving existing handlers and response models.

### Testing
- Ran `python -m compileall src/api/routes/audit.py` which completed successfully.  
- Attempted targeted pytest runs (`tests/api/test_auth.py::TestRoleChecking::test_require_role_success` and `test_require_role_forbidden`) but the test environment is missing `pytest_asyncio`, so pytest could not load `tests/conftest.py` and the run failed; full test execution should be validated in CI or a dev environment with test dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5f89e58c4832a94259ca45d66819a)