### PR TITLE
fix(autonomy): redact credentials from git origin in run artifacts

### DIFF
--- a/scripts/autonomy/run_artifacts.py
+++ b/scripts/autonomy/run_artifacts.py
@@ -10,6 +10,7 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
+from urllib.parse import urlsplit, urlunsplit
 
 
 RUN_SCHEMA_VERSION = "mutx.autonomy.run/v1alpha1"
@@ -52,10 +53,22 @@ def git_snapshot() -> dict[str, Any]:
     return {
         "head": git_output(["rev-parse", "HEAD"]),
         "branch": git_output(["branch", "--show-current"]),
-        "origin_url": git_output(["remote", "get-url", "origin"]),
+        "origin_url": sanitize_git_remote_url(git_output(["remote", "get-url", "origin"])),
         "dirty": bool(status),
         "status_lines": [line for line in status.splitlines() if line],
     }
+
+
+def sanitize_git_remote_url(url: str | None) -> str | None:
+    if not url:
+        return url
+    split_url = urlsplit(url)
+    if not split_url.scheme or not split_url.netloc or "@" not in split_url.netloc:
+        return url
+    sanitized_netloc = split_url.netloc.rsplit("@", maxsplit=1)[-1]
+    return urlunsplit(
+        (split_url.scheme, sanitized_netloc, split_url.path, split_url.query, split_url.fragment)
+    )
 
 
 def load_run_record(run_json_path: Path) -> dict[str, Any]:

--- a/tests/test_hosted_llm_executor.py
+++ b/tests/test_hosted_llm_executor.py
@@ -179,6 +179,23 @@ def test_initialize_run_artifact_creates_schema_bundle(
     assert (run_json_path.parent / "inputs" / "brief.md").exists()
 
 
+def test_sanitize_git_remote_url_redacts_credentials() -> None:
+    assert (
+        RUN_ARTIFACTS.sanitize_git_remote_url("https://token123@github.com/example/repo.git")
+        == "https://github.com/example/repo.git"
+    )
+    assert (
+        RUN_ARTIFACTS.sanitize_git_remote_url(
+            "https://oauth:secret@github.com/example/repo.git"
+        )
+        == "https://github.com/example/repo.git"
+    )
+    assert (
+        RUN_ARTIFACTS.sanitize_git_remote_url("git@github.com:example/repo.git")
+        == "git@github.com:example/repo.git"
+    )
+
+
 def test_record_verification_results_marks_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     work_order = {


### PR DESCRIPTION
### Motivation
- Run artifacts persisted the raw `origin_url` from `git remote get-url origin`, which can embed credentials (e.g., `https://token@github.com/...`) and leak sensitive tokens when run artifacts are shared.

### Description
- Add `sanitize_git_remote_url()` in `scripts/autonomy/run_artifacts.py` using `urllib.parse` to strip userinfo from credentialed HTTPS-style remote URLs and leave SSH/scp-like remotes unchanged.
- Wire the sanitizer into `git_snapshot()` so `origin_url` is sanitized before being recorded in run provenance.
- Add a regression test `test_sanitize_git_remote_url_redacts_credentials` in `tests/test_hosted_llm_executor.py` to assert credential redaction behavior; changes touch `scripts/autonomy/run_artifacts.py` and `tests/test_hosted_llm_executor.py`.

### Testing
- Compiled the modified modules with `python -m compileall scripts/autonomy/run_artifacts.py tests/test_hosted_llm_executor.py`, which succeeded. 
- Attempted `pytest -q tests/test_hosted_llm_executor.py`, but the test run failed in this environment due to a missing test dependency (`pytest_asyncio`) declared in `tests/conftest.py`, so full pytest validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c7215370832a864c60fd923e9068)