### PR TITLE
fix(api): harden autonomy dashboard local-only guard

### DIFF
--- a/app/api/dashboard/autonomy/route.ts
+++ b/app/api/dashboard/autonomy/route.ts
@@ -17,9 +17,8 @@ type QueueItem = {
   notes?: Array<{ ts?: string; message?: string }>
 }
 
-function isLocalRequest(request: NextRequest) {
-  const host = request.nextUrl.hostname
-  return process.env.NODE_ENV === 'development' || host === 'localhost' || host === '127.0.0.1' || host === '::1'
+function isLocalRequest() {
+  return process.env.NODE_ENV === 'development'
 }
 
 async function readJsonFile<T>(filePath: string, fallback: T): Promise<T> {
@@ -49,7 +48,7 @@ async function readJsonlTail(filePath: string, limit: number) {
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   return withErrorHandling(async () => {
-    if (!isLocalRequest(request)) {
+    if (!isLocalRequest()) {
       return notFound('Autonomy dashboard')
     }
 


### PR DESCRIPTION
### Motivation
- The dashboard `/api/dashboard/autonomy` relied on `request.nextUrl.hostname` (derived from the `Host` header) to decide locality, which is spoofable and allowed unauthenticated disclosure of local autonomy files and the repository path; the change restricts access to development-only to remove the Host-header trust.

### Description
- Replace the Host-header-based `isLocalRequest(request)` check with a simple `isLocalRequest()` that returns `process.env.NODE_ENV === 'development'` and update the GET handler to call the new check, preserving the existing payload and file-reading behavior for local development.

### Testing
- Ran `npx eslint app/api/dashboard/autonomy/route.ts`, which could not complete in this environment due to a missing `@next/eslint-plugin-next` dependency referenced by `eslint.config.mjs`, so no further automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c72216b0832aa0e5260bc06ddc32)