### PR TITLE
fix: require explicit Grafana admin password in monitoring compose

### DIFF
--- a/infrastructure/docker/docker-compose.monitoring.yml
+++ b/infrastructure/docker/docker-compose.monitoring.yml
@@ -51,7 +51,7 @@ services:
     container_name: mutx-grafana
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL:-http://localhost:3001}
       - GF_SERVER_SERVE_FROM_SUB_PATH=false


### PR DESCRIPTION
### Motivation
- Prevent predictable default Grafana credentials by removing the insecure `admin` fallback and forcing operators to provide `GRAFANA_ADMIN_PASSWORD` at deploy time.

### Description
- Change the Grafana env entry in `infrastructure/docker/docker-compose.monitoring.yml` from `GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}` to `GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD}` so the password is required.

### Testing
- Ran `rg -n "GF_SECURITY_ADMIN_PASSWORD" infrastructure/docker/docker-compose.monitoring.yml` to confirm the updated line and ran `git diff --check` to ensure no whitespace or diff issues; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c7225038832a8001e355e32b01ba)