### PR TITLE
fix: require API key auth for MLX RAG service endpoints

### DIFF
--- a/scripts/mlx-rag-service.py
+++ b/scripts/mlx-rag-service.py
@@ -14,7 +14,7 @@ import numpy as np
 from mlx_embeddings import load as load_embed_model
 from mlx_embeddings import generate as mlx_generate
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.responses import ORJSONResponse
 from pydantic import BaseModel
 import uvicorn
@@ -25,6 +25,7 @@ MODEL_ID  = os.getenv("EMBED_MODEL", "mlx-community/mxbai-embed-large-v1")
 PORT      = int(os.getenv("PORT", "18792"))
 TOP_K     = int(os.getenv("TOP_K", "8"))
 DIM       = 1024  # mxbai-embed-large-v1 output dim
+API_KEY   = os.getenv("MLX_RAG_API_KEY")
 
 # ── Model (loaded once, stays in M4 GPU memory) ───────────────────────────────
 _model_lock = threading.Lock()
@@ -95,6 +96,23 @@ def init_db():
 # ── FastAPI ───────────────────────────────────────────────────────────────────
 app = FastAPI(title="MUTX MLX RAG", version="1.0.0", default_response_class=ORJSONResponse)
 
+def require_api_key(
+    x_api_key: Optional[str] = Header(default=None),
+    authorization: Optional[str] = Header(default=None),
+) -> None:
+    if not API_KEY:
+        raise HTTPException(503, "MLX_RAG_API_KEY is not configured")
+
+    bearer_token = None
+    if authorization:
+        scheme, _, token = authorization.partition(" ")
+        if scheme.lower() == "bearer" and token:
+            bearer_token = token
+
+    provided_key = x_api_key or bearer_token
+    if provided_key != API_KEY:
+        raise HTTPException(401, "unauthorized")
+
 # ── Health ────────────────────────────────────────────────────────────────────
 @app.get("/health")
 def health():
@@ -106,7 +124,7 @@ def health():
 
 # ── Embed ─────────────────────────────────────────────────────────────────────
 @app.post("/embed")
-def embed(texts: list[str]):
+def embed(texts: list[str], _auth: None = Depends(require_api_key)):
     if not texts or len(texts) > 100:
         raise HTTPException(400, "texts must be 1–100 items")
     try:
@@ -117,7 +135,7 @@ def embed(texts: list[str]):
 
 # ── Index ─────────────────────────────────────────────────────────────────────
 @app.post("/index")
-def index_docs(docs: list[dict]):
+def index_docs(docs: list[dict], _auth: None = Depends(require_api_key)):
     """
     Index documents. Each: {id, content, metadata: {source, title, tags}}
     Re-indexing same doc_id replaces content + vector.
@@ -153,7 +171,7 @@ class QueryReq(BaseModel):
 
 # ── Query ─────────────────────────────────────────────────────────────────────
 @app.post("/query")
-def query_req(req: QueryReq):
+def query_req(req: QueryReq, _auth: None = Depends(require_api_key)):
     """
     Semantic similarity search. Returns top-k docs ranked by cosine similarity.
     Set hybrid=true for MLX semantic + keyword boost.
@@ -213,14 +231,14 @@ def query_req(req: QueryReq):
 
 # ── Stats ─────────────────────────────────────────────────────────────────────
 @app.get("/stats")
-def stats():
+def stats(_auth: None = Depends(require_api_key)):
     conn = get_db()
     count = conn.execute("SELECT COUNT(*) FROM docs").fetchone()[0]
     return {"docs": count, "dim": DIM, "model": MODEL_ID, "db": DB_PATH}
 
 # ── Clear ─────────────────────────────────────────────────────────────────────
 @app.post("/clear")
-def clear():
+def clear(_auth: None = Depends(require_api_key)):
     conn = get_db()
     conn.execute("DELETE FROM docs")
     conn.execute("DELETE FROM doc_vecs")


### PR DESCRIPTION
### Motivation
- The MLX RAG FastAPI script exposed sensitive read/write/delete endpoints (`/embed`, `/index`, `/query`, `/stats`, `/clear`) with no access control, allowing any local caller to exfiltrate, poison, or wipe the index.
- The service binds to `127.0.0.1` by default which reduces network exposure but still leaves a local attack surface that must be protected.

### Description
- Add an `MLX_RAG_API_KEY` environment variable and a shared `require_api_key` dependency that validates requests via `X-API-Key` or `Authorization: Bearer <token>`.
- Apply the `require_api_key` dependency (via `Depends`) to the data-bearing and mutating endpoints: `/embed`, `/index`, `/query`, `/stats`, and `/clear`.
- Keep the `/health` endpoint unauthenticated for local liveness checks and return `503` if the API key is not configured or `401` for invalid credentials.
- Make minimal, targeted changes in `scripts/mlx-rag-service.py` and preserve existing endpoint behavior and payloads.

### Testing
- Ran `python3 -m compileall scripts/mlx-rag-service.py` which completed successfully and verified the modified module compiles without syntax errors.
- Verified the updated file compiles under the repository Python environment as part of the change validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c72207b0832ab1cd8eb89bb0a557)