### PR TITLE
fix(api): redact sensitive details from public health endpoint

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -316,10 +316,6 @@ def _serialize_background_monitor_component(app: FastAPI) -> dict[str, object]:
 
     return {
         "status": component_status,
-        "started_at": monitor_state.started_at,
-        "last_success_at": monitor_state.last_success_at,
-        "last_error_at": monitor_state.last_error_at,
-        "error": monitor_state.last_error,
         "consecutive_failures": monitor_state.consecutive_failures,
     }
 
@@ -357,7 +353,6 @@ def _register_system_routes(app: FastAPI) -> None:
                 },
                 "background_monitor": background_monitor,
             },
-            schema_repairs_applied=list(request.app.state.schema_repairs_applied),
         )
 
     @app.get("/ready")

--- a/tests/api/test_app_factory.py
+++ b/tests/api/test_app_factory.py
@@ -167,6 +167,9 @@ async def test_health_includes_component_status(client: AsyncClient):
     assert payload["schema_repairs_applied"] == []
     assert payload["components"]["database"]["status"] == "healthy"
     assert payload["components"]["background_monitor"]["status"] == "disabled"
+    assert "error" not in payload["components"]["background_monitor"]
+    assert "last_error_at" not in payload["components"]["background_monitor"]
+    assert "started_at" not in payload["components"]["background_monitor"]
 
 
 @pytest.mark.asyncio
@@ -185,6 +188,8 @@ async def test_health_degrades_for_background_monitor_failures_while_ready_stays
     assert health_response.status_code == 200
     assert health_response.json()["status"] == "degraded"
     assert health_response.json()["components"]["background_monitor"]["status"] == "degraded"
+    assert "error" not in health_response.json()["components"]["background_monitor"]
+    assert "last_error_at" not in health_response.json()["components"]["background_monitor"]
 
     assert ready_response.status_code == 200
     assert ready_response.json()["status"] == "ready"


### PR DESCRIPTION
### Motivation

- The unauthenticated `/health` endpoint was returning raw background monitor internals (`error` and error timestamps) and `schema_repairs_applied`, which can disclose internal exception texts and schema repair details.

### Description

- Update `_serialize_background_monitor_component` to only expose high-level state (`status` and `consecutive_failures`) and remove sensitive fields (`error`, `last_error_at`, `last_success_at`, `started_at`).
- Stop explicitly returning `schema_repairs_applied` from the public `/health` handler to avoid leaking runtime schema repair details.
- Add/adjust assertions in `tests/api/test_app_factory.py` to ensure sensitive background monitor fields are not present in `/health` responses.

### Testing

- Ran `python -m compileall src/api/main.py tests/api/test_app_factory.py` successfully to validate syntax and imports.
- Attempted to run targeted pytest cases `tests/api/test_app_factory.py::test_health_includes_component_status` and `tests/api/test_app_factory.py::test_health_degrades_for_background_monitor_failures_while_ready_stays_db_based` but the environment is missing `pytest_asyncio`, causing the test run to fail to start (dependency issue unrelated to the change).
- Local unit test assertions in `tests/api/test_app_factory.py` were updated to assert the absence of the sensitive fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c72149d8832ab8dbd5b506fab397)