### PR TITLE
fix(autonomy): restore dynamic REPO resolution in autonomy scripts

### DIFF
--- a/scripts/autonomy/autonomous-coder.py
+++ b/scripts/autonomy/autonomous-coder.py
@@ -5,8 +5,7 @@ Reads queue → MiniMax generates code → git commits → gh PRs → loops
 """
 import json, os, time, subprocess, urllib.request, urllib.error, shlex
 from datetime import datetime
-
-import os
+from pathlib import Path
 _REPO = None
 def _get_repo():
     global _REPO

--- a/scripts/autonomy/mutx-autonomous-daemon.py
+++ b/scripts/autonomy/mutx-autonomous-daemon.py
@@ -6,7 +6,7 @@ Supervises itself: keeps running, auto-restarts, logs everything.
 """
 import json, os, sys, time, subprocess, signal, random, shlex
 from datetime import datetime
-import os
+from pathlib import Path
 _REPO = None
 def _get_repo():
     global _REPO
@@ -20,8 +20,6 @@ def _get_repo():
     _REPO = str(Path(__file__).resolve().parents[2])
     return _REPO
 REPO = _get_repo()
-
-REPO      = "REPO"
 QUEUE     = f"{REPO}/mutx-engineering-agents/dispatch/action-queue.json"
 LOG       = "/Users/fortune/.openclaw/logs/autonomous-daemon.log"
 PID_FILE  = "/Users/fortune/.openclaw/autonomous-daemon.pid"

--- a/scripts/autonomy/mutx-gap-scanner-v3.py
+++ b/scripts/autonomy/mutx-gap-scanner-v3.py
@@ -21,8 +21,6 @@ def _get_repo():
     _REPO = str(Path(__file__).resolve().parents[2])
     return _REPO
 REPO = _get_repo()
-
-REPO     = "REPO"
 QUEUE    = f"{REPO}/mutx-engineering-agents/dispatch/action-queue.json"
 GH_REPO  = "mutx-dev/mutx-dev"
 

--- a/scripts/autonomy/mutx-master-controller.py
+++ b/scripts/autonomy/mutx-master-controller.py
@@ -4,7 +4,7 @@ MUTX Master Controller — runs gap scanner + daemon watchdog in one supervised 
 Replaces LaunchAgent approach (sandbox issues). Uses simple nohup supervision.
 """
 import os, sys, time, subprocess, json, signal
-import os
+from pathlib import Path
 _REPO = None
 def _get_repo():
     global _REPO
@@ -18,8 +18,6 @@ def _get_repo():
     _REPO = str(Path(__file__).resolve().parents[2])
     return _REPO
 REPO = _get_repo()
-
-REPO      = "REPO"
 DAEMON    = f"{REPO}/scripts/autonomy/mutx-autonomous-daemon.py"
 GAPSCAN   = f"{REPO}/scripts/autonomy/mutx-gap-scanner-v3.py"
 QUEUE     = f"{REPO}/mutx-engineering-agents/dispatch/action-queue.json"


### PR DESCRIPTION
### Motivation
- A recent change tried to centralize repo root resolution but left `_get_repo()` using `Path` without importing it and then overwrote the computed `REPO` with the literal string `"REPO"`, causing startup `NameError` crashes and incorrect file paths. 
- The autonomy daemon/scanner/controller rely on correct repo-root resolution for queue and script paths, so this regression prevents the autonomous tooling from running correctly.

### Description
- Import `Path` from `pathlib` where `_get_repo()` uses it to compute the repo root to fix the `NameError` on startup. 
- Remove accidental `REPO = "REPO"` overrides so the computed `_get_repo()` value is preserved and queue/script paths remain anchored to the repository. 
- Modified files: `scripts/autonomy/mutx-autonomous-daemon.py`, `scripts/autonomy/mutx-master-controller.py`, `scripts/autonomy/autonomous-coder.py`, and `scripts/autonomy/mutx-gap-scanner-v3.py`.

### Testing
- Ran `python -m py_compile scripts/autonomy/mutx-autonomous-daemon.py scripts/autonomy/mutx-master-controller.py scripts/autonomy/autonomous-coder.py scripts/autonomy/mutx-gap-scanner-v3.py scripts/autonomy/autonomous-loop.py scripts/autonomy/mutx-gap-scanner.py` which succeeded indicating there are no top-level syntax errors. 
- Executing `python scripts/autonomy/mutx-autonomous-daemon.py` and `python scripts/autonomy/mutx-master-controller.py` progressed past the previous `NameError` but then failed with `FileNotFoundError` for host-local log/pid directories (these failures are due to the container environment not having `/Users/fortune/.openclaw/...` paths and are unrelated to the repo-resolution fix). 
- `python scripts/autonomy/mutx-gap-scanner-v3.py` ran successfully in this environment, and `autonomous-coder.py` now progresses past `_get_repo()` but fails due to missing local log directory as noted above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c722327c832abca57877a96f34c5)