### PR TITLE
fix(security): sanitize docs HTML before rendering

### DIFF
--- a/components/site/docs/DocsRenderer.tsx
+++ b/components/site/docs/DocsRenderer.tsx
@@ -86,6 +86,13 @@ export function extractHeadings(source: string): Heading[] {
   return headings;
 }
 
+function sanitizeHtml(html: string): string {
+  return html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/\son\w+=(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+    .replace(/\s(href|src)\s*=\s*(['"])\s*javascript:[^'"]*\2/gi, ' $1="#"')
+}
+
 export async function DocsRenderer({ source, currentSlug = [] }: { source: string; currentSlug?: string[] }) {
   // Preprocess: convert GitBook liquid hints → HTML callouts
   const preprocessed = preprocessHints(source);
@@ -128,6 +135,8 @@ export async function DocsRenderer({ source, currentSlug = [] }: { source: strin
       `$1<a id="${heading.id}" href="#${heading.id}" class="heading-anchor" aria-hidden="true">#</a>$3$4$5`
     );
   }
+
+  html = sanitizeHtml(html)
 
   // Dynamic import of client component to avoid SSR issues with DOM APIs
   const { DocsRendererClient } = await import("./DocsRendererClient");


### PR DESCRIPTION
### Motivation
- Remediate a stored XSS vector where markdown processed by `remark()` was injected into the DOM via `dangerouslySetInnerHTML` without sanitization, while preserving the existing markdown/anchor behavior.

### Description
- Add a `sanitizeHtml` helper that strips `<script>` blocks, inline `on*=` event handler attributes, and `javascript:` payloads in `href`/`src`, and pass the sanitized HTML to `dangerouslySetInnerHTML` in `DocsRenderer` while keeping the `remark` pipeline and heading-anchor augmentation unchanged.

### Testing
- Ran `npm run typecheck`, which completed successfully.
- Attempted `npx eslint components/site/docs/DocsRenderer.tsx`, but lint could not run in this environment due to a missing `@next/eslint-plugin-next` package (ESLint error), so linting was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c7214afc832abfaa0b983c92cf9c)