### PR TITLE
fix(cli): validate tar members to prevent path traversal during local control-plane bootstrap

### DIFF
--- a/cli/local_control_plane.py
+++ b/cli/local_control_plane.py
@@ -329,8 +329,24 @@ def _materialize_source_ref(source_ref: str, destination: Path) -> Path:
 
 
 def _extract_archive(archive_path: Path, destination: Path) -> None:
+    destination_root = destination.resolve()
     with tarfile.open(archive_path, "r:*") as archive:
-        archive.extractall(destination)
+        members = archive.getmembers()
+        for member in members:
+            if member.issym() or member.islnk():
+                raise LocalControlPlaneError(
+                    "MUTX could not provision the local control plane source. "
+                    "Archive contains unsupported link entries."
+                )
+
+            extraction_target = (destination_root / member.name).resolve()
+            if extraction_target != destination_root and destination_root not in extraction_target.parents:
+                raise LocalControlPlaneError(
+                    "MUTX could not provision the local control plane source. "
+                    "Archive contains unsafe paths."
+                )
+
+        archive.extractall(destination_root, members=members)
 
 
 def _resolve_checkout_root(path: Path) -> Path:

--- a/tests/test_local_control_plane.py
+++ b/tests/test_local_control_plane.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import json
+import tarfile
+from io import BytesIO
 from pathlib import Path
 
+import pytest
+
 from cli.local_control_plane import (
+    LocalControlPlaneError,
+    _extract_archive,
     ensure_local_container_runtime,
     ensure_local_control_plane,
     ensure_managed_local_control_checkout,
@@ -140,3 +146,38 @@ def test_ensure_local_container_runtime_can_install_docker_desktop_on_macos(
     assert ["brew", "install", "--cask", "docker"] in commands
     assert ["open", "-a", "Docker"] in commands
     assert any("Installing Docker Desktop" in message for message in progress)
+
+
+def test_extract_archive_rejects_path_traversal(tmp_path: Path) -> None:
+    archive_path = tmp_path / "malicious.tar"
+    destination = tmp_path / "destination"
+    destination.mkdir(parents=True, exist_ok=True)
+
+    escaped_target = tmp_path / "escaped.txt"
+    with tarfile.open(archive_path, "w") as archive:
+        payload = b"owned"
+        info = tarfile.TarInfo(name="../escaped.txt")
+        info.size = len(payload)
+        archive.addfile(info, fileobj=BytesIO(payload))
+
+    with pytest.raises(LocalControlPlaneError) as error:
+        _extract_archive(archive_path, destination)
+    assert "unsafe paths" in str(error.value)
+
+    assert not escaped_target.exists()
+
+
+def test_extract_archive_rejects_symlink_entries(tmp_path: Path) -> None:
+    archive_path = tmp_path / "symlink.tar"
+    destination = tmp_path / "destination"
+    destination.mkdir(parents=True, exist_ok=True)
+
+    with tarfile.open(archive_path, "w") as archive:
+        info = tarfile.TarInfo(name="link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/etc/passwd"
+        archive.addfile(info)
+
+    with pytest.raises(LocalControlPlaneError) as error:
+        _extract_archive(archive_path, destination)
+    assert "unsupported link entries" in str(error.value)


### PR DESCRIPTION
### Motivation

- The local control-plane bootstrap used `tarfile.extractall()` on untrusted archives, allowing path traversal and arbitrary file overwrite via crafted tar members.
- The control source can be overridden by environment variables, so a malicious archive URL or path could be supplied and extracted into the user's filesystem.
- The change aims to eliminate this high-risk arbitrary-write vector while preserving the provisioning flow.

### Description

- Hardened `_extract_archive()` in `cli/local_control_plane.py` to resolve `destination`, iterate `archive.getmembers()`, and validate each member before extraction. 
- Added checks to reject symbolic or hard link entries and to ensure each member's resolved extraction target is inside the intended `destination` root, and only call `archive.extractall()` with the validated `members` into `destination_root`.
- Added regression tests `test_extract_archive_rejects_path_traversal` and `test_extract_archive_rejects_symlink_entries` in `tests/test_local_control_plane.py` that construct malicious tar files and assert `LocalControlPlaneError` is raised.

### Testing

- Ran `python3 -m compileall cli/local_control_plane.py tests/test_local_control_plane.py` which succeeded and verified the modified files compile. 
- Attempted `pytest -q tests/test_local_control_plane.py` but the run failed in this environment due to a missing test dependency (`pytest_asyncio`) imported by `tests/conftest.py`, so the new tests could not be executed here. 
- The change is minimal and the added unit tests exercise the new validation logic; CI or a local environment with test dependencies should run `pytest` to verify full test success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c72315cc832ab1793e7b36c5d6e8)