### PR TITLE
fix(docs): prevent path traversal in docs slug resolution

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -56,6 +56,9 @@ function resolveSlug(slugSegments: string[]): string | null {
   if (isRootContent(slugSegments)) {
     return resolveRootContentSlug(slugSegments);
   }
+  if (hasUnsafeSlugSegment(slugSegments)) {
+    return null;
+  }
 
   if (slugSegments.length === 1 && slugSegments[0] === "README") {
     const rootReadme = path.join(docsDir(), "README.md");
@@ -100,6 +103,18 @@ function resolveSlug(slugSegments: string[]): string | null {
   }
 
   return null;
+}
+
+function hasUnsafeSlugSegment(slugSegments: string[]): boolean {
+  return slugSegments.some(
+    (segment) =>
+      segment.length === 0 ||
+      segment === "." ||
+      segment === ".." ||
+      segment.includes("/") ||
+      segment.includes("\\") ||
+      segment.includes("\0")
+  );
 }
 
 export async function generateMetadata({


### PR DESCRIPTION
### Motivation

- The docs catch-all route built filesystem paths directly from URL slug segments, allowing `..` and other crafted segments to escape the `docs/` directory and disclose arbitrary `.md` files via the docs renderer. 
- The change aims to block unsafe slug segments early so that traversal-style or malformed inputs map to the existing `notFound()` behavior rather than reading files outside the docs tree.

### Description

- Added a new `hasUnsafeSlugSegment(slugSegments: string[])` helper in `app/docs/[[...slug]]/page.tsx` that rejects empty segments, `.`/`..`, path separators (`/` or `\`), and null bytes.
- Short-circuited `resolveSlug(...)` to return `null` when an unsafe segment is present, preserving the existing file-candidate lookup for valid slugs and causing the route to render `notFound()` for unsafe inputs.
- No changes were made to rendering or frontmatter parsing; normal docs lookup and rendering remain unchanged for safe slugs.
- Modified file: `app/docs/[[...slug]]/page.tsx`.

### Testing

- Ran `npm run typecheck` (which invokes `tsc --noEmit`) and it completed successfully.
- No other automated tests were modified or executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c7222300832a856df2b445590ec3)