### PR TITLE
fix(ansible): reconcile n8n log level variable in templates

### DIFF
--- a/infrastructure/ansible/roles/n8n/templates/docker-compose.yml.j2
+++ b/infrastructure/ansible/roles/n8n/templates/docker-compose.yml.j2
@@ -29,8 +29,8 @@ services:
       {% if n8n_webhook_url %}
       - WEBHOOK_URL={{ n8n_webhook_url }}
       {% endif %}
-      {% if n8n_log_LEVEL %}
-      - N8N_LOG_LEVEL={{ n8n_log_LEVEL }}
+      {% if (n8n_log_level | default(n8n_log_LEVEL | default(""))) %}
+      - N8N_LOG_LEVEL={{ n8n_log_level | default(n8n_log_LEVEL | default("info")) }}
       {% endif %}
     volumes:
       - {{ n8n_data_path }}:/home/node/.n8n

--- a/infrastructure/ansible/roles/n8n/templates/n8n.env.j2
+++ b/infrastructure/ansible/roles/n8n/templates/n8n.env.j2
@@ -39,7 +39,7 @@ N8N_CUSTOM_EXTENSION_BUNDLE={{ n8n_n8n_custom_extension_bundle }}
 N8N_CUSTOM_EXTENSIONS={{ n8n_n8n_custom_extensions }}
 {% endif %}
 
-N8N_LOG_LEVEL={{ n8n_log_LEVEL }}
+N8N_LOG_LEVEL={{ n8n_log_level | default(n8n_log_LEVEL | default("info")) }}
 
 {% for key, value in n8n_generic_variables.items() %}
 {{ key }}={{ value }}


### PR DESCRIPTION
### Motivation

- The role defaults were renamed to `n8n_log_level` while templates still referenced `n8n_log_LEVEL`, causing Jinja/Ansible undefined-variable rendering failures or an empty `N8N_LOG_LEVEL` in generated configs.
- This mismatch prevents the `n8n` role from reliably producing correct environment files and docker-compose entries under strict undefined-variable behavior.

### Description

- Updated `infrastructure/ansible/roles/n8n/templates/n8n.env.j2` to render `N8N_LOG_LEVEL` from `n8n_log_level` while falling back to legacy `n8n_log_LEVEL` and defaulting to `"info"` when neither is set.
- Updated `infrastructure/ansible/roles/n8n/templates/docker-compose.yml.j2` to conditionally include the `N8N_LOG_LEVEL` environment line using the same fallback logic and default value.
- The changes are intentionally minimal and backward-compatible to avoid breaking existing inventories that still set the old variable name.

### Testing

- Searched the role for both variable names with `rg -n "n8n_log_LEVEL|n8n_log_level" infrastructure/ansible/roles/n8n` to confirm all occurrences were updated and the defaults remain defined.
- Ran `make -C infrastructure ansible-lint`, which could not complete in this environment because `ansible-lint` is not installed (command not found), so linting could not be validated here.
- Verified template diffs and committed the fix to the branch; no other automated test failures were produced locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c7214e9c832abfe45a7365d4853b)