### PR TITLE
fix: restore SDK error-handling scanning in gap-scanner v3

### DIFF
--- a/scripts/autonomy/mutx-gap-scanner-v3.py
+++ b/scripts/autonomy/mutx-gap-scanner-v3.py
@@ -108,7 +108,7 @@ def scan_untested():
 def scan_error_handling():
     """Find functions without try/except or error handling."""
     items = []
-    for pattern in f"{REPO}/sdk/mutx/*.py":
+    for pattern in [f"{REPO}/sdk/mutx/*.py"]:
         for path in glob.glob(pattern):
             name = os.path.basename(path).replace('.py', '')
             if name.startswith('_'):


### PR DESCRIPTION
### Motivation
- Fix a bug where `scan_error_handling()` iterated over a string (character-by-character) instead of glob pattern(s), which prevented `sdk/mutx/*.py` files from being discovered and analyzed for missing error-handling.

### Description
- Change the loop to iterate a list of glob patterns by replacing `for pattern in f"{REPO}/sdk/mutx/*.py":` with `for pattern in [f"{REPO}/sdk/mutx/*.py"]`, restoring correct file discovery while preserving the existing heuristics.

### Testing
- Performed an automated module load and run: `importlib.util`-based import of `scripts/autonomy/mutx-gap-scanner-v3.py` and executed `mod.scan_error_handling()` with `mod.REPO` set to `/workspace/mutx-dev`, which returned a `list` of findings (`len(items) == 5`), confirming the scanner now detects SDK candidates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c72258f0832ab200960550fe6f96)