### PR TITLE
Avoid passing OpenClaw gateway secrets via CLI args

### DIFF
--- a/cli/openclaw_runtime.py
+++ b/cli/openclaw_runtime.py
@@ -709,9 +709,6 @@ def build_openclaw_surface_command(
     if normalized == "tui":
         if gateway_url and not _is_default_gateway_url(gateway_url):
             command.extend(["--url", gateway_url])
-            auth_arg = resolve_gateway_auth_argument()
-            if auth_arg is not None:
-                command.extend(list(auth_arg))
         if session_key:
             command.extend(["--session", session_key])
     return command

--- a/tests/test_openclaw_runtime.py
+++ b/tests/test_openclaw_runtime.py
@@ -430,17 +430,13 @@ def test_resolve_gateway_auth_argument_reads_password_from_config(
     assert resolve_gateway_auth_argument() == ("--password", "gateway-password")
 
 
-def test_build_openclaw_surface_command_includes_gateway_url_and_auth_for_override(
+def test_build_openclaw_surface_command_includes_gateway_url_without_auth_for_override(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(
         "cli.openclaw_runtime.find_openclaw_bin", lambda: "/opt/homebrew/bin/openclaw"
     )
     monkeypatch.setattr("cli.openclaw_runtime.detect_gateway_port", lambda: 18789)
-    monkeypatch.setattr(
-        "cli.openclaw_runtime.resolve_gateway_auth_argument",
-        lambda: ("--token", "gateway-token"),
-    )
 
     command = build_openclaw_surface_command(
         surface="tui",
@@ -452,8 +448,6 @@ def test_build_openclaw_surface_command_includes_gateway_url_and_auth_for_overri
         "tui",
         "--url",
         "ws://remote.example.test:18789",
-        "--token",
-        "gateway-token",
     ]
 
 
@@ -462,10 +456,6 @@ def test_build_openclaw_surface_command_omits_local_url_override(monkeypatch) ->
         "cli.openclaw_runtime.find_openclaw_bin", lambda: "/opt/homebrew/bin/openclaw"
     )
     monkeypatch.setattr("cli.openclaw_runtime.detect_gateway_port", lambda: 18789)
-    monkeypatch.setattr(
-        "cli.openclaw_runtime.resolve_gateway_auth_argument",
-        lambda: ("--token", "gateway-token"),
-    )
 
     command = build_openclaw_surface_command(
         surface="tui",


### PR DESCRIPTION
### Motivation

- Prevent accidental local disclosure of gateway credentials by removing injection of `--token`/`--password` into process arguments when launching the OpenClaw TUI with a custom gateway URL.

### Description

- Stop adding resolved gateway auth flags to the `openclaw tui` argv in `build_openclaw_surface_command` and preserve the existing URL override and `--session` behavior by only including `--url` and `--session` when appropriate.
- Update the runtime unit test to assert that a custom gateway URL is included but that no auth flags are added to the command argv.
- Changes touch `cli/openclaw_runtime.py` and `tests/test_openclaw_runtime.py` and are intentionally minimal to avoid altering other behavior.

### Testing

- Ran `python3 -m compileall cli/openclaw_runtime.py tests/test_openclaw_runtime.py` which succeeded.
- Ran `pytest -q tests/test_openclaw_runtime.py` in this environment but it failed to run due to a missing test dependency (`pytest_asyncio`) rather than a logic failure in the changes.
- The updated tests assert the URL-override behavior without embedding auth secrets and were updated locally to match the new secure behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c721b594832a937133d21f3ad80f)