### PR TITLE
fix(migrations): use Postgres ARRAY for swarms.agent_ids when available

### DIFF
--- a/src/api/models/migrations/versions/c3d4e5f6a7b8_add_swarms_table.py
+++ b/src/api/models/migrations/versions/c3d4e5f6a7b8_add_swarms_table.py
@@ -18,15 +18,21 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # Create swarms table — agent_ids stored as JSON array (text) for SQLite compatibility
-    # PostgreSQL will use native ARRAY
+    bind = op.get_bind()
+    is_postgresql = bind.dialect.name == "postgresql"
+
+    # Keep SQLite-compatible text storage, but use native ARRAY on PostgreSQL
+    agent_ids_type = (
+        sa.dialects.postgresql.ARRAY(sa.String()) if is_postgresql else sa.Text()
+    )
+
     op.create_table(
         "swarms",
         sa.Column("id", sa.UUID(), nullable=False),
         sa.Column("user_id", sa.UUID(), nullable=False),
         sa.Column("name", sa.String(length=255), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("agent_ids", sa.Text(), nullable=True),  # JSON array serialized as text
+        sa.Column("agent_ids", agent_ids_type, nullable=True),
         sa.Column("min_replicas", sa.Integer(), nullable=False, server_default="1"),
         sa.Column("max_replicas", sa.Integer(), nullable=False, server_default="10"),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),


### PR DESCRIPTION
### Motivation
- The swarms migration previously created `agent_ids` as `TEXT` for all dialects which mismatches the ORM `ARRAY` mapping on PostgreSQL and causes runtime failures when deserializing agent IDs.

### Description
- Detect the active dialect in the migration with `op.get_bind().dialect.name` and choose `sa.dialects.postgresql.ARRAY(sa.String())` when running on PostgreSQL, otherwise keep `sa.Text()` for SQLite compatibility.
- Apply the computed `agent_ids_type` to the `swarms.agent_ids` column in the `upgrade()` function of the migration file `src/api/models/migrations/versions/c3d4e5f6a7b8_add_swarms_table.py`.

### Testing
- Ran `python -m compileall src/api/models/migrations/versions/c3d4e5f6a7b8_add_swarms_table.py` which compiled successfully.
- Attempted `python -m pytest tests/api/test_swarms.py -q` which could not complete in this environment due to missing dependency `pytest_asyncio` (test run failed with `ModuleNotFoundError: No module named 'pytest_asyncio'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d98918aef0832aa7b552b2a5223a9c)