### PR TITLE
fix: enforce governance deferrals in gateway middleware

### DIFF
--- a/src/api/services/gateway_client.py
+++ b/src/api/services/gateway_client.py
@@ -168,10 +168,10 @@ async def call_gateway_method_governed(
                 tool_id=method,
                 params=params or {},
             )
-            if decision.outcome == "HALT":
+            if decision.outcome == "HALT" or decision.effect == "DEFER":
                 raise GovernanceError(
                     tool_id=method,
-                    reason=decision.reason or "denied by policy",
+                    reason=decision.reason or "denied or deferred by policy",
                     reason_code=decision.reason_code,
                 )
 

--- a/tests/api/test_gateway_client.py
+++ b/tests/api/test_gateway_client.py
@@ -1,0 +1,69 @@
+import pytest
+
+from src.api.services import gateway_client
+
+
+class _Decision:
+    def __init__(self, outcome: str, effect: str, reason: str | None = None, reason_code: str | None = None):
+        self.outcome = outcome
+        self.effect = effect
+        self.reason = reason
+        self.reason_code = reason_code
+
+
+@pytest.mark.asyncio
+async def test_call_gateway_method_governed_blocks_deferred_decision(monkeypatch):
+    from cli import faramesh_runtime
+
+    monkeypatch.setattr(
+        faramesh_runtime,
+        'gate_decide',
+        lambda **kwargs: _Decision(
+            outcome='ABSTAIN',
+            effect='DEFER',
+            reason='approval required',
+            reason_code='approval_pending',
+        ),
+    )
+
+    async def _unexpected_call(*args, **kwargs):
+        raise AssertionError('gateway call should not run for deferred governance decision')
+
+    monkeypatch.setattr(gateway_client, 'call_gateway_method', _unexpected_call)
+
+    with pytest.raises(gateway_client.GovernanceError) as excinfo:
+        await gateway_client.call_gateway_method_governed(
+            method='sensitive.action',
+            params={'amount': 42},
+            agent_id='agent-1',
+            governance_enabled=True,
+        )
+
+    assert excinfo.value.reason == 'approval required'
+    assert excinfo.value.reason_code == 'approval_pending'
+
+
+@pytest.mark.asyncio
+async def test_call_gateway_method_governed_allows_permit_decision(monkeypatch):
+    from cli import faramesh_runtime
+
+    monkeypatch.setattr(
+        faramesh_runtime,
+        'gate_decide',
+        lambda **kwargs: _Decision(outcome='EXECUTE', effect='PERMIT'),
+    )
+
+    async def _mock_call_gateway_method(method, params, timeout_ms):
+        return {'method': method, 'params': params, 'timeout_ms': timeout_ms}
+
+    monkeypatch.setattr(gateway_client, 'call_gateway_method', _mock_call_gateway_method)
+
+    result = await gateway_client.call_gateway_method_governed(
+        method='safe.action',
+        params={'ok': True},
+        agent_id='agent-1',
+        governance_enabled=True,
+        timeout_ms=1234,
+    )
+
+    assert result == {'method': 'safe.action', 'params': {'ok': True}, 'timeout_ms': 1234}


### PR DESCRIPTION
### Motivation
- The governed gateway call path only blocked hard denials (`outcome == "HALT"`) and ignored Faramesh `DEFER` decisions (which arrive as `outcome == "ABSTAIN"` with `effect == "DEFER"`), allowing sensitive actions to execute without approval.
- The change aims to ensure deferred decisions trigger the approval flow instead of being bypassed.

### Description
- In `src/api/services/gateway_client.py` `call_gateway_method_governed` now treats `decision.effect == "DEFER"` the same as a denial and raises `GovernanceError` (the error reason message was adjusted to reflect deny/defer semantics).
- Added targeted regression tests in `tests/api/test_gateway_client.py` that assert a `DEFER`/`ABSTAIN` decision blocks execution and that a `PERMIT`/`EXECUTE` decision still allows the gateway call.
- The fix is minimal and scoped to governance enforcement prior to dispatching `call_gateway_method` so normal behavior for permitted calls is preserved.

### Testing
- Ran `pytest -q tests/api/test_gateway_client.py` which passed (`2 passed`).
- Ran `ruff check src/api/services/gateway_client.py tests/api/test_gateway_client.py` which passed with no issues.
- Development dependencies were installed as needed to run the tests (`python3 -m pip install -e '.[dev]'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c7231238832a805b34d0b0e05aff)