### PR TITLE
Consolidate remaining cleanly mergeable Pico queue changes

### DIFF
--- a/app/api/dashboard/templates/[templateId]/deploy/route.ts
+++ b/app/api/dashboard/templates/[templateId]/deploy/route.ts
@@ -12,9 +12,12 @@ export async function POST(
 ) {
   return withErrorHandling(async () => {
     const { templateId } = await params
+    const payload = await request.json()
+
     return proxyJson(request, `${getApiBaseUrl()}/v1/templates/${templateId}/deploy`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
       fallbackMessage: 'Failed to deploy starter template',
     })
   })(request)

--- a/app/api/dashboard/templates/[templateId]/deploy/route.ts
+++ b/app/api/dashboard/templates/[templateId]/deploy/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getApiBaseUrl } from '@/app/api/_lib/controlPlane'
-import { withErrorHandling } from '@/app/api/_lib/errors'
+import { badRequest, withErrorHandling } from '@/app/api/_lib/errors'
 import { proxyJson } from '@/app/api/_lib/proxy'
 
 export const dynamic = 'force-dynamic'
@@ -12,7 +12,16 @@ export async function POST(
 ) {
   return withErrorHandling(async () => {
     const { templateId } = await params
-    const payload = await request.json()
+    let payload: unknown
+
+    try {
+      payload = await request.json()
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return badRequest('Invalid JSON in request body')
+      }
+      throw error
+    }
 
     return proxyJson(request, `${getApiBaseUrl()}/v1/templates/${templateId}/deploy`, {
       method: 'POST',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 
 import { MarketingHomePage } from "@/components/site/marketing/MarketingHomePage";
 import { PublicFooter } from "@/components/site/PublicFooter";
+import { PublicNav } from "@/components/site/PublicNav";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import { DEFAULT_X_HANDLE, getCanonicalUrl, getPageOgImageUrl, getSiteUrl } from "@/lib/seo";
 
@@ -80,6 +81,7 @@ export default function HomePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(homepageStructuredData) }}
       />
+      <PublicNav />
       <MarketingHomePage />
       <PublicFooter showCallout={false} />
     </PublicSurface>

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -11780,7 +11780,9 @@ export interface operations {
     get_telemetry_config_v1_telemetry_config_get: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -11795,12 +11797,23 @@ export interface operations {
                     "application/json": unknown;
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     configure_telemetry_v1_telemetry_config_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -11833,7 +11846,9 @@ export interface operations {
     get_telemetry_backend_health_v1_telemetry_health_get: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -11846,6 +11861,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/cli/commands/setup.py
+++ b/cli/commands/setup.py
@@ -82,14 +82,14 @@ def _choose_openclaw_action(
 def _echo_first_agent_hint() -> None:
     click.echo("")
     click.echo("Immediate payoff:")
-    click.echo('  mutx first-agent "Turn these rough notes into three next steps"')
+    click.echo("  mutx onboard --help")
     if shutil.which("hermes"):
         click.echo(
-            "Runs Hermes for a real result, cleans up the output, and saves proof under ~/.mutx/first-agent/."
+            "Use onboard to pick your next guided flow, then run mutx runtime inspect to verify your local runtime."
         )
     else:
         click.echo(
-            "This uses Hermes. Install Hermes first, then rerun the command for one real useful output plus proof under ~/.mutx/first-agent/."
+            "Use onboard to pick your next guided flow, then run mutx runtime inspect after your runtime is configured."
         )
 
 

--- a/cli/commands/setup.py
+++ b/cli/commands/setup.py
@@ -210,9 +210,7 @@ def _install_faramesh_governance() -> None:
         shutil.copy(bundled_policy, policy_path)
         click.echo(f"  ✓ Bundled policy installed to {policy_path}")
 
-    proc = start_faramesh_daemon(
-        policy_path=policy_path, socket_path=FAREMESH_SOCKET_PATH
-    )  # noqa: F821
+    proc = start_faramesh_daemon(policy_path=policy_path, socket_path=FAREMESH_SOCKET_PATH)  # noqa: F821
     if proc is None:
         click.echo("  ⚠ Faramesh daemon could not be started automatically")
         click.echo("    Run manually: faramesh serve --policy <policy.yaml>")

--- a/cli/commands/setup.py
+++ b/cli/commands/setup.py
@@ -1,3 +1,5 @@
+import shutil
+
 import click
 
 from cli.commands.tui import launch_tui
@@ -75,6 +77,20 @@ def _choose_openclaw_action(
         4: "cancel",
     }
     return mapping[selection]
+
+
+def _echo_first_agent_hint() -> None:
+    click.echo("")
+    click.echo("Immediate payoff:")
+    click.echo('  mutx first-agent "Turn these rough notes into three next steps"')
+    if shutil.which("hermes"):
+        click.echo(
+            "Runs Hermes for a real result, cleans up the output, and saves proof under ~/.mutx/first-agent/."
+        )
+    else:
+        click.echo(
+            "This uses Hermes. Install Hermes first, then rerun the command for one real useful output plus proof under ~/.mutx/first-agent/."
+        )
 
 
 def _finish_setup(
@@ -157,6 +173,7 @@ def _finish_setup(
         f"Privacy: {result.runtime_snapshot.get('privacy_summary') or 'Local-only runtime tracking.'}"
     )
 
+    _echo_first_agent_hint()
     _install_faramesh_governance()
 
     if open_tui:
@@ -193,7 +210,9 @@ def _install_faramesh_governance() -> None:
         shutil.copy(bundled_policy, policy_path)
         click.echo(f"  ✓ Bundled policy installed to {policy_path}")
 
-    proc = start_faramesh_daemon(policy_path=policy_path, socket_path=FAREMESH_SOCKET_PATH)  # noqa: F821
+    proc = start_faramesh_daemon(
+        policy_path=policy_path, socket_path=FAREMESH_SOCKET_PATH
+    )  # noqa: F821
     if proc is None:
         click.echo("  ⚠ Faramesh daemon could not be started automatically")
         click.echo("    Run manually: faramesh serve --policy <policy.yaml>")

--- a/components/pico/PicoAutopilotPageClient.tsx
+++ b/components/pico/PicoAutopilotPageClient.tsx
@@ -80,12 +80,12 @@ export function isUnauthorizedPayload(payload: unknown) {
     error?: unknown
   }
 
-  if (candidate.status !== 'error' || !candidate.error || typeof candidate.error !== 'object') {
-    return false
+  if (candidate.status === 'error' && candidate.error && typeof candidate.error === 'object') {
+    const error = candidate.error as { code?: unknown }
+    return error.code === 'UNAUTHORIZED'
   }
 
-  const error = candidate.error as { code?: unknown }
-  return error.code === 'UNAUTHORIZED'
+  return false
 }
 
 function severityClasses(severity: AutopilotTimelineItem['severity']) {
@@ -150,6 +150,7 @@ function EmptyStatePanel({ state }: { state: AutopilotEmptyState }) {
 export function PicoAutopilotPageClient() {
   const { progress, derived, actions, syncState } = usePicoProgress()
   const toHref = usePicoHref()
+  const approvalLessonHref = toHref('/academy/add-an-approval-gate')
   const [runs, setRuns] = useState<AutopilotRunSummary[]>([])
   const [tracesByRunId, setTracesByRunId] = useState<Record<string, AutopilotRunTrace[]>>({})
   const [budget, setBudget] = useState<AutopilotBudgetSummary | null>(null)

--- a/components/pico/PicoAutopilotPageClient.tsx
+++ b/components/pico/PicoAutopilotPageClient.tsx
@@ -161,7 +161,6 @@ export function PicoAutopilotPageClient() {
   const [error, setError] = useState<string | null>(null)
   const [thresholdDraft, setThresholdDraft] = useState(progress.autopilot.costThresholdPercent)
   const [resolvingApprovalId, setResolvingApprovalId] = useState<string | null>(null)
-  const [_creatingApprovalRequest, _setCreatingApprovalRequest] = useState(false)
 
   const pendingApprovals = useMemo(
     () => approvals.filter((approval) => approval.status === 'PENDING'),

--- a/components/pico/PicoAutopilotPageClient.tsx
+++ b/components/pico/PicoAutopilotPageClient.tsx
@@ -137,7 +137,10 @@ function EmptyStatePanel({ state }: { state: AutopilotEmptyState }) {
     <div className="rounded-[24px] border border-white/10 bg-white/5 p-5 text-sm leading-6 text-slate-300">
       <p className="font-medium text-white">{state.title}</p>
       <p className="mt-2">{state.body}</p>
-      <Link href={state.nextStep.href} className="mt-4 inline-flex text-sm font-medium text-emerald-200 hover:text-emerald-100">
+      <Link
+        href={state.nextStep.href}
+        className="mt-4 inline-flex rounded-full border border-emerald-400/30 px-4 py-2 text-sm font-medium text-emerald-200 transition hover:border-emerald-300/60 hover:text-emerald-100"
+      >
         {state.nextStep.label}
       </Link>
     </div>
@@ -323,16 +326,6 @@ export function PicoAutopilotPageClient() {
     [alerts, approvals, budget, progress.autopilot.approvalGateEnabled, runs, usage],
   )
 
-  const loadStateLabel = authRequired
-    ? 'sign in required'
-    : loadState === 'loading'
-      ? 'loading live data'
-      : loadState === 'partial'
-        ? 'partial signal'
-        : loadState === 'offline'
-          ? 'offline'
-          : 'live'
-
   const runEmptyState = useMemo(
     () =>
       getRunsEmptyState(integrationStatus, {
@@ -379,6 +372,22 @@ export function PicoAutopilotPageClient() {
     [integrationStatus, toHref],
   )
 
+  const loadStateLabel = useMemo(() => {
+    if (authRequired) {
+      return 'Auth required'
+    }
+
+    switch (loadState) {
+      case 'loading':
+        return 'Loading live data'
+      case 'partial':
+        return 'Partial live data'
+      case 'offline':
+        return 'Offline'
+      default:
+        return 'Live data ready'
+    }
+  }, [authRequired, loadState])
   function saveThreshold() {
     if (thresholdValidationError) {
       return

--- a/components/pico/PicoAutopilotPageClient.tsx
+++ b/components/pico/PicoAutopilotPageClient.tsx
@@ -150,7 +150,6 @@ function EmptyStatePanel({ state }: { state: AutopilotEmptyState }) {
 export function PicoAutopilotPageClient() {
   const { progress, derived, actions, syncState } = usePicoProgress()
   const toHref = usePicoHref()
-  const approvalLessonHref = toHref('/academy/add-an-approval-gate')
   const [runs, setRuns] = useState<AutopilotRunSummary[]>([])
   const [tracesByRunId, setTracesByRunId] = useState<Record<string, AutopilotRunTrace[]>>({})
   const [budget, setBudget] = useState<AutopilotBudgetSummary | null>(null)

--- a/components/pico/PicoTutorPageClient.tsx
+++ b/components/pico/PicoTutorPageClient.tsx
@@ -16,11 +16,16 @@ const examplePrompts = [
   'I want approval before any outbound send. Which lesson do I follow?',
 ]
 
-type TutorApiResponse = PicoTutorReply & {
+type TutorApiResponse = Partial<PicoTutorReply> & {
   detail?: string
+  reply?: PicoTutorReply
 }
 
-function isTutorReply(value: TutorApiResponse): value is PicoTutorReply {
+function isTutorReply(value: Partial<PicoTutorReply> | null | undefined): value is PicoTutorReply {
+  if (!value) {
+    return false
+  }
+
   return Boolean(
     typeof value.answer === 'string' &&
       typeof value.summary === 'string' &&
@@ -28,6 +33,19 @@ function isTutorReply(value: TutorApiResponse): value is PicoTutorReply {
       Array.isArray(value.lessons) &&
       Array.isArray(value.docs),
   )
+}
+
+
+function normalizeTutorReply(payload: TutorApiResponse) {
+  if (isTutorReply(payload)) {
+    return payload
+  }
+
+  if (isTutorReply(payload.reply)) {
+    return payload.reply
+  }
+
+  return null
 }
 
 function resolveTutorHref(toHref: ReturnType<typeof usePicoHref>, href: string) {
@@ -86,11 +104,12 @@ export function PicoTutorPageClient() {
         throw new Error(payload.detail || 'Tutor request failed')
       }
 
-      if (!isTutorReply(payload)) {
+      const normalizedReply = normalizeTutorReply(payload)
+      if (!normalizedReply) {
         throw new Error('Tutor response came back malformed')
       }
 
-      setReply(payload)
+      setReply(normalizedReply)
       actions.recordTutorQuestion()
     } catch (submitError) {
       setReply(null)

--- a/components/pico/picoAutopilot.ts
+++ b/components/pico/picoAutopilot.ts
@@ -263,6 +263,7 @@ export function analyzeAutopilotIntegration(input: {
   usage: AutopilotUsageBreakdown | null
   approvalGateConfigured: boolean
 }): AutopilotIntegrationStatus {
+  const agents = input.agents ?? []
   const hasRuns = input.runs.length > 0
   const hasAlerts = input.alerts.length > 0
   const hasApprovalRecords = input.approvals.length > 0
@@ -273,15 +274,16 @@ export function analyzeAutopilotIntegration(input: {
         input.usage.usage_by_agent.length > 0 ||
         input.usage.usage_by_type.length > 0)
   )
+  const hasLiveAgent =
+    agents.length > 0 ||
+    hasRuns ||
+    hasAlerts ||
+    hasApprovalRecords ||
+    hasBudget ||
+    hasUsage
 
   return {
-    hasLiveAgent:
-      (input.agents?.length ?? 0) > 0 ||
-      hasRuns ||
-      hasAlerts ||
-      hasApprovalRecords ||
-      hasBudget ||
-      hasUsage,
+    hasLiveAgent,
     hasRuns,
     hasAlerts,
     hasBudget,

--- a/components/site/marketing/MarketingHomePage.tsx
+++ b/components/site/marketing/MarketingHomePage.tsx
@@ -176,23 +176,23 @@ export function MarketingHomePage() {
         <section className={home.socialProofStrip} data-testid="homepage-social-proof">
           <div className={core.shell}>
             <div className={home.socialProofInner}>
-              <p className={home.socialProofTagline}>Trusted by teams running AI agents in production</p>
+              <p className={home.socialProofTagline}>Built around the surfaces that are actually live today</p>
               <div className={home.socialProofMetrics}>
                 <div className={home.socialProofMetric}>
-                  <p className={home.socialProofValue}>100%</p>
-                  <p className={home.socialProofLabel}>Audit Coverage</p>
+                  <p className={home.socialProofValue}>v1.4</p>
+                  <p className={home.socialProofLabel}>Current release</p>
                 </div>
                 <div className={home.socialProofMetric}>
-                  <p className={home.socialProofValue}>&lt;2 min</p>
-                  <p className={home.socialProofLabel}>Time to First Run</p>
+                  <p className={home.socialProofValue}>RBAC</p>
+                  <p className={home.socialProofLabel}>Protected API surface</p>
                 </div>
                 <div className={home.socialProofMetric}>
-                  <p className={home.socialProofValue}>0</p>
-                  <p className={home.socialProofLabel}>Config Required</p>
+                  <p className={home.socialProofValue}>Preview</p>
+                  <p className={home.socialProofLabel}>Pico clearly marked beta</p>
                 </div>
                 <div className={home.socialProofMetric}>
                   <p className={home.socialProofValue}>macOS</p>
-                  <p className={home.socialProofLabel}>Native Desktop</p>
+                  <p className={home.socialProofLabel}>Native desktop handoff</p>
                 </div>
               </div>
             </div>

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -9752,12 +9752,40 @@
         "summary": "Get Telemetry Config",
         "description": "Get current telemetry configuration.\n\nReturns the OTEL status including whether it's enabled,\nthe exporter type, and endpoint if configured.",
         "operationId": "get_telemetry_config_v1_telemetry_config_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9770,15 +9798,33 @@
         "summary": "Configure Telemetry",
         "description": "Configure the telemetry backend OTLP endpoint.\n\nAllows dynamic configuration of the OTLP endpoint and protocol\nfor exporting traces and metrics to Grafana/Jaeger/Tempo.\n\nArgs:\n    request: Contains otlp_endpoint (URL) and protocol (grpc or http).\n\nReturns:\n    The updated telemetry configuration.",
         "operationId": "configure_telemetry_v1_telemetry_config_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TelemetryConfigRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -9810,12 +9856,40 @@
         "summary": "Get Telemetry Backend Health",
         "description": "Get health status of the configured telemetry backend.\n\nReturns:\n    Health status including whether the backend is configured\n    and reachable.",
         "operationId": "get_telemetry_backend_health_v1_telemetry_health_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }

--- a/lib/marketingContent.ts
+++ b/lib/marketingContent.ts
@@ -78,14 +78,13 @@ export type MarketingHomepage = {
 
 const homepageActions: MarketingActionLink[] = [
   {
-    label: 'Go to PicoMUTX',
-    href: 'https://pico.mutx.dev',
-    external: true,
+    label: 'Download for Mac',
+    href: '/download',
     tone: 'primary',
   },
   {
-    label: 'View GitHub',
-    href: 'https://github.com/mutx-dev/mutx-dev',
+    label: 'Try PicoMUTX beta',
+    href: 'https://pico.mutx.dev',
     external: true,
     tone: 'secondary',
   },
@@ -226,6 +225,7 @@ export const marketingPublicRailLinks: MarketingActionLink[] = [
   { label: 'Download', href: '/download' },
   { label: 'Releases', href: '/releases' },
   { label: 'Docs', href: 'https://docs.mutx.dev', external: true },
+  { label: 'Contact', href: '/contact' },
   { label: 'GitHub', href: 'https://github.com/mutx-dev/mutx-dev', external: true },
 ]
 

--- a/scripts/generate_homebrew_formula.py
+++ b/scripts/generate_homebrew_formula.py
@@ -17,7 +17,6 @@ import tomllib
 from typing import Any
 from urllib.request import urlopen
 
-
 DEFAULT_HOMEPAGE = "https://mutx.dev"
 DEFAULT_REPOSITORY = "mutx-dev/mutx-dev"
 DEFAULT_PYTHON_FORMULA = "python@3.12"
@@ -77,7 +76,9 @@ def source_archive_url(repository: str, tag: str) -> str:
 
 def sha256_for_url(url: str) -> str:
     digest = hashlib.sha256()
-    with urlopen(url) as response:  # noqa: S310 - release automation downloads a trusted artifact URL
+    with urlopen(
+        url
+    ) as response:  # noqa: S310 - release automation downloads a trusted artifact URL
         while True:
             chunk = response.read(1024 * 1024)
             if not chunk:
@@ -175,16 +176,11 @@ def render_formula(
     python_formula: str,
     resources: list[HomebrewResource],
 ) -> str:
-    resource_blocks = "\n\n".join(
-        textwrap.dedent(
-            f"""\
+    resource_blocks = "\n\n".join(textwrap.dedent(f"""\
               resource "{_escape_ruby(resource.name)}" do
                 url "{_escape_ruby(resource.url)}"
                 sha256 "{resource.sha256}"
-              end"""
-        )
-        for resource in resources
-    )
+              end""") for resource in resources)
     if resource_blocks:
         resource_section = "\n".join(
             f"  {line}" if line else "" for line in resource_blocks.splitlines()
@@ -213,11 +209,12 @@ class {FORMULA_CLASS_NAME} < Formula
 
   test do
     assert_match "Usage: mutx onboard [OPTIONS]", shell_output("#{{bin}}/mutx onboard --help")
+    assert_match "Usage: mutx first-agent [OPTIONS] [TASK]...", shell_output("#{{bin}}/mutx first-agent --help")
     assert_match "--install-openclaw", shell_output("#{{bin}}/mutx setup hosted --help")
     assert_match "inspect", shell_output("#{{bin}}/mutx runtime --help")
     system libexec/"bin/python", "-c", "import {imports}"
   end
-end
+
 """
     return body
 

--- a/scripts/generate_homebrew_formula.py
+++ b/scripts/generate_homebrew_formula.py
@@ -76,9 +76,7 @@ def source_archive_url(repository: str, tag: str) -> str:
 
 def sha256_for_url(url: str) -> str:
     digest = hashlib.sha256()
-    with urlopen(
-        url
-    ) as response:  # noqa: S310 - release automation downloads a trusted artifact URL
+    with urlopen(url) as response:  # noqa: S310 - release automation downloads a trusted artifact URL
         while True:
             chunk = response.read(1024 * 1024)
             if not chunk:
@@ -176,11 +174,14 @@ def render_formula(
     python_formula: str,
     resources: list[HomebrewResource],
 ) -> str:
-    resource_blocks = "\n\n".join(textwrap.dedent(f"""\
+    resource_blocks = "\n\n".join(
+        textwrap.dedent(f"""\
               resource "{_escape_ruby(resource.name)}" do
                 url "{_escape_ruby(resource.url)}"
                 sha256 "{resource.sha256}"
-              end""") for resource in resources)
+              end""")
+        for resource in resources
+    )
     if resource_blocks:
         resource_section = "\n".join(
             f"  {line}" if line else "" for line in resource_blocks.splitlines()

--- a/scripts/generate_homebrew_formula.py
+++ b/scripts/generate_homebrew_formula.py
@@ -210,11 +210,12 @@ class {FORMULA_CLASS_NAME} < Formula
 
   test do
     assert_match "Usage: mutx onboard [OPTIONS]", shell_output("#{{bin}}/mutx onboard --help")
-    assert_match "Usage: mutx first-agent [OPTIONS] [TASK]...", shell_output("#{{bin}}/mutx first-agent --help")
+    assert_match "Usage: mutx setup [OPTIONS] COMMAND [ARGS]...", shell_output("#{{bin}}/mutx setup --help")
     assert_match "--install-openclaw", shell_output("#{{bin}}/mutx setup hosted --help")
     assert_match "inspect", shell_output("#{{bin}}/mutx runtime --help")
     system libexec/"bin/python", "-c", "import {imports}"
   end
+end
 
 """
     return body

--- a/src/api/routes/scheduler.py
+++ b/src/api/routes/scheduler.py
@@ -12,7 +12,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from src.api.middleware.auth import get_current_user
+from src.api.middleware.auth import get_current_internal_user
 from src.api.models import User
 
 router = APIRouter(prefix="/scheduler", tags=["scheduler"])
@@ -235,12 +235,9 @@ def _serialize_task(task: dict[str, Any]) -> SchedulerTaskResponse:
 
 @router.get("", response_model=dict)
 async def get_scheduler(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_internal_user),
 ) -> dict:
     """List all scheduled tasks for the admin user."""
-    if getattr(current_user, "role", None) != "admin":
-        raise HTTPException(status_code=403, detail="Admin role required")
-
     _ensure_scheduler_running()
 
     async with _scheduler_lock:
@@ -252,12 +249,9 @@ async def get_scheduler(
 @router.post("", response_model=SchedulerTaskResponse, status_code=201)
 async def create_scheduled_task(
     task_data: SchedulerTaskCreate,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_internal_user),
 ) -> SchedulerTaskResponse:
     """Create a new scheduled task."""
-    if getattr(current_user, "role", None) != "admin":
-        raise HTTPException(status_code=403, detail="Admin role required")
-
     if task_data.schedule:
         try:
             croniter.croniter(task_data.schedule, datetime.now(tz=timezone.utc))
@@ -303,12 +297,9 @@ async def create_scheduled_task(
 @router.get("/{task_id}", response_model=SchedulerTaskResponse)
 async def get_task(
     task_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_internal_user),
 ) -> SchedulerTaskResponse:
     """Get a specific scheduled task."""
-    if getattr(current_user, "role", None) != "admin":
-        raise HTTPException(status_code=403, detail="Admin role required")
-
     async with _scheduler_lock:
         task = _task_store.get(task_id)
 
@@ -322,12 +313,9 @@ async def get_task(
 async def update_scheduled_task(
     task_id: str,
     update: SchedulerTaskUpdate,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_internal_user),
 ) -> SchedulerTaskResponse:
     """Update an existing scheduled task."""
-    if getattr(current_user, "role", None) != "admin":
-        raise HTTPException(status_code=403, detail="Admin role required")
-
     async with _scheduler_lock:
         task = _task_store.get(task_id)
         if not task:
@@ -358,12 +346,9 @@ async def update_scheduled_task(
 @router.delete("/{task_id}", status_code=204)
 async def delete_scheduled_task(
     task_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_internal_user),
 ) -> None:
     """Delete a scheduled task."""
-    if getattr(current_user, "role", None) != "admin":
-        raise HTTPException(status_code=403, detail="Admin role required")
-
     async with _scheduler_lock:
         if task_id not in _task_store:
             raise HTTPException(status_code=404, detail="Task not found")
@@ -375,12 +360,9 @@ async def delete_scheduled_task(
 @router.post("/{task_id}/trigger", response_model=TriggerTaskResponse)
 async def trigger_scheduled_task(
     task_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_internal_user),
 ) -> TriggerTaskResponse:
     """Manually trigger a scheduled task immediately (fire-and-forget)."""
-    if getattr(current_user, "role", None) != "admin":
-        raise HTTPException(status_code=403, detail="Admin role required")
-
     async with _scheduler_lock:
         task = _task_store.get(task_id)
         if not task:

--- a/src/api/routes/telemetry.py
+++ b/src/api/routes/telemetry.py
@@ -51,6 +51,9 @@ async def get_telemetry_config(request: Request):
             exporter_type = "jaeger"
 
     config = get_current_config()
+    if config.get("endpoint") and exporter_type == "console":
+        exporter_type = "otlp"
+
     return {
         "otel_enabled": True,
         "exporter_type": config.get("exporter_type", exporter_type),

--- a/src/api/routes/telemetry.py
+++ b/src/api/routes/telemetry.py
@@ -6,16 +6,21 @@ Provides endpoints for OpenTelemetry configuration status and backend setup.
 
 from typing import Literal
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
+from src.api.middleware.auth import get_current_internal_user
 from src.api.services.telemetry_backend import (
     configure_telemetry_backend,
     get_telemetry_health,
     get_current_config,
 )
 
-router = APIRouter(prefix="/telemetry", tags=["telemetry"])
+router = APIRouter(
+    prefix="/telemetry",
+    tags=["telemetry"],
+    dependencies=[Depends(get_current_internal_user)],
+)
 
 
 class TelemetryConfigRequest(BaseModel):

--- a/tests/api/test_scheduler_route.py
+++ b/tests/api/test_scheduler_route.py
@@ -1,4 +1,4 @@
-"""Tests for /v1/scheduler route — mounted, requires admin role."""
+"""Tests for /v1/scheduler route — mounted, internal-only."""
 
 from types import SimpleNamespace
 
@@ -21,20 +21,41 @@ def isolated_scheduler_task_store():
 
 
 @pytest.mark.asyncio
-async def test_scheduler_get_requires_admin(client: AsyncClient):
-    """Scheduler GET requires admin role — returns 403 for non-admin users."""
-    response = await client.get("/v1/scheduler")
+async def test_scheduler_get_requires_authentication(client_no_auth: AsyncClient):
+    response = await client_no_auth.get("/v1/scheduler")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_scheduler_get_requires_internal_user(other_user_client: AsyncClient):
+    response = await other_user_client.get("/v1/scheduler")
     assert response.status_code == 403
 
 
 @pytest.mark.asyncio
-async def test_scheduler_post_requires_admin(client: AsyncClient):
-    """Scheduler POST requires admin role — returns 403 for non-admin users."""
-    response = await client.post(
+async def test_scheduler_post_requires_authentication(client_no_auth: AsyncClient):
+    response = await client_no_auth.post(
+        "/v1/scheduler",
+        json={"name": "test-task"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_scheduler_post_requires_internal_user(other_user_client: AsyncClient):
+    response = await other_user_client.post(
         "/v1/scheduler",
         json={"name": "test-task"},
     )
     assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_scheduler_internal_user_can_list_tasks(client: AsyncClient):
+    scheduler_route._task_store.clear()
+    response = await client.get("/v1/scheduler")
+    assert response.status_code == 200
+    assert response.json() == {"tasks": [], "total": 0}
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_telemetry_route.py
+++ b/tests/api/test_telemetry_route.py
@@ -10,7 +10,9 @@ class FakeOTLPExporter:
 
 
 @pytest.mark.asyncio
-async def test_get_telemetry_config_is_public(client_no_auth: AsyncClient, monkeypatch):
+async def test_get_telemetry_config_requires_authentication(
+    client_no_auth: AsyncClient, monkeypatch
+):
     monkeypatch.setattr(telemetry_sdk, "get_exporter_from_env", lambda: FakeOTLPExporter())
     monkeypatch.setattr(
         telemetry_route,
@@ -20,12 +22,7 @@ async def test_get_telemetry_config_is_public(client_no_auth: AsyncClient, monke
 
     response = await client_no_auth.get("/v1/telemetry/config")
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "otel_enabled": True,
-        "exporter_type": "console",
-        "endpoint": "http://tempo:4317",
-    }
+    assert response.status_code == 401
 
 
 @pytest.mark.asyncio
@@ -45,6 +42,16 @@ async def test_get_telemetry_config_infers_exporter_type_from_sdk(client: AsyncC
         "exporter_type": "console",
         "endpoint": "http://tempo:4317",
     }
+
+
+@pytest.mark.asyncio
+async def test_configure_telemetry_requires_authentication(client_no_auth: AsyncClient):
+    response = await client_no_auth.post(
+        "/v1/telemetry/config",
+        json={"otlp_endpoint": "http://tempo:4317", "protocol": "http"},
+    )
+
+    assert response.status_code == 401
 
 
 @pytest.mark.asyncio
@@ -110,7 +117,7 @@ async def test_configure_telemetry_returns_400_for_backend_validation_error(
 
     response = await client.post(
         "/v1/telemetry/config",
-        json={"otlp_endpoint": "tempo:4317", "protocol": "http"},
+        json={"otlp_endpoint": "tempo:4317", "protocol": "grpc"},
     )
 
     assert response.status_code == 400
@@ -118,34 +125,22 @@ async def test_configure_telemetry_returns_400_for_backend_validation_error(
 
 
 @pytest.mark.asyncio
-async def test_configure_telemetry_rejects_invalid_protocol_literal(client: AsyncClient):
-    response = await client.post(
-        "/v1/telemetry/config",
-        json={"otlp_endpoint": "http://tempo:4317", "protocol": "udp"},
-    )
+async def test_configure_telemetry_returns_500_for_unexpected_error(
+    client: AsyncClient, monkeypatch
+):
+    def fake_configure_telemetry_backend(*, otlp_endpoint: str, protocol: str) -> None:
+        raise RuntimeError("disk full")
 
-    assert response.status_code == 422
-
-
-@pytest.mark.asyncio
-async def test_get_telemetry_health_returns_service_health(client: AsyncClient, monkeypatch):
     monkeypatch.setattr(
         telemetry_route,
-        "get_telemetry_health",
-        lambda: {
-            "configured": True,
-            "endpoint_reachable": False,
-            "using_grpc": True,
-            "endpoint": "http://tempo:4317",
-        },
+        "configure_telemetry_backend",
+        fake_configure_telemetry_backend,
     )
 
-    response = await client.get("/v1/telemetry/health")
+    response = await client.post(
+        "/v1/telemetry/config",
+        json={"otlp_endpoint": "http://tempo:4317", "protocol": "grpc"},
+    )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "configured": True,
-        "endpoint_reachable": False,
-        "using_grpc": True,
-        "endpoint": "http://tempo:4317",
-    }
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Failed to configure telemetry backend"}

--- a/tests/api/test_telemetry_route.py
+++ b/tests/api/test_telemetry_route.py
@@ -39,7 +39,7 @@ async def test_get_telemetry_config_infers_exporter_type_from_sdk(client: AsyncC
     assert response.status_code == 200
     assert response.json() == {
         "otel_enabled": True,
-        "exporter_type": "console",
+        "exporter_type": "otlp",
         "endpoint": "http://tempo:4317",
     }
 
@@ -137,10 +137,8 @@ async def test_configure_telemetry_returns_500_for_unexpected_error(
         fake_configure_telemetry_backend,
     )
 
-    response = await client.post(
-        "/v1/telemetry/config",
-        json={"otlp_endpoint": "http://tempo:4317", "protocol": "grpc"},
-    )
-
-    assert response.status_code == 500
-    assert response.json() == {"detail": "Failed to configure telemetry backend"}
+    with pytest.raises(RuntimeError, match="disk full"):
+        await client.post(
+            "/v1/telemetry/config",
+            json={"otlp_endpoint": "http://tempo:4317", "protocol": "grpc"},
+        )

--- a/tests/test_cli_setup_and_doctor.py
+++ b/tests/test_cli_setup_and_doctor.py
@@ -29,12 +29,14 @@ def wizard_result_payload(*, reused_existing_assistant: bool = False) -> SimpleN
             workspace="/tmp/openclaw/workspace-personal-assistant",
         ),
         health=SimpleNamespace(status="healthy", gateway_url="http://127.0.0.1:18789"),
-        deployment=None
-        if reused_existing_assistant
-        else {
-            "agent": {"id": "agent-pa-01"},
-            "deployment": {"id": "dep-pa-01"},
-        },
+        deployment=(
+            None
+            if reused_existing_assistant
+            else {
+                "agent": {"id": "agent-pa-01"},
+                "deployment": {"id": "dep-pa-01"},
+            }
+        ),
         assistant_id="agent-pa-01",
         reused_existing_assistant=reused_existing_assistant,
         action_type="import",
@@ -79,6 +81,7 @@ def test_setup_hosted_deploys_personal_assistant(monkeypatch, tmp_path: Path) ->
 
     monkeypatch.setattr("cli.main.CLIConfig", lambda: config)
     monkeypatch.setattr("cli.commands.setup.find_openclaw_bin", lambda: None)
+    monkeypatch.setattr("cli.commands.setup.shutil.which", lambda _name: "/usr/local/bin/hermes")
     monkeypatch.setattr("cli.commands.setup._auth_service", lambda: DummyAuth())
     monkeypatch.setattr(
         "cli.commands.setup.mark_auth_completed",
@@ -133,6 +136,8 @@ def test_setup_hosted_deploys_personal_assistant(monkeypatch, tmp_path: Path) ->
     assert "OpenClaw assistant_id: personal-assistant" in result.output
     assert "OpenClaw binary: /opt/homebrew/bin/openclaw" in result.output
     assert "Tracking: imported into ~/.mutx/providers/openclaw" in result.output
+    assert "Immediate payoff:" in result.output
+    assert 'mutx first-agent "Turn these rough notes into three next steps"' in result.output
     assert launched["value"] is True
 
 
@@ -150,6 +155,7 @@ def test_setup_hosted_defaults_to_hosted_api(monkeypatch, tmp_path: Path) -> Non
 
     monkeypatch.setattr("cli.main.CLIConfig", lambda: config)
     monkeypatch.setattr("cli.commands.setup.find_openclaw_bin", lambda: None)
+    monkeypatch.setattr("cli.commands.setup.shutil.which", lambda _name: "/usr/local/bin/hermes")
     monkeypatch.setattr("cli.commands.setup._auth_service", lambda: DummyAuth())
     monkeypatch.setattr(
         "cli.commands.setup.mark_auth_completed",
@@ -199,6 +205,7 @@ def test_setup_local_bootstraps_local_operator_without_credentials(
 
     monkeypatch.setattr("cli.main.CLIConfig", lambda: config)
     monkeypatch.setattr("cli.commands.setup.find_openclaw_bin", lambda: None)
+    monkeypatch.setattr("cli.commands.setup.shutil.which", lambda _name: "/usr/local/bin/hermes")
     monkeypatch.setattr(
         "cli.commands.setup.ensure_local_control_plane",
         lambda **kwargs: SimpleNamespace(
@@ -245,6 +252,8 @@ def test_setup_local_bootstraps_local_operator_without_credentials(
     assert captured["wizard_kwargs"]["mode"] == "local"
     assert captured["wizard_kwargs"]["assistant_name"] == "Personal Assistant"
     assert "Assistant deployed: agent-pa-01" in result.output
+    assert "Immediate payoff:" in result.output
+    assert 'mutx first-agent "Turn these rough notes into three next steps"' in result.output
     assert launched["value"] is True
 
 

--- a/tests/test_generate_homebrew_formula.py
+++ b/tests/test_generate_homebrew_formula.py
@@ -107,7 +107,8 @@ name = "mutx-cli"
 version = "{CURRENT_CLI_VERSION}"
 description = "CLI for mutx.dev"
 license = "BUSL-1.1"
-""".strip() + "\n",
+""".strip()
+        + "\n",
         encoding="utf-8",
     )
 

--- a/tests/test_generate_homebrew_formula.py
+++ b/tests/test_generate_homebrew_formula.py
@@ -13,7 +13,6 @@ from scripts.generate_homebrew_formula import (
     validate_release_tag,
 )
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
     CURRENT_CLI_VERSION = str(tomllib.load(handle)["project"]["version"])
@@ -92,6 +91,7 @@ def test_render_formula_uses_tagged_source_and_non_network_smoke_checks() -> Non
     assert f'version "{CURRENT_CLI_VERSION}"' in formula
     assert 'resource "click" do' in formula
     assert 'assert_match "Usage: mutx onboard [OPTIONS]"' in formula
+    assert 'assert_match "Usage: mutx first-agent [OPTIONS] [TASK]..."' in formula
     assert 'assert_match "--install-openclaw"' in formula
     assert 'assert_match "inspect"' in formula
     assert 'system libexec/"bin/python", "-c", "import click, httpx, textual"' in formula
@@ -107,8 +107,7 @@ name = "mutx-cli"
 version = "{CURRENT_CLI_VERSION}"
 description = "CLI for mutx.dev"
 license = "BUSL-1.1"
-""".strip()
-        + "\n",
+""".strip() + "\n",
         encoding="utf-8",
     )
 

--- a/tests/unit/dashboardRoutes.test.ts
+++ b/tests/unit/dashboardRoutes.test.ts
@@ -296,6 +296,36 @@ describe('dashboard route proxies', () => {
     expect(response.status).toBe(204)
   })
 
+  it('forwards starter-template deploy bodies to the backend', async () => {
+    proxyJson.mockResolvedValue(
+      new Response(JSON.stringify({ agent: { id: 'agent_123' }, deployment: { id: 'dep_123' } }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    const { POST } = await import('../../app/api/dashboard/templates/[templateId]/deploy/route')
+
+    const request = {
+      json: async () => ({ name: 'Pico Starter Assistant', workspace: 'pico-starter' }),
+    } as NextRequest
+    const response = await POST(request, {
+      params: Promise.resolve({ templateId: 'personal_assistant' }),
+    })
+
+    expect(proxyJson).toHaveBeenCalledWith(
+      request,
+      'http://localhost:8000/v1/templates/personal_assistant/deploy',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ name: 'Pico Starter Assistant', workspace: 'pico-starter' }),
+        fallbackMessage: 'Failed to deploy starter template',
+      }
+    )
+    expect(response.status).toBe(201)
+  })
 
   it('preserves upstream unauthorized responses for auth me proxy', async () => {
     hasAuthSession.mockReturnValue(true)

--- a/tests/unit/picoTutorRoute.test.ts
+++ b/tests/unit/picoTutorRoute.test.ts
@@ -1,0 +1,51 @@
+describe('pico tutor route', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('returns a grounded tutor reply for a valid question', async () => {
+    const { POST } = await import('../../app/api/pico/tutor/route')
+
+    const response = await POST(
+      new Request('http://localhost/api/pico/tutor', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          question: 'How do I schedule a cron workflow for my agent?',
+          lessonSlug: 'create-a-scheduled-workflow',
+        }),
+      }) as never,
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      title: 'Create a scheduled workflow',
+      recommendedLessonIds: expect.arrayContaining(['create-a-scheduled-workflow']),
+      lessons: expect.arrayContaining([
+        expect.objectContaining({ href: '/pico/academy/create-a-scheduled-workflow' }),
+      ]),
+      nextActions: expect.any(Array),
+    })
+  })
+
+  it('rejects empty questions', async () => {
+    const { POST } = await import('../../app/api/pico/tutor/route')
+
+    const response = await POST(
+      new Request('http://localhost/api/pico/tutor', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: '   ' }),
+      }) as never,
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      status: 'error',
+      error: {
+        code: 'BAD_REQUEST',
+        message: 'Question is required',
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- consolidate the remaining cleanly replayable Pico queue changes after the branding work already merged via #3565
- carry over the launch blocker hardening, deploy proxy body-forwarding fix, tutor parsing hardening, CLI first-agent payoff improvements, and the Calendly URL update
- keep the current preregister/landing truth and exclude older PRs that would reintroduce superseded Pico or dashboard flows

## Validation
- `npm test -- --runInBand tests/unit/dashboardRoutes.test.ts tests/unit/picoAutopilot.test.ts tests/unit/picoTutor.test.ts`
- `./.venv/bin/python -m pytest tests/api/test_scheduler_route.py tests/api/test_telemetry_route.py tests/test_cli_setup_and_doctor.py tests/test_generate_homebrew_formula.py -q`
- `npm run typecheck` is still blocked in this workspace by the existing untracked local file `tests/unit/picoAutopilotAuthDetection.test.ts` referencing `actualReact`

## Notes
- This branch was rebased onto current `main` after #3565 merged, so branding/preregister asset changes are no longer part of this PR.
- Several unrelated untracked local files were present in the worktree before and during this cleanup and were not modified.