### PR TITLE
fix(docker): restore lockfile determinism in Docker dependency stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM base AS deps
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 
 # Builder stage
 FROM base AS builder


### PR DESCRIPTION
### Motivation
- Prevent supply-chain regression by enforcing lockfile determinism during image builds because the dependency stage previously ran `RUN pnpm install` without `--frozen-lockfile`, allowing dependency resolution drift if `package.json` and `pnpm-lock.yaml` diverged.

### Description
- Replace `RUN pnpm install` with `RUN pnpm install --frozen-lockfile` in the `Dockerfile` dependency stage so the build will fail if the lockfile is out of sync and prevent unreviewed dependency updates.

### Testing
- Confirmed the change by inspecting the `Dockerfile` with `nl -ba Dockerfile` and `git diff -- Dockerfile`, and committed the update; inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c72181e4832ab12537c06ebc050d)