### PR TITLE
fix: cap retry-after derived lane pauses to prevent orchestrator crashes

### DIFF
--- a/scripts/autonomy/lane_state.py
+++ b/scripts/autonomy/lane_state.py
@@ -24,6 +24,7 @@ def save_lane_state(path: str | Path, payload: dict[str, Any]) -> None:
 
 
 DEFAULT_QUOTA_RESUME_SECONDS = 1800
+MAX_QUOTA_RESUME_SECONDS = 86400
 
 
 def pause_lane(
@@ -40,13 +41,17 @@ def pause_lane(
     paused_at = utc_now_iso()
     auto_resume_after_seconds = None
     if reason == "quota_exceeded":
-        auto_resume_after_seconds = retry_after_seconds or int(
+        requested_resume_seconds = retry_after_seconds or int(
             lane_state.get("auto_resume_after_seconds") or DEFAULT_QUOTA_RESUME_SECONDS
         )
+        auto_resume_after_seconds = max(1, min(requested_resume_seconds, MAX_QUOTA_RESUME_SECONDS))
     resume_at = None
     if auto_resume_after_seconds:
-        resume_at = datetime.now(timezone.utc).timestamp() + auto_resume_after_seconds
-        resume_at = datetime.fromtimestamp(resume_at, timezone.utc).isoformat().replace("+00:00", "Z")
+        try:
+            resume_at_ts = datetime.now(timezone.utc).timestamp() + auto_resume_after_seconds
+            resume_at = datetime.fromtimestamp(resume_at_ts, timezone.utc).isoformat().replace("+00:00", "Z")
+        except (OverflowError, OSError, ValueError):
+            resume_at = None
     lane_state.update(
         {
             "paused": True,

--- a/tests/test_autonomy_lane_contract.py
+++ b/tests/test_autonomy_lane_contract.py
@@ -190,6 +190,21 @@ def test_lane_state_can_pause_lane() -> None:
     assert updated["lanes"]["codex"]["resume_at"]
 
 
+def test_lane_state_caps_extreme_retry_after_values() -> None:
+    payload = {"lanes": {}}
+    updated = LANE_STATE.pause_lane(
+        payload,
+        "codex",
+        reason="quota_exceeded",
+        source="issue-2",
+        retry_after_seconds=10**12,
+    )
+
+    assert LANE_STATE.is_lane_paused(updated, "codex") is True
+    assert updated["lanes"]["codex"]["auto_resume_after_seconds"] == LANE_STATE.MAX_QUOTA_RESUME_SECONDS
+    assert updated["lanes"]["codex"]["resume_at"]
+
+
 def test_worktree_utils_recognizes_git_repo(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
### Motivation
- A parsed `retry_after_seconds` value from untrusted runner output could be arbitrarily large and lead to `datetime.fromtimestamp` raising `ValueError`, crashing the orchestrator or leading to indefinite lane pauses.  
- The change aims to make pause/resume behavior robust against attacker-controlled or malformed retry values while preserving pause semantics.

### Description
- Add a bounded window `MAX_QUOTA_RESUME_SECONDS = 86400` (24h) and clamp `quota_exceeded` auto-resume values to `max(1, min(requested, MAX_QUOTA_RESUME_SECONDS))` in `pause_lane`.  
- Replace the previous direct timestamp math + `datetime.fromtimestamp` call with a `try/except` block that catches `(OverflowError, OSError, ValueError)` and falls back to leaving `resume_at` as `None` on failure.  
- Add a regression test `test_lane_state_caps_extreme_retry_after_values` to `tests/test_autonomy_lane_contract.py` that passes an extreme `retry_after_seconds` and verifies the value is capped and a pause is still applied.  
- Modified files: `scripts/autonomy/lane_state.py` and `tests/test_autonomy_lane_contract.py`.

### Testing
- `python -m compileall scripts/autonomy/lane_state.py tests/test_autonomy_lane_contract.py` succeeded.  
- `python -m pytest tests/test_autonomy_lane_contract.py -q` could not be run to completion in this environment due to a missing dependency (`pytest_asyncio`), so full test execution is pending in CI or a developer environment where test dependencies are installed.  
- A new regression test was added to assert oversized `retry_after_seconds` are clamped and do not cause `fromtimestamp` to raise.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e68f8e70832a83b7f8bcea6fc665)