### PR TITLE
fix(api): restrict runtime governance metrics/status to internal users

### DIFF
--- a/src/api/routes/runtime.py
+++ b/src/api/routes/runtime.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.database import get_db
-from src.api.middleware.auth import get_current_user
+from src.api.middleware.auth import get_current_internal_user, get_current_user
 from src.api.models import User
 from src.api.models.schemas import RuntimeProviderSnapshotResponse, RuntimeProviderSnapshotUpsert
 from src.api.services.operator_state import (
@@ -43,7 +43,7 @@ async def upsert_runtime_provider_state(
 
 @router.get("/governance/metrics")
 async def governance_metrics(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_internal_user),
 ):
     try:
         from cli.faramesh_runtime import (
@@ -60,7 +60,7 @@ async def governance_metrics(
 
 @router.get("/governance/status")
 async def governance_status(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_internal_user),
 ):
     try:
         from cli.faramesh_runtime import collect_faramesh_snapshot, get_faramesh_health

--- a/tests/api/test_governance_security.py
+++ b/tests/api/test_governance_security.py
@@ -131,3 +131,64 @@ async def test_governance_supervision_start_returns_400_for_rejected_launch(
 
     assert response.status_code == 400
     assert "launch profile" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_governance_runtime_metrics_require_internal_user(
+    client: AsyncClient, other_user_client: AsyncClient, monkeypatch
+):
+    import cli.faramesh_runtime as faramesh_runtime
+
+    class FakeSnapshot:
+        decisions_total = 4
+        permits_today = 2
+        denies_today = 1
+        defers_today = 1
+        pending_approvals = 3
+        status = "running"
+
+    monkeypatch.setattr(faramesh_runtime, "collect_faramesh_snapshot", lambda: FakeSnapshot())
+    monkeypatch.setattr(
+        faramesh_runtime,
+        "generate_prometheus_metrics",
+        lambda _snapshot: "mutx_governance_decisions_total 4\n",
+    )
+
+    allowed_response = await client.get("/v1/runtime/governance/metrics")
+    assert allowed_response.status_code == 200
+    assert "mutx_governance_decisions_total" in allowed_response.text
+
+    forbidden_response = await other_user_client.get("/v1/runtime/governance/metrics")
+    assert forbidden_response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_governance_runtime_status_require_internal_user(
+    client: AsyncClient, other_user_client: AsyncClient, monkeypatch
+):
+    import cli.faramesh_runtime as faramesh_runtime
+
+    class FakeHealth:
+        daemon_reachable = True
+        socket_reachable = True
+        policy_loaded = True
+        version = "1.2.3"
+        policy_name = "starter"
+
+    class FakeSnapshot:
+        decisions_total = 4
+        permits_today = 2
+        denies_today = 1
+        defers_today = 1
+        pending_approvals = 3
+        status = "running"
+
+    monkeypatch.setattr(faramesh_runtime, "get_faramesh_health", lambda: FakeHealth())
+    monkeypatch.setattr(faramesh_runtime, "collect_faramesh_snapshot", lambda: FakeSnapshot())
+
+    allowed_response = await client.get("/v1/runtime/governance/status")
+    assert allowed_response.status_code == 200
+    assert allowed_response.json()["policy_name"] == "starter"
+
+    forbidden_response = await other_user_client.get("/v1/runtime/governance/status")
+    assert forbidden_response.status_code == 403


### PR DESCRIPTION
### Motivation

- The `/v1/runtime/governance/metrics` and `/v1/runtime/governance/status` endpoints previously accepted any authenticated user via `get_current_user`, exposing global Faramesh governance statistics and pending approvals to non-internal tenants.
- The change closes an information-disclosure hole by ensuring only verified internal users (configured internal email domains) can access these operational endpoints.

### Description

- Require `get_current_internal_user` for the governance endpoints in `src/api/routes/runtime.py` instead of `get_current_user` to enforce internal-user verification.
- Add two API security tests in `tests/api/test_governance_security.py` verifying that internal users can access `GET /v1/runtime/governance/metrics` and `GET /v1/runtime/governance/status` while other authenticated users receive `403` responses.
- Tests mock `cli.faramesh_runtime` helpers (`collect_faramesh_snapshot`, `get_faramesh_health`, `generate_prometheus_metrics`) so the assertions focus on auth behavior rather than runtime I/O.
- Changes are minimal and preserve existing endpoint behavior for authorized internal users.

### Testing

- Ran `python -m compileall src/api/routes/runtime.py tests/api/test_governance_security.py`, which succeeded and confirmed the modified files compile.
- Attempted `python -m pytest tests/api/test_governance_security.py -q`, which failed in this environment due to a missing test dependency (`pytest_asyncio`), so test execution could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c7217b94832aa315577d520541bd)