### PR TITLE
Fix Pico locale autoload mapping

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -18,6 +18,63 @@ const APP_HOSTS = new Set([APP_HOST, 'app.localhost'])
 const MARKETING_HOSTS = new Set(['mutx.dev', 'www.mutx.dev'])
 const PICO_HOSTS = new Set(['pico.mutx.dev', 'pico.localhost'])
 const PICO_LOCALES = ['en', 'es', 'fr', 'de', 'it', 'pt', 'ja', 'ko', 'zh', 'ar'] as const
+const PICO_COUNTRY_TO_LOCALE: Record<string, (typeof PICO_LOCALES)[number]> = {
+  US: 'en',
+  GB: 'en',
+  AU: 'en',
+  NZ: 'en',
+  IE: 'en',
+  CA: 'en',
+  ES: 'es',
+  MX: 'es',
+  AR: 'es',
+  CO: 'es',
+  CL: 'es',
+  PE: 'es',
+  VE: 'es',
+  UY: 'es',
+  PY: 'es',
+  BO: 'es',
+  EC: 'es',
+  CR: 'es',
+  PA: 'es',
+  GT: 'es',
+  HN: 'es',
+  SV: 'es',
+  NI: 'es',
+  DO: 'es',
+  PR: 'es',
+  FR: 'fr',
+  BE: 'fr',
+  LU: 'fr',
+  CH: 'fr',
+  DE: 'de',
+  AT: 'de',
+  IT: 'it',
+  PT: 'pt',
+  BR: 'pt',
+  JP: 'ja',
+  KR: 'ko',
+  CN: 'zh',
+  HK: 'zh',
+  TW: 'zh',
+  MO: 'zh',
+  SA: 'ar',
+  AE: 'ar',
+  EG: 'ar',
+  QA: 'ar',
+  KW: 'ar',
+  BH: 'ar',
+  OM: 'ar',
+  JO: 'ar',
+  MA: 'ar',
+  DZ: 'ar',
+  TN: 'ar',
+  IQ: 'ar',
+  LB: 'ar',
+  SY: 'ar',
+  YE: 'ar',
+}
 const UI_CACHE_CONTROL = 'private, no-cache, no-store, max-age=0, must-revalidate'
 const API_CACHE_CONTROL = 'no-store'
 const APP_PUBLIC_PATHS = new Set([
@@ -66,17 +123,10 @@ function getLocaleFromRequest(request: NextRequest): string {
   const cfCountry = request.headers.get('CF-IPCountry') ||
                     request.headers.get('X-Vercel-IP-Country')
   if (cfCountry) {
-    const lang = cfCountry.toLowerCase()
-    if (lang === 'zh') return 'zh'
-    if (['ja'].includes(lang)) return lang
-    if (['ko'].includes(lang)) return lang
-    if (['ar', 'sa', 'ae', 'eg'].includes(lang)) return 'ar'
-    if (['en', 'gb', 'au', 'ca', 'us'].includes(lang)) return 'en'
-    if (['es', 'mx', 'ar', 'co', 'cl'].includes(lang)) return 'es'
-    if (['fr', 'be', 'ca', 'ch'].includes(lang)) return 'fr'
-    if (['de', 'at', 'ch'].includes(lang)) return 'de'
-    if (['it'].includes(lang)) return 'it'
-    if (['pt', 'br'].includes(lang)) return 'pt'
+    const localeFromCountry = PICO_COUNTRY_TO_LOCALE[cfCountry.toUpperCase()]
+    if (localeFromCountry) {
+      return localeFromCountry
+    }
   }
   // 3. Accept-Language header
   const acceptLang = request.headers.get('accept-language')

--- a/tests/unit/middlewareRouting.test.ts
+++ b/tests/unit/middlewareRouting.test.ts
@@ -10,6 +10,15 @@ function mockRequest(
   const normalizedHeaders = Object.fromEntries(
     Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
   )
+  const cookieEntries = (normalizedHeaders.cookie ?? '')
+    .split(';')
+    .map((chunk) => chunk.trim())
+    .filter(Boolean)
+    .map((chunk) => {
+      const [name, ...rest] = chunk.split('=')
+      return [name, rest.join('=')] as const
+    })
+  const cookieMap = new Map(cookieEntries)
 
   return {
     url,
@@ -18,6 +27,12 @@ function mockRequest(
     headers: {
       get(name: string) {
         return normalizedHeaders[name.toLowerCase()] ?? null
+      },
+    },
+    cookies: {
+      get(name: string) {
+        const value = cookieMap.get(name)
+        return value ? { name, value } : undefined
       },
     },
   } as unknown as NextRequest
@@ -128,6 +143,48 @@ describe('host-aware UI routing proxy', () => {
     expect(response.headers.get('cache-control')).toBe(
       'private, no-cache, no-store, max-age=0, must-revalidate',
     )
+  })
+
+
+  it('maps pico geo country codes onto the expected locale cookie', () => {
+    const japanResponse = proxy(
+      mockRequest('https://pico.mutx.dev/', { host: 'pico.mutx.dev', 'cf-ipcountry': 'JP' }),
+    )
+    expect(japanResponse.headers.get('x-middleware-rewrite')).toBe('https://pico.mutx.dev/pico')
+    expect(japanResponse.cookies.get('NEXT_LOCALE')?.value).toBe('ja')
+
+    const koreaResponse = proxy(
+      mockRequest('https://pico.mutx.dev/', { host: 'pico.mutx.dev', 'cf-ipcountry': 'KR' }),
+    )
+    expect(koreaResponse.cookies.get('NEXT_LOCALE')?.value).toBe('ko')
+
+    const chinaResponse = proxy(
+      mockRequest('https://pico.mutx.dev/', { host: 'pico.mutx.dev', 'cf-ipcountry': 'CN' }),
+    )
+    expect(chinaResponse.cookies.get('NEXT_LOCALE')?.value).toBe('zh')
+  })
+
+  it('prefers an explicit NEXT_LOCALE cookie over geo detection on pico hosts', () => {
+    const response = proxy(
+      mockRequest('https://pico.mutx.dev/', {
+        host: 'pico.mutx.dev',
+        cookie: 'NEXT_LOCALE=fr',
+        'cf-ipcountry': 'IT',
+      }),
+    )
+
+    expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('fr')
+  })
+
+  it('falls back to Accept-Language when pico geo headers are missing', () => {
+    const response = proxy(
+      mockRequest('https://pico.mutx.dev/', {
+        host: 'pico.mutx.dev',
+        'accept-language': 'es-ES,es;q=0.9,en;q=0.8',
+      }),
+    )
+
+    expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('es')
   })
 
   it('passes through unrelated marketing routes without injecting auth-form rate-limit headers', () => {


### PR DESCRIPTION
## Summary
- fix Pico geo-country locale mapping so JP, KR, CN and related region codes resolve to ja, ko, and zh instead of silently falling back to English
- preserve cookie precedence while keeping Accept-Language fallback when no geo header is present
- add regression coverage for Pico locale cookie selection in middleware routing tests

## Validation
- npm run typecheck
- npm test -- --runInBand tests/unit/middlewareRouting.test.ts
- npm run build
- local curl checks confirmed JP -> ja, KR -> ko, CN -> zh with localized landing content
