### PR TITLE
[codex] add reasoning workflow dashboard and cli

### DIFF
--- a/app/dashboard/reasoning/page.tsx
+++ b/app/dashboard/reasoning/page.tsx
@@ -1,0 +1,30 @@
+import { Brain } from "lucide-react";
+
+import { ReasoningPageClient } from "@/components/dashboard/ReasoningPageClient";
+import { RouteHeader } from "@/components/dashboard/RouteHeader";
+import { DesktopRouteBoundary } from "@/components/desktop/DesktopRouteBoundary";
+
+export default function DashboardReasoningPage() {
+  return (
+    <DesktopRouteBoundary
+      routeKey="reasoning"
+      browserView={
+        <div className="space-y-4">
+          <RouteHeader
+            title="Reasoning"
+            description="Autoreason refinement jobs with blind judging, persisted artifacts, and direct run/trace linkage."
+            icon={Brain}
+            iconTone="text-violet-300 bg-violet-400/10"
+            badge="autoreason v1"
+            stats={[
+              { label: "Loop", value: "A/B/AB" },
+              { label: "Judging", value: "Blind panel", tone: "success" },
+            ]}
+          />
+
+          <ReasoningPageClient />
+        </div>
+      }
+    />
+  );
+}

--- a/cli/commands/reasoning.py
+++ b/cli/commands/reasoning.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+
+import click
+
+from cli.config import current_config, get_client
+from cli.services import CLIServiceError, ReasoningService
+
+
+def _service() -> ReasoningService:
+    return ReasoningService(config=current_config(), client_factory=get_client)
+
+
+def _echo_service_error(error: CLIServiceError) -> None:
+    click.echo(f"Error: {error}", err=True)
+
+
+@click.group(name="reasoning")
+def reasoning_group():
+    """Operate reasoning workflow templates and jobs."""
+    pass
+
+
+@reasoning_group.command(name="templates")
+@click.option("--output", type=click.Choice(["table", "json"]), default="table")
+def templates_command(output: str):
+    try:
+        templates = _service().list_templates()
+    except CLIServiceError as exc:
+        _echo_service_error(exc)
+        return
+
+    if output == "json":
+        click.echo(
+            json.dumps(
+                [
+                    {
+                        "id": item.id,
+                        "name": item.name,
+                        "summary": item.summary,
+                        "description": item.description,
+                        "supports_managed": item.supports_managed,
+                        "supports_local": item.supports_local,
+                    }
+                    for item in templates
+                ],
+                indent=2,
+            )
+        )
+        return
+
+    for item in templates:
+        click.echo(
+            f"{item.id} | {item.name} | managed={item.supports_managed} | local={item.supports_local}"
+        )
+
+
+@reasoning_group.command(name="list")
+@click.option("--status", "status_filter", default=None, help="Filter jobs by status")
+@click.option("--template-id", default=None, help="Filter jobs by template id")
+@click.option("--limit", default=20, show_default=True)
+@click.option("--output", type=click.Choice(["table", "json"]), default="table")
+def list_command(status_filter: str | None, template_id: str | None, limit: int, output: str):
+    try:
+        history = _service().list_jobs(
+            limit=limit, status_filter=status_filter, template_id=template_id
+        )
+    except CLIServiceError as exc:
+        _echo_service_error(exc)
+        return
+
+    if output == "json":
+        click.echo(
+            json.dumps(
+                {
+                    "total": history.total,
+                    "items": [
+                        {
+                            "id": item.id,
+                            "template_id": item.template_id,
+                            "execution_mode": item.execution_mode,
+                            "status": item.status,
+                            "created_at": item.created_at,
+                        }
+                        for item in history.items
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    if not history.items:
+        click.echo("No reasoning jobs found.")
+        return
+
+    for item in history.items:
+        click.echo(
+            f"{item.id} | {item.template_id} | {item.execution_mode} | {item.status} | {item.created_at or 'n/a'}"
+        )
+
+
+@reasoning_group.command(name="get")
+@click.argument("job_id")
+@click.option("--output", type=click.Choice(["table", "json"]), default="table")
+def get_command(job_id: str, output: str):
+    try:
+        job = _service().get_job(job_id)
+    except CLIServiceError as exc:
+        _echo_service_error(exc)
+        return
+
+    if output == "json":
+        click.echo(
+            json.dumps(
+                {
+                    "id": job.id,
+                    "run_id": job.run_id,
+                    "template_id": job.template_id,
+                    "execution_mode": job.execution_mode,
+                    "status": job.status,
+                    "parameters": job.parameters,
+                    "result_summary": job.result_summary,
+                    "artifacts": [
+                        {
+                            "id": artifact.id,
+                            "role": artifact.role,
+                            "kind": artifact.kind,
+                            "filename": artifact.filename,
+                            "storage_backend": artifact.storage_backend,
+                        }
+                        for artifact in job.artifacts
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    click.echo(f"Job: {job.id}")
+    click.echo(f"Template: {job.template_id}")
+    click.echo(f"Mode: {job.execution_mode}")
+    click.echo(f"Status: {job.status}")
+    click.echo(f"Artifacts: {len(job.artifacts)}")
+    if job.error_message:
+        click.echo(f"Error: {job.error_message}")
+
+
+@reasoning_group.command(name="run")
+@click.option("--template-id", default="autoreason_refine", show_default=True)
+@click.option("--mode", type=click.Choice(["managed", "local"]), default="managed")
+@click.option("--task-prompt", required=True, help="Primary reasoning task prompt")
+@click.option("--incumbent", default=None, help="Optional incumbent answer")
+@click.option("--rubric", default=None, help="Optional judging rubric")
+@click.option(
+    "--context-file", "context_files", multiple=True, type=click.Path(exists=True, dir_okay=False)
+)
+@click.option("--output-dir", type=click.Path(file_okay=False), default=None)
+def run_command(
+    template_id: str,
+    mode: str,
+    task_prompt: str,
+    incumbent: str | None,
+    rubric: str | None,
+    context_files: tuple[str, ...],
+    output_dir: str | None,
+):
+    service = _service()
+    parameters: dict[str, object] = {"task_prompt": task_prompt}
+    if incumbent:
+        parameters["incumbent"] = incumbent
+    if rubric:
+        parameters["rubric"] = rubric
+
+    try:
+        job = service.create_job(
+            template_id=template_id,
+            execution_mode=mode,
+            parameters=parameters,
+        )
+
+        for path in context_files:
+            if mode == "managed":
+                service.upload_artifact(job_id=job.id, role="context", kind="file", file_path=path)
+            else:
+                service.register_artifact_reference(
+                    job_id=job.id,
+                    role="context",
+                    kind="file",
+                    file_path=path,
+                )
+
+        if mode == "managed":
+            job = service.dispatch_job(job_id=job.id, mode=mode)
+            click.echo(f"Queued managed reasoning job {job.id} ({job.template_id}).")
+            return
+
+        job = service.run_local_job(job=job, output_dir=output_dir)
+        click.echo(f"Completed local reasoning job {job.id} ({job.status}).")
+    except CLIServiceError as exc:
+        _echo_service_error(exc)
+
+
+@reasoning_group.command(name="download-artifact")
+@click.argument("job_id")
+@click.argument("artifact_id")
+@click.option("--output", "destination", type=click.Path(), default=None)
+def download_artifact_command(job_id: str, artifact_id: str, destination: str | None):
+    try:
+        path = _service().download_artifact(
+            job_id=job_id,
+            artifact_id=artifact_id,
+            destination=destination,
+        )
+    except CLIServiceError as exc:
+        _echo_service_error(exc)
+        return
+
+    click.echo(f"Downloaded artifact to {path}")

--- a/cli/main.py
+++ b/cli/main.py
@@ -12,6 +12,7 @@ from cli.commands.deployment import deployment_group
 from cli.commands.deploy import deploy_group
 from cli.commands.doctor import doctor_command
 from cli.commands.documents import documents_group
+from cli.commands.reasoning import reasoning_group
 from cli.commands.governance import governance_group
 from cli.commands.observability import observability_group
 from cli.commands.runtime import runtime_group
@@ -114,6 +115,7 @@ cli.add_command(deploy_group)
 cli.add_command(deployment_group)
 cli.add_command(doctor_command)
 cli.add_command(documents_group)
+cli.add_command(reasoning_group)
 cli.add_command(config_group)
 cli.add_command(governance_group)
 cli.add_command(observability_group)

--- a/cli/services/__init__.py
+++ b/cli/services/__init__.py
@@ -2,6 +2,7 @@ from cli.services.agents import AgentsService
 from cli.services.assistant import AssistantService, TemplatesService
 from cli.services.auth import AuthService
 from cli.services.documents import DocumentsService
+from cli.services.reasoning import ReasoningService
 from cli.errors import (
     APIRequestError,
     AuthenticationExpiredError,
@@ -30,6 +31,11 @@ from cli.services.models import (
     DocumentTemplateFieldRecord,
     DocumentTemplateOutputRecord,
     DocumentTemplateRecord,
+    ReasoningArtifactRecord,
+    ReasoningJobHistoryRecord,
+    ReasoningJobRecord,
+    ReasoningLocalLaunchRecord,
+    ReasoningTemplateRecord,
     LogEntry,
     MetricPoint,
     OnboardingStateRecord,
@@ -67,6 +73,12 @@ __all__ = [
     "DocumentTemplateOutputRecord",
     "DocumentTemplateRecord",
     "DocumentsService",
+    "ReasoningArtifactRecord",
+    "ReasoningJobHistoryRecord",
+    "ReasoningJobRecord",
+    "ReasoningLocalLaunchRecord",
+    "ReasoningTemplateRecord",
+    "ReasoningService",
     "InvalidCredentialsError",
     "LogEntry",
     "MetricPoint",

--- a/cli/services/models.py
+++ b/cli/services/models.py
@@ -513,7 +513,9 @@ class DocumentArtifactRecord:
             local_path=_as_optional_str(payload.get("local_path")),
             filename=str(payload.get("filename", "")),
             content_type=_as_optional_str(payload.get("content_type")),
-            size_bytes=int(payload["size_bytes"]) if payload.get("size_bytes") is not None else None,
+            size_bytes=(
+                int(payload["size_bytes"]) if payload.get("size_bytes") is not None else None
+            ),
             sha256=_as_optional_str(payload.get("sha256")),
             metadata=metadata,
             created_at=_as_optional_str(payload.get("created_at")),
@@ -549,7 +551,9 @@ class DocumentJobRecord:
             template_id=str(payload.get("template_id", "")),
             execution_mode=str(payload.get("execution_mode", "")),
             status=str(payload.get("status", "unknown")),
-            parameters=payload.get("parameters") if isinstance(payload.get("parameters"), dict) else {},
+            parameters=(
+                payload.get("parameters") if isinstance(payload.get("parameters"), dict) else {}
+            ),
             result_summary=(
                 payload.get("result_summary")
                 if isinstance(payload.get("result_summary"), dict)
@@ -614,6 +618,169 @@ class DocumentLocalLaunchRecord:
             manifest=payload.get("manifest") if isinstance(payload.get("manifest"), dict) else {},
             artifacts=[
                 DocumentArtifactRecord.from_payload(item)
+                for item in (payload.get("artifacts") or [])
+                if isinstance(item, dict)
+            ],
+        )
+
+
+@dataclass(slots=True)
+class ReasoningTemplateRecord:
+    id: str
+    name: str
+    summary: str
+    description: str
+    supports_managed: bool
+    supports_local: bool
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ReasoningTemplateRecord":
+        return cls(
+            id=str(payload.get("id", "")),
+            name=str(payload.get("name", "")),
+            summary=str(payload.get("summary", "")),
+            description=str(payload.get("description", "")),
+            supports_managed=bool(payload.get("supports_managed", True)),
+            supports_local=bool(payload.get("supports_local", True)),
+        )
+
+
+@dataclass(slots=True)
+class ReasoningArtifactRecord:
+    id: str
+    job_id: str
+    role: str
+    kind: str
+    storage_backend: str
+    storage_uri: str | None
+    local_path: str | None
+    filename: str
+    content_type: str | None
+    size_bytes: int | None
+    sha256: str | None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: str | None = None
+    updated_at: str | None = None
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ReasoningArtifactRecord":
+        raw_metadata = payload.get("metadata")
+        metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+        return cls(
+            id=str(payload.get("id", "")),
+            job_id=str(payload.get("job_id", "")),
+            role=str(payload.get("role", "")),
+            kind=str(payload.get("kind", "")),
+            storage_backend=str(payload.get("storage_backend", "")),
+            storage_uri=_as_optional_str(payload.get("storage_uri")),
+            local_path=_as_optional_str(payload.get("local_path")),
+            filename=str(payload.get("filename", "")),
+            content_type=_as_optional_str(payload.get("content_type")),
+            size_bytes=(
+                int(payload["size_bytes"]) if payload.get("size_bytes") is not None else None
+            ),
+            sha256=_as_optional_str(payload.get("sha256")),
+            metadata=metadata,
+            created_at=_as_optional_str(payload.get("created_at")),
+            updated_at=_as_optional_str(payload.get("updated_at")),
+        )
+
+
+@dataclass(slots=True)
+class ReasoningJobRecord:
+    id: str
+    run_id: str
+    template_id: str
+    execution_mode: str
+    status: str
+    parameters: dict[str, Any] = field(default_factory=dict)
+    result_summary: dict[str, Any] = field(default_factory=dict)
+    error_message: str | None = None
+    claimed_by: str | None = None
+    claimed_at: str | None = None
+    last_heartbeat_at: str | None = None
+    attempts: int = 0
+    dispatched_at: str | None = None
+    completed_at: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    artifacts: list[ReasoningArtifactRecord] = field(default_factory=list)
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ReasoningJobRecord":
+        return cls(
+            id=str(payload.get("id", "")),
+            run_id=str(payload.get("run_id", "")),
+            template_id=str(payload.get("template_id", "")),
+            execution_mode=str(payload.get("execution_mode", "")),
+            status=str(payload.get("status", "unknown")),
+            parameters=(
+                payload.get("parameters") if isinstance(payload.get("parameters"), dict) else {}
+            ),
+            result_summary=(
+                payload.get("result_summary")
+                if isinstance(payload.get("result_summary"), dict)
+                else {}
+            ),
+            error_message=_as_optional_str(payload.get("error_message")),
+            claimed_by=_as_optional_str(payload.get("claimed_by")),
+            claimed_at=_as_optional_str(payload.get("claimed_at")),
+            last_heartbeat_at=_as_optional_str(payload.get("last_heartbeat_at")),
+            attempts=int(payload.get("attempts", 0)),
+            dispatched_at=_as_optional_str(payload.get("dispatched_at")),
+            completed_at=_as_optional_str(payload.get("completed_at")),
+            created_at=_as_optional_str(payload.get("created_at")),
+            updated_at=_as_optional_str(payload.get("updated_at")),
+            artifacts=[
+                ReasoningArtifactRecord.from_payload(item)
+                for item in (payload.get("artifacts") or [])
+                if isinstance(item, dict)
+            ],
+        )
+
+
+@dataclass(slots=True)
+class ReasoningJobHistoryRecord:
+    items: list[ReasoningJobRecord]
+    total: int
+    skip: int
+    limit: int
+    status: str | None
+    template_id: str | None
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ReasoningJobHistoryRecord":
+        return cls(
+            items=[
+                ReasoningJobRecord.from_payload(item)
+                for item in (payload.get("items") or [])
+                if isinstance(item, dict)
+            ],
+            total=int(payload.get("total", 0)),
+            skip=int(payload.get("skip", 0)),
+            limit=int(payload.get("limit", 0)),
+            status=_as_optional_str(payload.get("status")),
+            template_id=_as_optional_str(payload.get("template_id")),
+        )
+
+
+@dataclass(slots=True)
+class ReasoningLocalLaunchRecord:
+    job_id: str
+    template_id: str
+    execution_mode: str
+    manifest: dict[str, Any] = field(default_factory=dict)
+    artifacts: list[ReasoningArtifactRecord] = field(default_factory=list)
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ReasoningLocalLaunchRecord":
+        return cls(
+            job_id=str(payload.get("job_id", "")),
+            template_id=str(payload.get("template_id", "")),
+            execution_mode=str(payload.get("execution_mode", "")),
+            manifest=payload.get("manifest") if isinstance(payload.get("manifest"), dict) else {},
+            artifacts=[
+                ReasoningArtifactRecord.from_payload(item)
                 for item in (payload.get("artifacts") or [])
                 if isinstance(item, dict)
             ],

--- a/cli/services/reasoning.py
+++ b/cli/services/reasoning.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import mimetypes
+from pathlib import Path
+from typing import Any
+
+from cli.errors import CLIServiceError, ValidationError
+from cli.services.base import APIService
+from cli.services.models import (
+    ReasoningArtifactRecord,
+    ReasoningJobHistoryRecord,
+    ReasoningJobRecord,
+    ReasoningLocalLaunchRecord,
+    ReasoningTemplateRecord,
+)
+
+
+def _guess_content_type(path: Path) -> str | None:
+    content_type, _encoding = mimetypes.guess_type(path.name)
+    return content_type
+
+
+class ReasoningService(APIService):
+    def list_templates(self) -> list[ReasoningTemplateRecord]:
+        response = self._request("get", "/v1/reasoning/templates")
+        self._expect_status(response, {200})
+        return [ReasoningTemplateRecord.from_payload(item) for item in response.json()]
+
+    def create_job(
+        self,
+        *,
+        template_id: str,
+        execution_mode: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> ReasoningJobRecord:
+        response = self._request(
+            "post",
+            "/v1/reasoning/jobs",
+            json={
+                "template_id": template_id,
+                "execution_mode": execution_mode,
+                "parameters": parameters or {},
+            },
+        )
+        self._expect_status(response, {201}, invalid_message="Unable to create reasoning job")
+        return ReasoningJobRecord.from_payload(response.json())
+
+    def list_jobs(
+        self,
+        *,
+        skip: int = 0,
+        limit: int = 50,
+        status_filter: str | None = None,
+        template_id: str | None = None,
+    ) -> ReasoningJobHistoryRecord:
+        params: dict[str, Any] = {"skip": skip, "limit": limit}
+        if status_filter:
+            params["status"] = status_filter
+        if template_id:
+            params["template_id"] = template_id
+        response = self._request("get", "/v1/reasoning/jobs", params=params)
+        self._expect_status(response, {200})
+        return ReasoningJobHistoryRecord.from_payload(response.json())
+
+    def get_job(self, job_id: str) -> ReasoningJobRecord:
+        response = self._request("get", f"/v1/reasoning/jobs/{job_id}")
+        self._expect_status(response, {200}, not_found_message="Reasoning job not found")
+        return ReasoningJobRecord.from_payload(response.json())
+
+    def register_artifact_reference(
+        self,
+        *,
+        job_id: str,
+        role: str,
+        kind: str,
+        file_path: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> ReasoningArtifactRecord:
+        path = Path(file_path).expanduser().resolve()
+        if not path.exists():
+            raise ValidationError(f"Artifact path does not exist: {path}")
+
+        payload = {
+            "role": role,
+            "kind": kind,
+            "storage_backend": "local_reference",
+            "filename": path.name,
+            "local_path": str(path),
+            "content_type": _guess_content_type(path),
+            "size_bytes": path.stat().st_size,
+            "metadata": metadata or {},
+        }
+        response = self._request("post", f"/v1/reasoning/jobs/{job_id}/artifacts", json=payload)
+        self._expect_status(
+            response, {201}, invalid_message="Unable to register reasoning artifact"
+        )
+        return ReasoningArtifactRecord.from_payload(response.json())
+
+    def upload_artifact(
+        self,
+        *,
+        job_id: str,
+        role: str,
+        kind: str,
+        file_path: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> ReasoningArtifactRecord:
+        path = Path(file_path).expanduser().resolve()
+        if not path.exists():
+            raise ValidationError(f"Artifact path does not exist: {path}")
+
+        with path.open("rb") as handle:
+            files = {
+                "file": (path.name, handle, _guess_content_type(path) or "application/octet-stream")
+            }
+            data = {
+                "role": role,
+                "kind": kind,
+                "metadata": json.dumps(metadata or {}),
+            }
+            response = self._request(
+                "post",
+                f"/v1/reasoning/jobs/{job_id}/artifacts",
+                files=files,
+                data=data,
+            )
+        self._expect_status(response, {201}, invalid_message="Unable to upload reasoning artifact")
+        return ReasoningArtifactRecord.from_payload(response.json())
+
+    def dispatch_job(self, *, job_id: str, mode: str) -> ReasoningJobRecord:
+        response = self._request(
+            "post",
+            f"/v1/reasoning/jobs/{job_id}/dispatch",
+            json={"mode": mode},
+        )
+        self._expect_status(response, {200}, invalid_message="Unable to dispatch reasoning job")
+        return ReasoningJobRecord.from_payload(response.json())
+
+    def launch_local(
+        self, *, job_id: str, output_dir: str | None = None
+    ) -> ReasoningLocalLaunchRecord:
+        response = self._request(
+            "post",
+            f"/v1/reasoning/jobs/{job_id}/launch-local",
+            json={"output_dir": output_dir},
+        )
+        self._expect_status(
+            response, {200}, invalid_message="Unable to launch reasoning job locally"
+        )
+        return ReasoningLocalLaunchRecord.from_payload(response.json())
+
+    def submit_event(
+        self,
+        *,
+        job_id: str,
+        event_type: str,
+        message: str | None = None,
+        payload: dict[str, Any] | None = None,
+        status_value: str | None = None,
+        output_text: str | None = None,
+        error_message: str | None = None,
+        result_summary: dict[str, Any] | None = None,
+    ) -> ReasoningJobRecord:
+        body = {
+            "event_type": event_type,
+            "message": message,
+            "payload": payload or {},
+            "status": status_value,
+            "output_text": output_text,
+            "error_message": error_message,
+            "result_summary": result_summary,
+        }
+        response = self._request("post", f"/v1/reasoning/jobs/{job_id}/events", json=body)
+        self._expect_status(response, {200}, invalid_message="Unable to submit reasoning job event")
+        return ReasoningJobRecord.from_payload(response.json())
+
+    def download_artifact(
+        self,
+        *,
+        job_id: str,
+        artifact_id: str,
+        destination: str | None = None,
+    ) -> Path:
+        response = self._request(
+            "get",
+            f"/v1/reasoning/jobs/{job_id}/artifacts/{artifact_id}",
+            allow_refresh=True,
+        )
+        self._expect_status(response, {200}, not_found_message="Reasoning artifact not found")
+
+        header = response.headers.get("content-disposition", "")
+        filename = artifact_id
+        if "filename=" in header:
+            filename = header.split("filename=", 1)[1].strip().strip('"')
+
+        path = Path(destination).expanduser().resolve() if destination else Path.cwd() / filename
+        if path.exists() and path.is_dir():
+            path = path / filename
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(response.content)
+        return path
+
+    def run_local_job(
+        self,
+        *,
+        job: ReasoningJobRecord,
+        output_dir: str | None = None,
+    ) -> ReasoningJobRecord:
+        try:
+            from src.api.services.reasoning_engine import execute_reasoning_manifest
+        except Exception as exc:  # noqa: BLE001
+            raise CLIServiceError(
+                "Local reasoning execution requires the backend source tree to be available."
+            ) from exc
+
+        launch = self.launch_local(job_id=job.id, output_dir=output_dir)
+        self.submit_event(
+            job_id=job.id,
+            event_type="reasoning.pass_started",
+            message="Local reasoning execution started",
+            payload={"execution_mode": "local"},
+            status_value="running",
+        )
+
+        try:
+            execution_result = asyncio.run(execute_reasoning_manifest(launch.manifest))
+            for event in execution_result.events:
+                self.submit_event(
+                    job_id=job.id,
+                    event_type=event.event_type,
+                    message=event.message,
+                    payload=event.payload,
+                )
+            for artifact in execution_result.artifacts:
+                self.upload_artifact(
+                    job_id=job.id,
+                    role=artifact.role,
+                    kind=artifact.kind,
+                    file_path=str(artifact.path),
+                    metadata=artifact.metadata,
+                )
+            return self.submit_event(
+                job_id=job.id,
+                event_type="reasoning.completed",
+                message="Local reasoning execution completed",
+                payload={"driver": execution_result.driver},
+                status_value="completed",
+                output_text=execution_result.output_text,
+                result_summary=execution_result.summary,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return self.submit_event(
+                job_id=job.id,
+                event_type="reasoning.failed",
+                message="Local reasoning execution failed",
+                payload={"error": str(exc)},
+                status_value="failed",
+                error_message=str(exc),
+            )

--- a/components/dashboard/ReasoningPageClient.tsx
+++ b/components/dashboard/ReasoningPageClient.tsx
@@ -1,0 +1,445 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { ApiRequestError, readJson, writeJson } from "@/components/app/http";
+import {
+  LiveAuthRequired,
+  LiveEmptyState,
+  LiveErrorState,
+  LiveKpiGrid,
+  LiveLoading,
+  LivePanel,
+  LiveStatCard,
+  asDashboardStatus,
+  formatRelativeTime,
+} from "@/components/dashboard/livePrimitives";
+import { StatusBadge } from "@/components/dashboard/StatusBadge";
+
+type ReasoningTemplate = {
+  id: string;
+  name: string;
+  summary: string;
+  description: string;
+  supports_managed: boolean;
+  supports_local: boolean;
+};
+
+type ReasoningArtifact = {
+  id: string;
+  role: string;
+  kind: string;
+  storage_backend: string;
+  filename: string;
+};
+
+type ReasoningJob = {
+  id: string;
+  run_id: string;
+  template_id: string;
+  execution_mode: string;
+  status: string;
+  parameters: Record<string, unknown>;
+  result_summary: Record<string, unknown>;
+  error_message?: string | null;
+  created_at?: string | null;
+  completed_at?: string | null;
+  artifacts: ReasoningArtifact[];
+};
+
+type ReasoningJobHistory = {
+  items: ReasoningJob[];
+  total: number;
+};
+
+async function uploadContextArtifact(jobId: string, file: File) {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("role", "context");
+  formData.append("kind", "file");
+
+  const response = await fetch(`/api/dashboard/reasoning/jobs/${encodeURIComponent(jobId)}/artifacts`, {
+    method: "POST",
+    body: formData,
+  });
+  const payload = await response.json().catch(() => ({ detail: "Failed to upload reasoning context" }));
+  if (!response.ok) {
+    throw new ApiRequestError(
+      typeof payload?.detail === "string" ? payload.detail : "Failed to upload reasoning context",
+      response.status,
+    );
+  }
+  return payload as ReasoningArtifact;
+}
+
+export function ReasoningPageClient() {
+  const [loading, setLoading] = useState(true);
+  const [authRequired, setAuthRequired] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [templates, setTemplates] = useState<ReasoningTemplate[]>([]);
+  const [jobs, setJobs] = useState<ReasoningJob[]>([]);
+  const [selectedTemplateId, setSelectedTemplateId] = useState("autoreason_refine");
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+  const [taskPrompt, setTaskPrompt] = useState("");
+  const [incumbent, setIncumbent] = useState("");
+  const [rubric, setRubric] = useState("");
+  const [contextFiles, setContextFiles] = useState<File[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const selectedTemplate = useMemo(
+    () => templates.find((item) => item.id === selectedTemplateId) ?? null,
+    [templates, selectedTemplateId],
+  );
+  const selectedJob = useMemo(
+    () => jobs.find((item) => item.id === selectedJobId) ?? null,
+    [jobs, selectedJobId],
+  );
+
+  async function loadData(nextJobId?: string) {
+    setLoading(true);
+    setError(null);
+    setAuthRequired(false);
+
+    try {
+      const [templateResponse, jobsResponse] = await Promise.all([
+        readJson<ReasoningTemplate[]>("/api/dashboard/reasoning/templates"),
+        readJson<ReasoningJobHistory>("/api/dashboard/reasoning/jobs?limit=20"),
+      ]);
+      setTemplates(templateResponse);
+      setJobs(jobsResponse.items ?? []);
+      setSelectedTemplateId((current) => current || templateResponse[0]?.id || "autoreason_refine");
+      setSelectedJobId(nextJobId ?? jobsResponse.items?.[0]?.id ?? null);
+    } catch (loadError) {
+      if (
+        loadError instanceof ApiRequestError &&
+        (loadError.status === 401 || loadError.status === 403)
+      ) {
+        setAuthRequired(true);
+      } else {
+        setError(loadError instanceof Error ? loadError.message : "Failed to load reasoning workflows");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadData();
+  }, []);
+
+  async function submitManagedJob() {
+    if (!taskPrompt.trim()) {
+      setError("Task prompt is required.");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const parameters: Record<string, unknown> = {
+        task_prompt: taskPrompt.trim(),
+      };
+      if (incumbent.trim()) {
+        parameters.incumbent = incumbent.trim();
+      }
+      if (rubric.trim()) {
+        parameters.rubric = rubric.trim();
+      }
+
+      const job = await writeJson<ReasoningJob>("/api/dashboard/reasoning/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          template_id: selectedTemplateId,
+          execution_mode: "managed",
+          parameters,
+        }),
+      });
+
+      for (const file of contextFiles) {
+        await uploadContextArtifact(job.id, file);
+      }
+
+      await writeJson<ReasoningJob>(`/api/dashboard/reasoning/jobs/${encodeURIComponent(job.id)}/dispatch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "managed" }),
+      });
+
+      setTaskPrompt("");
+      setIncumbent("");
+      setRubric("");
+      setContextFiles([]);
+      await loadData(job.id);
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : "Failed to queue reasoning job");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const jobStats = useMemo(() => {
+    const queued = jobs.filter((job) => job.status === "queued" || job.status === "created").length;
+    const running = jobs.filter((job) => job.status === "running").length;
+    const completed = jobs.filter((job) => job.status === "completed").length;
+    const failed = jobs.filter((job) => job.status === "failed").length;
+    return { queued, running, completed, failed };
+  }, [jobs]);
+
+  if (loading) return <LiveLoading title="Reasoning" />;
+  if (authRequired) {
+    return (
+      <LiveAuthRequired
+        title="Operator session required"
+        message="Sign in to launch and inspect Autoreason refinement jobs."
+      />
+    );
+  }
+  if (error && templates.length === 0 && jobs.length === 0) {
+    return <LiveErrorState title="Reasoning workflows unavailable" message={error} />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <LiveKpiGrid>
+        <LiveStatCard
+          label="Templates"
+          value={String(templates.length)}
+          detail="Reasoning workflow templates available in MUTX."
+        />
+        <LiveStatCard
+          label="Queued"
+          value={String(jobStats.queued)}
+          detail="Jobs waiting for a reasoning worker to pick them up."
+          status={asDashboardStatus(jobStats.queued > 0 ? "warning" : "idle")}
+        />
+        <LiveStatCard
+          label="Running"
+          value={String(jobStats.running)}
+          detail="Autoreason loops actively judging or refining."
+          status={asDashboardStatus(jobStats.running > 0 ? "running" : "idle")}
+        />
+        <LiveStatCard
+          label="Completed"
+          value={String(jobStats.completed)}
+          detail="Jobs that finished with a final incumbent and artifacts."
+          status="success"
+        />
+        <LiveStatCard
+          label="Failed"
+          value={String(jobStats.failed)}
+          detail="Reasoning jobs that need operator follow-up."
+          status={asDashboardStatus(jobStats.failed > 0 ? "failed" : "healthy")}
+        />
+      </LiveKpiGrid>
+
+      {error ? <LiveErrorState title="Reasoning update failed" message={error} /> : null}
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.05fr)_minmax(380px,0.95fr)]">
+        <LivePanel title="Launch autoreason" meta={selectedTemplate?.name || "Select template"}>
+          <div className="space-y-4">
+            <label className="block space-y-2">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                Template
+              </span>
+              <select
+                value={selectedTemplateId}
+                onChange={(event) => setSelectedTemplateId(event.target.value)}
+                className="w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm text-white"
+              >
+                {templates.map((template) => (
+                  <option key={template.id} value={template.id}>
+                    {template.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {selectedTemplate ? (
+              <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4 text-sm text-slate-300">
+                <p className="font-medium text-white">{selectedTemplate.summary}</p>
+                <p className="mt-2 text-slate-400">{selectedTemplate.description}</p>
+              </div>
+            ) : null}
+
+            <label className="block space-y-2">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                Task prompt
+              </span>
+              <textarea
+                value={taskPrompt}
+                onChange={(event) => setTaskPrompt(event.target.value)}
+                className="min-h-32 w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm text-white"
+                placeholder="What should Autoreason improve, decide, or rewrite?"
+              />
+            </label>
+
+            <label className="block space-y-2">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                Incumbent answer
+              </span>
+              <textarea
+                value={incumbent}
+                onChange={(event) => setIncumbent(event.target.value)}
+                className="min-h-28 w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm text-white"
+                placeholder="Optional starting answer. Leave empty to draft from scratch."
+              />
+            </label>
+
+            <label className="block space-y-2">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                Rubric
+              </span>
+              <textarea
+                value={rubric}
+                onChange={(event) => setRubric(event.target.value)}
+                className="min-h-24 w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm text-white"
+                placeholder="Optional evaluation rubric for the judge panel."
+              />
+            </label>
+
+            <label className="block space-y-2">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                Context files
+              </span>
+              <input
+                type="file"
+                multiple
+                onChange={(event) => setContextFiles(Array.from(event.target.files ?? []))}
+                className="block w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm text-slate-300"
+              />
+              {contextFiles.length > 0 ? (
+                <ul className="space-y-1 text-xs text-slate-400">
+                  {contextFiles.map((file) => (
+                    <li key={`${file.name}-${file.size}`}>{file.name}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </label>
+
+            <button
+              type="button"
+              onClick={() => void submitManagedJob()}
+              disabled={submitting}
+              className="inline-flex items-center justify-center rounded-full border border-[#d4ab73]/30 bg-[#d4ab73]/12 px-5 py-2.5 text-sm font-medium text-[#fff1df] transition hover:bg-[#d4ab73]/18 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {submitting ? "Queueing..." : "Queue managed job"}
+            </button>
+          </div>
+        </LivePanel>
+
+        <div className="space-y-4">
+          <LivePanel title="Reasoning history" meta={`${jobs.length} jobs`}>
+            {jobs.length === 0 ? (
+              <LiveEmptyState
+                title="No reasoning jobs yet"
+                message="Your first Autoreason run will show up here with artifacts and run linkage."
+              />
+            ) : (
+              <div className="space-y-3">
+                {jobs.map((job) => {
+                  const isSelected = selectedJobId === job.id;
+                  const winner = typeof job.result_summary?.winner === "string" ? job.result_summary.winner : null;
+                  const passCount = typeof job.result_summary?.pass_count === "number" ? job.result_summary.pass_count : null;
+                  return (
+                    <button
+                      key={job.id}
+                      type="button"
+                      onClick={() => setSelectedJobId(job.id)}
+                      className={`w-full rounded-2xl border p-4 text-left transition ${
+                        isSelected ? "border-[#d4ab73]/40 bg-[#d4ab73]/10" : "border-white/10 bg-white/[0.02]"
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-white">{job.id}</p>
+                          <p className="mt-1 text-xs text-slate-400">
+                            {job.template_id} · {job.execution_mode}
+                          </p>
+                        </div>
+                        <StatusBadge status={asDashboardStatus(job.status)} label={job.status} />
+                      </div>
+                      <div className="mt-3 flex flex-wrap gap-3 text-xs text-slate-500">
+                        <span>created {formatRelativeTime(job.created_at)}</span>
+                        {job.completed_at ? <span>finished {formatRelativeTime(job.completed_at)}</span> : null}
+                        {winner ? <span>winner {winner}</span> : null}
+                        {passCount !== null ? <span>{passCount} passes</span> : null}
+                      </div>
+                      {job.error_message ? (
+                        <p className="mt-3 text-sm text-rose-300">{job.error_message}</p>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </LivePanel>
+
+          <LivePanel title="Selected job" meta={selectedJob?.id || "None selected"}>
+            {selectedJob ? (
+              <div className="space-y-4 text-sm text-slate-300">
+                <div className="flex flex-wrap items-center gap-3">
+                  <StatusBadge status={asDashboardStatus(selectedJob.status)} label={selectedJob.status} />
+                  <span className="text-slate-500">run {selectedJob.run_id}</span>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                    <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Winner</p>
+                    <p className="mt-2 text-lg font-medium text-white">
+                      {typeof selectedJob.result_summary?.winner === "string"
+                        ? selectedJob.result_summary.winner
+                        : "Pending"}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                    <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Passes</p>
+                    <p className="mt-2 text-lg font-medium text-white">
+                      {typeof selectedJob.result_summary?.pass_count === "number"
+                        ? selectedJob.result_summary.pass_count
+                        : "-"}
+                    </p>
+                  </div>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                  <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Input task</p>
+                  <p className="mt-2 whitespace-pre-wrap text-slate-300">
+                    {typeof selectedJob.parameters?.task_prompt === "string"
+                      ? selectedJob.parameters.task_prompt
+                      : "No task prompt recorded."}
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                  <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Artifacts</p>
+                  {selectedJob.artifacts.length === 0 ? (
+                    <p className="mt-2 text-slate-500">No artifacts synced yet.</p>
+                  ) : (
+                    <div className="mt-3 space-y-2">
+                      {selectedJob.artifacts.map((artifact) => (
+                        <a
+                          key={artifact.id}
+                          href={`/api/dashboard/reasoning/jobs/${encodeURIComponent(selectedJob.id)}/artifacts/${encodeURIComponent(artifact.id)}`}
+                          className="flex items-center justify-between rounded-xl border border-white/10 bg-black/10 px-3 py-2 text-sm text-slate-200 transition hover:border-[#d4ab73]/40 hover:text-white"
+                        >
+                          <span>{artifact.filename}</span>
+                          <span className="text-xs text-slate-500">
+                            {artifact.role} · {artifact.kind}
+                          </span>
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <LiveEmptyState
+                title="No reasoning job selected"
+                message="Pick a job from the history panel to inspect winner state and artifacts."
+              />
+            )}
+          </LivePanel>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
 
 [project.scripts]
 mutx = "cli.main:cli"
+mutx-reasoning-worker = "src.api.reasoning_worker:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/src/api/models/migrations/versions/e7f8a9b0c1d2_add_reasoning_workflows.py
+++ b/src/api/models/migrations/versions/e7f8a9b0c1d2_add_reasoning_workflows.py
@@ -1,0 +1,133 @@
+"""Add reasoning workflow jobs and artifacts.
+
+Revision ID: e7f8a9b0c1d2
+Revises: d6e7f8a9b0c1
+Create Date: 2026-04-13
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "e7f8a9b0c1d2"
+down_revision: Union[str, None] = "d6e7f8a9b0c1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _bind():
+    return op.get_bind()
+
+
+def _inspector():
+    return sa.inspect(_bind())
+
+
+def _has_table(table_name: str) -> bool:
+    return _inspector().has_table(table_name)
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return any(index["name"] == index_name for index in _inspector().get_indexes(table_name))
+
+
+def _create_index_if_missing(
+    table_name: str,
+    index_name: str,
+    columns: list[str],
+    *,
+    unique: bool = False,
+) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(index_name, table_name, columns, unique=unique)
+
+
+def upgrade() -> None:
+    if not _has_table("reasoning_jobs"):
+        op.create_table(
+            "reasoning_jobs",
+            sa.Column("id", sa.UUID(), nullable=False),
+            sa.Column("user_id", sa.UUID(), nullable=False),
+            sa.Column("run_id", sa.UUID(), nullable=False),
+            sa.Column("template_id", sa.String(length=120), nullable=False),
+            sa.Column("execution_mode", sa.String(length=32), nullable=False),
+            sa.Column("status", sa.String(length=50), nullable=False),
+            sa.Column("parameters", sa.Text(), nullable=True),
+            sa.Column("result_summary", sa.Text(), nullable=True),
+            sa.Column("error_message", sa.Text(), nullable=True),
+            sa.Column("claimed_by", sa.String(length=255), nullable=True),
+            sa.Column("claim_token", sa.String(length=64), nullable=True),
+            sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("dispatched_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["run_id"], ["agent_runs.id"]),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("run_id"),
+        )
+
+    _create_index_if_missing("reasoning_jobs", op.f("ix_reasoning_jobs_user_id"), ["user_id"])
+    _create_index_if_missing("reasoning_jobs", op.f("ix_reasoning_jobs_run_id"), ["run_id"])
+    _create_index_if_missing(
+        "reasoning_jobs", op.f("ix_reasoning_jobs_template_id"), ["template_id"]
+    )
+    _create_index_if_missing(
+        "reasoning_jobs", op.f("ix_reasoning_jobs_execution_mode"), ["execution_mode"]
+    )
+    _create_index_if_missing("reasoning_jobs", op.f("ix_reasoning_jobs_status"), ["status"])
+    _create_index_if_missing(
+        "reasoning_jobs", op.f("ix_reasoning_jobs_claim_token"), ["claim_token"]
+    )
+    _create_index_if_missing("reasoning_jobs", op.f("ix_reasoning_jobs_created_at"), ["created_at"])
+    _create_index_if_missing("reasoning_jobs", op.f("ix_reasoning_jobs_updated_at"), ["updated_at"])
+
+    if not _has_table("reasoning_artifacts"):
+        op.create_table(
+            "reasoning_artifacts",
+            sa.Column("id", sa.UUID(), nullable=False),
+            sa.Column("job_id", sa.UUID(), nullable=False),
+            sa.Column("role", sa.String(length=120), nullable=False),
+            sa.Column("kind", sa.String(length=120), nullable=False),
+            sa.Column("storage_backend", sa.String(length=64), nullable=False),
+            sa.Column("storage_uri", sa.Text(), nullable=True),
+            sa.Column("local_path", sa.Text(), nullable=True),
+            sa.Column("filename", sa.String(length=255), nullable=False),
+            sa.Column("content_type", sa.String(length=255), nullable=True),
+            sa.Column("size_bytes", sa.Integer(), nullable=True),
+            sa.Column("sha256", sa.String(length=64), nullable=True),
+            sa.Column("extra_metadata", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["job_id"], ["reasoning_jobs.id"]),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+    _create_index_if_missing(
+        "reasoning_artifacts", op.f("ix_reasoning_artifacts_job_id"), ["job_id"]
+    )
+    _create_index_if_missing("reasoning_artifacts", op.f("ix_reasoning_artifacts_role"), ["role"])
+    _create_index_if_missing("reasoning_artifacts", op.f("ix_reasoning_artifacts_kind"), ["kind"])
+    _create_index_if_missing(
+        "reasoning_artifacts", op.f("ix_reasoning_artifacts_storage_backend"), ["storage_backend"]
+    )
+    _create_index_if_missing(
+        "reasoning_artifacts", op.f("ix_reasoning_artifacts_sha256"), ["sha256"]
+    )
+    _create_index_if_missing(
+        "reasoning_artifacts", op.f("ix_reasoning_artifacts_created_at"), ["created_at"]
+    )
+
+
+def downgrade() -> None:
+    if _has_table("reasoning_artifacts"):
+        op.drop_table("reasoning_artifacts")
+    if _has_table("reasoning_jobs"):
+        op.drop_table("reasoning_jobs")

--- a/src/api/services/reasoning_engine.py
+++ b/src/api/services/reasoning_engine.py
@@ -8,30 +8,30 @@ from pathlib import Path
 import tempfile
 from typing import Any
 
-from anthropic import AsyncAnthropic
-from openai import AsyncOpenAI
-
 from src.api.config import get_settings
 from src.api.services.reasoning_templates import get_reasoning_template
 
 REASONING_TRACE_EVENT_TYPES = {
-    'reasoning.job_created',
-    'reasoning.job_dispatched',
-    'reasoning.job_claimed',
-    'reasoning.pass_started',
-    'reasoning.critic_completed',
-    'reasoning.revision_completed',
-    'reasoning.synthesis_completed',
-    'reasoning.judge_vote',
-    'reasoning.pass_scored',
-    'reasoning.incumbent_retained',
-    'reasoning.incumbent_replaced',
-    'reasoning.converged',
-    'reasoning.completed',
-    'reasoning.failed',
+    "reasoning.job_created",
+    "reasoning.job_dispatched",
+    "reasoning.job_claimed",
+    "reasoning.pass_started",
+    "reasoning.critic_completed",
+    "reasoning.revision_completed",
+    "reasoning.synthesis_completed",
+    "reasoning.judge_vote",
+    "reasoning.pass_scored",
+    "reasoning.incumbent_retained",
+    "reasoning.incumbent_replaced",
+    "reasoning.converged",
+    "reasoning.artifact_registered",
+    "reasoning.artifact_uploaded",
+    "reasoning.artifact_synced",
+    "reasoning.completed",
+    "reasoning.failed",
 }
 
-DEFAULT_REASONING_MODEL = 'openrouter/openai/gpt-4.1-mini'
+DEFAULT_REASONING_MODEL = "openrouter/openai/gpt-4.1-mini"
 DEFAULT_AUTHOR_TEMPERATURE = 0.4
 DEFAULT_JUDGE_TEMPERATURE = 0.2
 DEFAULT_MAX_TOKENS = 2400
@@ -50,10 +50,10 @@ class EngineReadiness:
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'enabled': self.enabled,
-            'live_model_available': self.live_model_available,
-            'ready': self.ready,
-            'driver': self.driver,
+            "enabled": self.enabled,
+            "live_model_available": self.live_model_available,
+            "ready": self.ready,
+            "driver": self.driver,
         }
 
 
@@ -88,16 +88,16 @@ def get_reasoning_engine_readiness() -> EngineReadiness:
     settings = get_settings()
     live_model_available = any(
         [
-            os.environ.get('OPENROUTER_API_KEY'),
-            os.environ.get('OPENAI_API_KEY'),
-            os.environ.get('ANTHROPIC_API_KEY'),
+            os.environ.get("OPENROUTER_API_KEY"),
+            os.environ.get("OPENAI_API_KEY"),
+            os.environ.get("ANTHROPIC_API_KEY"),
         ]
     )
     return EngineReadiness(
         enabled=settings.reasoning_enabled,
         live_model_available=live_model_available,
         ready=settings.reasoning_enabled,
-        driver='llm' if live_model_available else 'builtin_fallback',
+        driver="llm" if live_model_available else "builtin_fallback",
     )
 
 
@@ -124,36 +124,36 @@ def _json_dump(data: Any) -> str:
 
 
 def _load_artifact_text(artifact: dict[str, Any]) -> str:
-    local_path = artifact.get('local_path')
+    local_path = artifact.get("local_path")
     if not local_path:
-        return ''
+        return ""
     path = Path(str(local_path))
     if not path.exists() or not path.is_file():
-        return ''
+        return ""
     try:
-        return path.read_text(encoding='utf-8')
+        return path.read_text(encoding="utf-8")
     except UnicodeDecodeError:
-        return ''
+        return ""
 
 
 def _build_context_block(parameters: dict[str, Any], artifacts: list[dict[str, Any]]) -> str:
     parts: list[str] = []
-    rubric = str(parameters.get('rubric') or '').strip()
+    rubric = str(parameters.get("rubric") or "").strip()
     if rubric:
-        parts.append(f'Rubric:\n{rubric}')
+        parts.append(f"Rubric:\n{rubric}")
 
     context_chunks: list[str] = []
     for artifact in artifacts:
-        if artifact.get('role') != 'context':
+        if artifact.get("role") != "context":
             continue
         content = _load_artifact_text(artifact).strip()
         if not content:
             continue
         context_chunks.append(f"[{artifact.get('filename') or artifact.get('id')}]\n{content}")
     if context_chunks:
-        parts.append('Context artifacts:\n' + '\n\n'.join(context_chunks))
+        parts.append("Context artifacts:\n" + "\n\n".join(context_chunks))
 
-    return '\n\n'.join(parts).strip()
+    return "\n\n".join(parts).strip()
 
 
 def build_reasoning_manifest(
@@ -165,79 +165,79 @@ def build_reasoning_manifest(
     readiness = get_reasoning_engine_readiness()
     serialized_artifacts = [
         {
-            'id': str(item.id),
-            'role': item.role,
-            'kind': item.kind,
-            'storage_backend': item.storage_backend,
-            'storage_uri': item.storage_uri,
-            'local_path': item.local_path,
-            'filename': item.filename,
-            'content_type': item.content_type,
-            'size_bytes': item.size_bytes,
-            'metadata': item.extra_metadata or {},
+            "id": str(item.id),
+            "role": item.role,
+            "kind": item.kind,
+            "storage_backend": item.storage_backend,
+            "storage_uri": item.storage_uri,
+            "local_path": item.local_path,
+            "filename": item.filename,
+            "content_type": item.content_type,
+            "size_bytes": item.size_bytes,
+            "metadata": item.extra_metadata or {},
         }
         for item in artifacts
     ]
     return {
-        'job_id': str(job.id),
-        'run_id': str(job.run_id),
-        'template_id': job.template_id,
-        'template_name': template.name if template else job.template_id,
-        'execution_mode': job.execution_mode,
-        'parameters': job.parameters or {},
-        'artifacts': serialized_artifacts,
-        'trace_metadata': {
-            'subject_type': 'reasoning_job',
-            'subject_id': str(job.id),
-            'subject_label': template.name if template else job.template_id,
-            'template_id': job.template_id,
-            'execution_mode': job.execution_mode,
+        "job_id": str(job.id),
+        "run_id": str(job.run_id),
+        "template_id": job.template_id,
+        "template_name": template.name if template else job.template_id,
+        "execution_mode": job.execution_mode,
+        "parameters": job.parameters or {},
+        "artifacts": serialized_artifacts,
+        "trace_metadata": {
+            "subject_type": "reasoning_job",
+            "subject_id": str(job.id),
+            "subject_label": template.name if template else job.template_id,
+            "template_id": job.template_id,
+            "execution_mode": job.execution_mode,
         },
-        'engine': readiness.to_payload(),
-        'output_dir': output_dir,
+        "engine": readiness.to_payload(),
+        "output_dir": output_dir,
     }
 
 
 def _extract_text_from_openai_response(response) -> str:
     if not response.choices:
-        return ''
+        return ""
     content = response.choices[0].message.content
     if isinstance(content, str):
         return content
     if isinstance(content, list):
         text_parts: list[str] = []
         for item in content:
-            if isinstance(item, dict) and item.get('type') == 'text':
-                text_parts.append(str(item.get('text') or ''))
-        return ''.join(text_parts)
-    return ''
+            if isinstance(item, dict) and item.get("type") == "text":
+                text_parts.append(str(item.get("text") or ""))
+        return "".join(text_parts)
+    return ""
 
 
 def _extract_usage_from_openai_response(response) -> dict[str, int]:
-    usage = getattr(response, 'usage', None)
+    usage = getattr(response, "usage", None)
     return {
-        'input_tokens': int(getattr(usage, 'prompt_tokens', 0) or 0),
-        'output_tokens': int(getattr(usage, 'completion_tokens', 0) or 0),
-        'total_tokens': int(getattr(usage, 'total_tokens', 0) or 0),
+        "input_tokens": int(getattr(usage, "prompt_tokens", 0) or 0),
+        "output_tokens": int(getattr(usage, "completion_tokens", 0) or 0),
+        "total_tokens": int(getattr(usage, "total_tokens", 0) or 0),
     }
 
 
 def _extract_text_from_anthropic_response(response) -> str:
-    blocks = getattr(response, 'content', []) or []
+    blocks = getattr(response, "content", []) or []
     text_parts: list[str] = []
     for block in blocks:
-        if getattr(block, 'type', None) == 'text':
-            text_parts.append(str(getattr(block, 'text', '') or ''))
-    return ''.join(text_parts)
+        if getattr(block, "type", None) == "text":
+            text_parts.append(str(getattr(block, "text", "") or ""))
+    return "".join(text_parts)
 
 
 def _extract_usage_from_anthropic_response(response) -> dict[str, int]:
-    usage = getattr(response, 'usage', None)
+    usage = getattr(response, "usage", None)
     return {
-        'input_tokens': int(getattr(usage, 'input_tokens', 0) or 0),
-        'output_tokens': int(getattr(usage, 'output_tokens', 0) or 0),
-        'total_tokens': int(
-            (getattr(usage, 'input_tokens', 0) or 0) + (getattr(usage, 'output_tokens', 0) or 0)
+        "input_tokens": int(getattr(usage, "input_tokens", 0) or 0),
+        "output_tokens": int(getattr(usage, "output_tokens", 0) or 0),
+        "total_tokens": int(
+            (getattr(usage, "input_tokens", 0) or 0) + (getattr(usage, "output_tokens", 0) or 0)
         ),
     }
 
@@ -254,115 +254,129 @@ async def _invoke_model(
     if not normalized_model:
         normalized_model = DEFAULT_REASONING_MODEL
 
-    openrouter_key = os.environ.get('OPENROUTER_API_KEY')
-    openai_key = os.environ.get('OPENAI_API_KEY')
-    anthropic_key = os.environ.get('ANTHROPIC_API_KEY')
+    openrouter_key = os.environ.get("OPENROUTER_API_KEY")
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
 
-    if normalized_model.startswith('openrouter/'):
+    if normalized_model.startswith("openrouter/"):
         if not openrouter_key:
-            raise ReasoningEngineError('OPENROUTER_API_KEY is required for openrouter/* models')
-        client = AsyncOpenAI(api_key=openrouter_key, base_url='https://openrouter.ai/api/v1')
+            raise ReasoningEngineError("OPENROUTER_API_KEY is required for openrouter/* models")
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
         response = await client.chat.completions.create(
-            model=normalized_model.removeprefix('openrouter/'),
+            model=normalized_model.removeprefix("openrouter/"),
             messages=[
-                {'role': 'system', 'content': system_prompt},
-                {'role': 'user', 'content': user_prompt},
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
             ],
             temperature=temperature,
             max_tokens=max_tokens,
         )
         return {
-            'text': _extract_text_from_openai_response(response),
-            'usage': _extract_usage_from_openai_response(response),
-            'provider': 'openrouter',
+            "text": _extract_text_from_openai_response(response),
+            "usage": _extract_usage_from_openai_response(response),
+            "provider": "openrouter",
         }
 
-    if normalized_model.startswith('anthropic/'):
+    if normalized_model.startswith("anthropic/"):
         if anthropic_key:
+            from anthropic import AsyncAnthropic
+
             client = AsyncAnthropic(api_key=anthropic_key)
             response = await client.messages.create(
-                model=normalized_model.removeprefix('anthropic/'),
+                model=normalized_model.removeprefix("anthropic/"),
                 system=system_prompt,
-                messages=[{'role': 'user', 'content': user_prompt}],
+                messages=[{"role": "user", "content": user_prompt}],
                 temperature=temperature,
                 max_tokens=max_tokens,
             )
             return {
-                'text': _extract_text_from_anthropic_response(response),
-                'usage': _extract_usage_from_anthropic_response(response),
-                'provider': 'anthropic',
+                "text": _extract_text_from_anthropic_response(response),
+                "usage": _extract_usage_from_anthropic_response(response),
+                "provider": "anthropic",
             }
         if openrouter_key:
-            client = AsyncOpenAI(api_key=openrouter_key, base_url='https://openrouter.ai/api/v1')
+            from openai import AsyncOpenAI
+
+            client = AsyncOpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
             response = await client.chat.completions.create(
                 model=normalized_model,
                 messages=[
-                    {'role': 'system', 'content': system_prompt},
-                    {'role': 'user', 'content': user_prompt},
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
                 ],
                 temperature=temperature,
                 max_tokens=max_tokens,
             )
             return {
-                'text': _extract_text_from_openai_response(response),
-                'usage': _extract_usage_from_openai_response(response),
-                'provider': 'openrouter',
+                "text": _extract_text_from_openai_response(response),
+                "usage": _extract_usage_from_openai_response(response),
+                "provider": "openrouter",
             }
-        raise ReasoningEngineError('No provider credentials available for anthropic model')
+        raise ReasoningEngineError("No provider credentials available for anthropic model")
 
-    if normalized_model.startswith('openai/') or normalized_model.lower().startswith(('gpt-', 'o1', 'o3', 'o4')):
+    if normalized_model.startswith("openai/") or normalized_model.lower().startswith(
+        ("gpt-", "o1", "o3", "o4")
+    ):
         if openai_key:
+            from openai import AsyncOpenAI
+
             client = AsyncOpenAI(api_key=openai_key)
             response = await client.chat.completions.create(
-                model=normalized_model.removeprefix('openai/'),
+                model=normalized_model.removeprefix("openai/"),
                 messages=[
-                    {'role': 'system', 'content': system_prompt},
-                    {'role': 'user', 'content': user_prompt},
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
                 ],
                 temperature=temperature,
                 max_tokens=max_tokens,
             )
             return {
-                'text': _extract_text_from_openai_response(response),
-                'usage': _extract_usage_from_openai_response(response),
-                'provider': 'openai',
+                "text": _extract_text_from_openai_response(response),
+                "usage": _extract_usage_from_openai_response(response),
+                "provider": "openai",
             }
         if openrouter_key:
-            client = AsyncOpenAI(api_key=openrouter_key, base_url='https://openrouter.ai/api/v1')
+            from openai import AsyncOpenAI
+
+            client = AsyncOpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
             response = await client.chat.completions.create(
-                model=normalized_model.removeprefix('openai/'),
+                model=normalized_model.removeprefix("openai/"),
                 messages=[
-                    {'role': 'system', 'content': system_prompt},
-                    {'role': 'user', 'content': user_prompt},
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
                 ],
                 temperature=temperature,
                 max_tokens=max_tokens,
             )
             return {
-                'text': _extract_text_from_openai_response(response),
-                'usage': _extract_usage_from_openai_response(response),
-                'provider': 'openrouter',
+                "text": _extract_text_from_openai_response(response),
+                "usage": _extract_usage_from_openai_response(response),
+                "provider": "openrouter",
             }
-        raise ReasoningEngineError('No provider credentials available for openai model')
+        raise ReasoningEngineError("No provider credentials available for openai model")
 
     if openrouter_key:
-        client = AsyncOpenAI(api_key=openrouter_key, base_url='https://openrouter.ai/api/v1')
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
         response = await client.chat.completions.create(
             model=normalized_model,
             messages=[
-                {'role': 'system', 'content': system_prompt},
-                {'role': 'user', 'content': user_prompt},
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
             ],
             temperature=temperature,
             max_tokens=max_tokens,
         )
         return {
-            'text': _extract_text_from_openai_response(response),
-            'usage': _extract_usage_from_openai_response(response),
-            'provider': 'openrouter',
+            "text": _extract_text_from_openai_response(response),
+            "usage": _extract_usage_from_openai_response(response),
+            "provider": "openrouter",
         }
 
-    raise ReasoningEngineError(f'Unable to resolve provider for model {normalized_model}')
+    raise ReasoningEngineError(f"Unable to resolve provider for model {normalized_model}")
 
 
 def _score_candidate(candidate: str, task_prompt: str, rubric: str) -> float:
@@ -370,26 +384,29 @@ def _score_candidate(candidate: str, task_prompt: str, rubric: str) -> float:
     task_tokens = {token for token in task_prompt.lower().split() if len(token) > 3}
     rubric_tokens = {token for token in rubric.lower().split() if len(token) > 3}
     overlap = sum(1 for token in task_tokens | rubric_tokens if token in candidate_text)
-    structure_bonus = 1.0 if ('\n-' in candidate or '\n1.' in candidate or ':' in candidate) else 0.0
+    structure_bonus = (
+        1.0 if ("\n-" in candidate or "\n1." in candidate or ":" in candidate) else 0.0
+    )
     brevity_penalty = max(len(candidate_text) - 2200, 0) / 500.0
     return overlap + structure_bonus - brevity_penalty
 
 
 async def _run_builtin_reasoning(manifest: dict[str, Any]) -> ReasoningExecutionResult:
-    parameters = manifest['parameters'] or {}
-    task_prompt = str(parameters.get('task_prompt') or '').strip()
-    incumbent = str(parameters.get('incumbent') or '').strip() or f'Draft answer for: {task_prompt}'
-    rubric = str(parameters.get('rubric') or '').strip()
-    context_block = _build_context_block(parameters, manifest.get('artifacts', []))
-    max_passes = max(_safe_int(parameters.get('max_passes'), 3), 1)
-    convergence_wins = max(_safe_int(parameters.get('convergence_wins'), 2), 1)
-    judge_count = max(_safe_int(parameters.get('judge_count'), 3), 1)
+    parameters = manifest["parameters"] or {}
+    task_prompt = str(parameters.get("task_prompt") or "").strip()
+    incumbent = str(parameters.get("incumbent") or "").strip() or f"Draft answer for: {task_prompt}"
+    rubric = str(parameters.get("rubric") or "").strip()
+    context_block = _build_context_block(parameters, manifest.get("artifacts", []))
+    max_passes = max(_safe_int(parameters.get("max_passes"), 3), 1)
+    convergence_wins = max(_safe_int(parameters.get("convergence_wins"), 2), 1)
+    judge_count = max(_safe_int(parameters.get("judge_count"), 3), 1)
 
-    output_dir = Path(manifest.get('output_dir') or tempfile.mkdtemp(prefix='mutx-reasoning-'))
+    output_dir = Path(manifest.get("output_dir") or tempfile.mkdtemp(prefix="mutx-reasoning-"))
     output_dir.mkdir(parents=True, exist_ok=True)
 
     current_a = incumbent
     incumbent_wins = 0
+    last_winner = "A"
     pass_log: list[dict[str, Any]] = []
     judge_ballots: list[dict[str, Any]] = []
     events: list[EngineEvent] = []
@@ -397,86 +414,99 @@ async def _run_builtin_reasoning(manifest: dict[str, Any]) -> ReasoningExecution
     for pass_index in range(1, max_passes + 1):
         events.append(
             EngineEvent(
-                event_type='reasoning.pass_started',
-                message=f'Started builtin reasoning pass {pass_index}',
-                payload={'pass_index': pass_index, 'driver': 'builtin_fallback'},
+                event_type="reasoning.pass_started",
+                message=f"Started builtin reasoning pass {pass_index}",
+                payload={"pass_index": pass_index, "driver": "builtin_fallback"},
             )
         )
-        critique = 'Clarify success criteria, cut filler, and keep the answer concrete.'
+        critique = "Clarify success criteria, cut filler, and keep the answer concrete."
         revision = current_a
-        if 'success criteria' not in revision.lower():
-            revision = revision.rstrip() + '\n\nSuccess criteria:\n- Clear next step\n- Concrete output\n- No vague filler'
+        if "success criteria" not in revision.lower():
+            revision = (
+                revision.rstrip()
+                + "\n\nSuccess criteria:\n- Clear next step\n- Concrete output\n- No vague filler"
+            )
         synthesis = revision if len(revision) >= len(current_a) else current_a
         if context_block:
-            synthesis = synthesis.rstrip() + '\n\nGrounding:\n' + context_block[:800]
+            synthesis = synthesis.rstrip() + "\n\nGrounding:\n" + context_block[:800]
 
-        candidates = {'A': current_a, 'B': revision, 'AB': synthesis}
-        scores = {key: _score_candidate(value, task_prompt, rubric) for key, value in candidates.items()}
-        ranking = [item[0] for item in sorted(scores.items(), key=lambda item: (-item[1], ['A', 'AB', 'B'].index(item[0])))]
+        candidates = {"A": current_a, "B": revision, "AB": synthesis}
+        scores = {
+            key: _score_candidate(value, task_prompt, rubric) for key, value in candidates.items()
+        }
+        ranking = [
+            item[0]
+            for item in sorted(
+                scores.items(), key=lambda item: (-item[1], ["A", "AB", "B"].index(item[0]))
+            )
+        ]
         winner = ranking[0]
+        last_winner = winner
 
         for judge_index in range(judge_count):
             ballot = {
-                'pass_index': pass_index,
-                'judge_index': judge_index,
-                'provider': 'builtin_fallback',
-                'ranking': ranking,
-                'rationale': 'Builtin heuristic scoring prefers grounded and structured outputs.',
+                "pass_index": pass_index,
+                "judge_index": judge_index,
+                "provider": "builtin_fallback",
+                "ranking": ranking,
+                "rationale": "Builtin heuristic scoring prefers grounded and structured outputs.",
             }
             judge_ballots.append(ballot)
             events.append(
                 EngineEvent(
-                    event_type='reasoning.judge_vote',
-                    message=f'Builtin judge {judge_index + 1} ranked pass {pass_index}',
+                    event_type="reasoning.judge_vote",
+                    message=f"Builtin judge {judge_index + 1} ranked pass {pass_index}",
                     payload=ballot,
                 )
             )
 
         pass_log.append(
             {
-                'pass_index': pass_index,
-                'critique': critique,
-                'scores': scores,
-                'winner': winner,
-                'ranking': ranking,
+                "pass_index": pass_index,
+                "critique": critique,
+                "scores": scores,
+                "winner": winner,
+                "ranking": ranking,
             }
         )
 
         for key, value in candidates.items():
-            (output_dir / f'pass_{pass_index:02d}_{key.lower()}.md').write_text(value, encoding='utf-8')
+            (output_dir / f"pass_{pass_index:02d}_{key.lower()}.md").write_text(
+                value, encoding="utf-8"
+            )
 
         events.extend(
             [
                 EngineEvent(
-                    event_type='reasoning.critic_completed',
-                    message=f'Builtin critic completed for pass {pass_index}',
-                    payload={'pass_index': pass_index},
+                    event_type="reasoning.critic_completed",
+                    message=f"Builtin critic completed for pass {pass_index}",
+                    payload={"pass_index": pass_index},
                 ),
                 EngineEvent(
-                    event_type='reasoning.revision_completed',
-                    message=f'Builtin revision completed for pass {pass_index}',
-                    payload={'pass_index': pass_index},
+                    event_type="reasoning.revision_completed",
+                    message=f"Builtin revision completed for pass {pass_index}",
+                    payload={"pass_index": pass_index},
                 ),
                 EngineEvent(
-                    event_type='reasoning.synthesis_completed',
-                    message=f'Builtin synthesis completed for pass {pass_index}',
-                    payload={'pass_index': pass_index},
+                    event_type="reasoning.synthesis_completed",
+                    message=f"Builtin synthesis completed for pass {pass_index}",
+                    payload={"pass_index": pass_index},
                 ),
                 EngineEvent(
-                    event_type='reasoning.pass_scored',
-                    message=f'Builtin pass {pass_index} scored',
-                    payload={'pass_index': pass_index, 'winner': winner, 'scores': scores},
+                    event_type="reasoning.pass_scored",
+                    message=f"Builtin pass {pass_index} scored",
+                    payload={"pass_index": pass_index, "winner": winner, "scores": scores},
                 ),
             ]
         )
 
-        if winner == 'A':
+        if winner == "A":
             incumbent_wins += 1
             events.append(
                 EngineEvent(
-                    event_type='reasoning.incumbent_retained',
-                    message=f'Incumbent retained on pass {pass_index}',
-                    payload={'pass_index': pass_index, 'winner': winner},
+                    event_type="reasoning.incumbent_retained",
+                    message=f"Incumbent retained on pass {pass_index}",
+                    payload={"pass_index": pass_index, "winner": winner},
                 )
             )
         else:
@@ -484,73 +514,83 @@ async def _run_builtin_reasoning(manifest: dict[str, Any]) -> ReasoningExecution
             incumbent_wins = 0
             events.append(
                 EngineEvent(
-                    event_type='reasoning.incumbent_replaced',
-                    message=f'Incumbent replaced with {winner} on pass {pass_index}',
-                    payload={'pass_index': pass_index, 'winner': winner},
+                    event_type="reasoning.incumbent_replaced",
+                    message=f"Incumbent replaced with {winner} on pass {pass_index}",
+                    payload={"pass_index": pass_index, "winner": winner},
                 )
             )
 
         if incumbent_wins >= convergence_wins:
             events.append(
                 EngineEvent(
-                    event_type='reasoning.converged',
-                    message=f'Builtin reasoning converged after pass {pass_index}',
-                    payload={'pass_index': pass_index, 'winner': winner, 'convergence_wins': incumbent_wins},
+                    event_type="reasoning.converged",
+                    message=f"Builtin reasoning converged after pass {pass_index}",
+                    payload={
+                        "pass_index": pass_index,
+                        "winner": winner,
+                        "convergence_wins": incumbent_wins,
+                    },
                 )
             )
             break
 
-    final_output_path = output_dir / 'final_output.md'
-    pass_log_path = output_dir / 'pass_log.json'
-    judge_ballots_path = output_dir / 'judge_ballots.json'
-    winner_summary_path = output_dir / 'winner_summary.json'
+    final_output_path = output_dir / "final_output.md"
+    pass_log_path = output_dir / "pass_log.json"
+    judge_ballots_path = output_dir / "judge_ballots.json"
+    winner_summary_path = output_dir / "winner_summary.json"
 
-    final_output_path.write_text(current_a, encoding='utf-8')
-    pass_log_path.write_text(_json_dump(pass_log), encoding='utf-8')
-    judge_ballots_path.write_text(_json_dump(judge_ballots), encoding='utf-8')
+    final_output_path.write_text(current_a, encoding="utf-8")
+    pass_log_path.write_text(_json_dump(pass_log), encoding="utf-8")
+    judge_ballots_path.write_text(_json_dump(judge_ballots), encoding="utf-8")
 
     summary = {
-        'winner': 'A',
-        'pass_count': len(pass_log),
-        'judge_count': judge_count,
-        'driver': 'builtin_fallback',
-        'converged': incumbent_wins >= convergence_wins,
-        'final_output_length': len(current_a),
+        "winner": last_winner,
+        "pass_count": len(pass_log),
+        "judge_count": judge_count,
+        "driver": "builtin_fallback",
+        "converged": incumbent_wins >= convergence_wins,
+        "final_output_length": len(current_a),
     }
-    winner_summary_path.write_text(_json_dump(summary), encoding='utf-8')
+    winner_summary_path.write_text(_json_dump(summary), encoding="utf-8")
     events.append(
         EngineEvent(
-            event_type='reasoning.completed',
-            message='Builtin reasoning workflow completed',
+            event_type="reasoning.completed",
+            message="Builtin reasoning workflow completed",
             payload=summary,
         )
     )
 
     artifacts = [
-        EngineManagedOutput('final_output', 'markdown', final_output_path, 'final_output.md', 'text/markdown'),
-        EngineManagedOutput('pass_log', 'json', pass_log_path, 'pass_log.json', 'application/json'),
-        EngineManagedOutput('judge_ballots', 'json', judge_ballots_path, 'judge_ballots.json', 'application/json'),
-        EngineManagedOutput('winner_summary', 'json', winner_summary_path, 'winner_summary.json', 'application/json'),
+        EngineManagedOutput(
+            "final_output", "markdown", final_output_path, "final_output.md", "text/markdown"
+        ),
+        EngineManagedOutput("pass_log", "json", pass_log_path, "pass_log.json", "application/json"),
+        EngineManagedOutput(
+            "judge_ballots", "json", judge_ballots_path, "judge_ballots.json", "application/json"
+        ),
+        EngineManagedOutput(
+            "winner_summary", "json", winner_summary_path, "winner_summary.json", "application/json"
+        ),
     ]
     return ReasoningExecutionResult(
-        status='completed',
+        status="completed",
         output_text=current_a,
         summary=summary,
         artifacts=artifacts,
         events=events,
-        driver='builtin_fallback',
+        driver="builtin_fallback",
     )
 
 
 def _strip_code_fences(text: str) -> str:
     cleaned = text.strip()
-    if cleaned.startswith('```'):
+    if cleaned.startswith("```"):
         lines = cleaned.splitlines()
-        if lines and lines[0].startswith('```'):
+        if lines and lines[0].startswith("```"):
             lines = lines[1:]
-        if lines and lines[-1].strip() == '```':
+        if lines and lines[-1].strip() == "```":
             lines = lines[:-1]
-        cleaned = '\n'.join(lines).strip()
+        cleaned = "\n".join(lines).strip()
     return cleaned
 
 
@@ -558,27 +598,31 @@ def _parse_judge_ranking(raw_text: str) -> tuple[list[str], str]:
     cleaned = _strip_code_fences(raw_text)
     try:
         payload = json.loads(cleaned)
-        ranking = [str(item).upper() for item in payload.get('ranking', []) if str(item).upper() in {'A', 'B', 'AB'}]
+        ranking = [
+            str(item).upper()
+            for item in payload.get("ranking", [])
+            if str(item).upper() in {"A", "B", "AB"}
+        ]
         if len(ranking) == 3:
-            return ranking, str(payload.get('rationale') or '').strip()
+            return ranking, str(payload.get("rationale") or "").strip()
     except json.JSONDecodeError:
         pass
 
     normalized = cleaned.upper()
     ranking: list[str] = []
-    for token in ('AB', 'A', 'B'):
+    for token in ("AB", "A", "B"):
         if token in normalized and token not in ranking:
             ranking.append(token)
-    for token in ('A', 'B', 'AB'):
+    for token in ("A", "B", "AB"):
         if token not in ranking:
             ranking.append(token)
     return ranking[:3], cleaned
 
 
 def _borda_scores(ballots: list[dict[str, Any]]) -> dict[str, int]:
-    scores = {'A': 0, 'B': 0, 'AB': 0}
+    scores = {"A": 0, "B": 0, "AB": 0}
     for ballot in ballots:
-        ranking = ballot.get('ranking') or []
+        ranking = ballot.get("ranking") or []
         for points, token in zip((2, 1, 0), ranking):
             if token in scores:
                 scores[token] += points
@@ -586,200 +630,204 @@ def _borda_scores(ballots: list[dict[str, Any]]) -> dict[str, int]:
 
 
 async def _run_llm_reasoning(manifest: dict[str, Any]) -> ReasoningExecutionResult:
-    parameters = manifest['parameters'] or {}
-    task_prompt = str(parameters.get('task_prompt') or '').strip()
+    parameters = manifest["parameters"] or {}
+    task_prompt = str(parameters.get("task_prompt") or "").strip()
     if not task_prompt:
-        raise ReasoningEngineError('task_prompt is required')
+        raise ReasoningEngineError("task_prompt is required")
 
-    rubric = str(parameters.get('rubric') or '').strip()
-    context_block = _build_context_block(parameters, manifest.get('artifacts', []))
-    incumbent = str(parameters.get('incumbent') or '').strip()
-    max_passes = max(_safe_int(parameters.get('max_passes'), 8), 1)
-    convergence_wins = max(_safe_int(parameters.get('convergence_wins'), 2), 1)
-    judge_count = max(_safe_int(parameters.get('judge_count'), 3), 1)
-    author_model = str(parameters.get('author_model') or DEFAULT_REASONING_MODEL)
-    critic_model = str(parameters.get('critic_model') or author_model)
-    synthesizer_model = str(parameters.get('synthesizer_model') or author_model)
-    judge_model = str(parameters.get('judge_model') or author_model)
-    author_temperature = _safe_float(parameters.get('temperature_author'), DEFAULT_AUTHOR_TEMPERATURE)
-    judge_temperature = _safe_float(parameters.get('temperature_judge'), DEFAULT_JUDGE_TEMPERATURE)
-    max_tokens = max(_safe_int(parameters.get('max_tokens'), DEFAULT_MAX_TOKENS), 256)
+    rubric = str(parameters.get("rubric") or "").strip()
+    context_block = _build_context_block(parameters, manifest.get("artifacts", []))
+    incumbent = str(parameters.get("incumbent") or "").strip()
+    max_passes = max(_safe_int(parameters.get("max_passes"), 8), 1)
+    convergence_wins = max(_safe_int(parameters.get("convergence_wins"), 2), 1)
+    judge_count = max(_safe_int(parameters.get("judge_count"), 3), 1)
+    author_model = str(parameters.get("author_model") or DEFAULT_REASONING_MODEL)
+    critic_model = str(parameters.get("critic_model") or author_model)
+    synthesizer_model = str(parameters.get("synthesizer_model") or author_model)
+    judge_model = str(parameters.get("judge_model") or author_model)
+    author_temperature = _safe_float(
+        parameters.get("temperature_author"), DEFAULT_AUTHOR_TEMPERATURE
+    )
+    judge_temperature = _safe_float(parameters.get("temperature_judge"), DEFAULT_JUDGE_TEMPERATURE)
+    max_tokens = max(_safe_int(parameters.get("max_tokens"), DEFAULT_MAX_TOKENS), 256)
 
-    output_dir = Path(manifest.get('output_dir') or tempfile.mkdtemp(prefix='mutx-reasoning-'))
+    output_dir = Path(manifest.get("output_dir") or tempfile.mkdtemp(prefix="mutx-reasoning-"))
     output_dir.mkdir(parents=True, exist_ok=True)
 
     base_user_prompt = task_prompt
     if context_block:
-        base_user_prompt = f'{task_prompt}\n\n{context_block}'
+        base_user_prompt = f"{task_prompt}\n\n{context_block}"
 
     if incumbent:
         current_a = incumbent
     else:
         initial = await _invoke_model(
             model=author_model,
-            system_prompt='You are the initial author. Produce the strongest complete answer to the task.',
+            system_prompt="You are the initial author. Produce the strongest complete answer to the task.",
             user_prompt=base_user_prompt,
             temperature=author_temperature,
             max_tokens=max_tokens,
         )
-        current_a = str(initial.get('text') or '').strip()
+        current_a = str(initial.get("text") or "").strip()
         if not current_a:
-            raise ReasoningEngineError('Initial author returned empty output')
+            raise ReasoningEngineError("Initial author returned empty output")
 
     pass_log: list[dict[str, Any]] = []
     judge_ballots: list[dict[str, Any]] = []
     events: list[EngineEvent] = []
     incumbent_wins = 0
-    last_winner = 'A'
+    last_winner = "A"
 
     for pass_index in range(1, max_passes + 1):
         events.append(
             EngineEvent(
-                event_type='reasoning.pass_started',
-                message=f'Started reasoning pass {pass_index}',
-                payload={'pass_index': pass_index},
+                event_type="reasoning.pass_started",
+                message=f"Started reasoning pass {pass_index}",
+                payload={"pass_index": pass_index},
             )
         )
 
         critic = await _invoke_model(
             model=critic_model,
-            system_prompt='You are a critical reviewer. Find real flaws only. Do not propose fixes.',
+            system_prompt="You are a critical reviewer. Find real flaws only. Do not propose fixes.",
             user_prompt=(
-                f'TASK:\n{base_user_prompt}\n\nCURRENT INCUMBENT (A):\n{current_a}\n\n'
-                'List concrete weaknesses, hidden assumptions, missing constraints, or wasted complexity.'
+                f"TASK:\n{base_user_prompt}\n\nCURRENT INCUMBENT (A):\n{current_a}\n\n"
+                "List concrete weaknesses, hidden assumptions, missing constraints, or wasted complexity."
             ),
             temperature=author_temperature,
             max_tokens=max_tokens,
         )
-        critique = str(critic.get('text') or '').strip()
+        critique = str(critic.get("text") or "").strip()
         events.append(
             EngineEvent(
-                event_type='reasoning.critic_completed',
-                message=f'Critic completed for pass {pass_index}',
+                event_type="reasoning.critic_completed",
+                message=f"Critic completed for pass {pass_index}",
                 payload={
-                    'pass_index': pass_index,
-                    'model': critic_model,
-                    'provider': critic.get('provider'),
-                    'usage': critic.get('usage') or {},
+                    "pass_index": pass_index,
+                    "model": critic_model,
+                    "provider": critic.get("provider"),
+                    "usage": critic.get("usage") or {},
                 },
             )
         )
 
         revision = await _invoke_model(
             model=author_model,
-            system_prompt='You are the revision author. Only change the answer when the critique justifies it.',
+            system_prompt="You are the revision author. Only change the answer when the critique justifies it.",
             user_prompt=(
-                f'TASK:\n{base_user_prompt}\n\nINCUMBENT (A):\n{current_a}\n\nCRITIQUE:\n{critique}\n\n'
-                'Produce revision B. Keep what still works. Make the answer stronger and more concrete.'
+                f"TASK:\n{base_user_prompt}\n\nINCUMBENT (A):\n{current_a}\n\nCRITIQUE:\n{critique}\n\n"
+                "Produce revision B. Keep what still works. Make the answer stronger and more concrete."
             ),
             temperature=author_temperature,
             max_tokens=max_tokens,
         )
-        version_b = str(revision.get('text') or '').strip()
+        version_b = str(revision.get("text") or "").strip()
         events.append(
             EngineEvent(
-                event_type='reasoning.revision_completed',
-                message=f'Revision completed for pass {pass_index}',
+                event_type="reasoning.revision_completed",
+                message=f"Revision completed for pass {pass_index}",
                 payload={
-                    'pass_index': pass_index,
-                    'model': author_model,
-                    'provider': revision.get('provider'),
-                    'usage': revision.get('usage') or {},
+                    "pass_index": pass_index,
+                    "model": author_model,
+                    "provider": revision.get("provider"),
+                    "usage": revision.get("usage") or {},
                 },
             )
         )
 
         synthesis = await _invoke_model(
             model=synthesizer_model,
-            system_prompt='You are the synthesizer. Combine the strongest elements from both versions into AB.',
+            system_prompt="You are the synthesizer. Combine the strongest elements from both versions into AB.",
             user_prompt=(
-                f'TASK:\n{base_user_prompt}\n\nVERSION A:\n{current_a}\n\nVERSION B:\n{version_b}\n\n'
-                'Produce AB: a clean synthesis with the best parts of both versions and no filler.'
+                f"TASK:\n{base_user_prompt}\n\nVERSION A:\n{current_a}\n\nVERSION B:\n{version_b}\n\n"
+                "Produce AB: a clean synthesis with the best parts of both versions and no filler."
             ),
             temperature=author_temperature,
             max_tokens=max_tokens,
         )
-        version_ab = str(synthesis.get('text') or '').strip()
+        version_ab = str(synthesis.get("text") or "").strip()
         events.append(
             EngineEvent(
-                event_type='reasoning.synthesis_completed',
-                message=f'Synthesis completed for pass {pass_index}',
+                event_type="reasoning.synthesis_completed",
+                message=f"Synthesis completed for pass {pass_index}",
                 payload={
-                    'pass_index': pass_index,
-                    'model': synthesizer_model,
-                    'provider': synthesis.get('provider'),
-                    'usage': synthesis.get('usage') or {},
+                    "pass_index": pass_index,
+                    "model": synthesizer_model,
+                    "provider": synthesis.get("provider"),
+                    "usage": synthesis.get("usage") or {},
                 },
             )
         )
 
-        candidates = {'A': current_a, 'B': version_b, 'AB': version_ab}
+        candidates = {"A": current_a, "B": version_b, "AB": version_ab}
         for key, value in candidates.items():
-            (output_dir / f'pass_{pass_index:02d}_{key.lower()}.md').write_text(value, encoding='utf-8')
+            (output_dir / f"pass_{pass_index:02d}_{key.lower()}.md").write_text(
+                value, encoding="utf-8"
+            )
 
         pass_ballots: list[dict[str, Any]] = []
         for judge_index in range(judge_count):
             judge = await _invoke_model(
                 model=judge_model,
                 system_prompt=(
-                    'You are an independent judge. Return strict JSON with keys ranking and rationale. '
+                    "You are an independent judge. Return strict JSON with keys ranking and rationale. "
                     'ranking must be a list with exactly ["A", "B", "AB"] in best-to-worst order. '
-                    'Blind judge the candidates against the task and optional rubric.'
+                    "Blind judge the candidates against the task and optional rubric."
                 ),
                 user_prompt=(
                     f'TASK:\n{base_user_prompt}\n\nRUBRIC:\n{rubric or "No rubric provided."}\n\n'
-                    f'CANDIDATE A:\n{current_a}\n\nCANDIDATE B:\n{version_b}\n\nCANDIDATE AB:\n{version_ab}'
+                    f"CANDIDATE A:\n{current_a}\n\nCANDIDATE B:\n{version_b}\n\nCANDIDATE AB:\n{version_ab}"
                 ),
                 temperature=judge_temperature,
                 max_tokens=max_tokens,
             )
-            ranking, rationale = _parse_judge_ranking(str(judge.get('text') or ''))
+            ranking, rationale = _parse_judge_ranking(str(judge.get("text") or ""))
             ballot = {
-                'pass_index': pass_index,
-                'judge_index': judge_index,
-                'ranking': ranking,
-                'rationale': rationale,
-                'model': judge_model,
-                'provider': judge.get('provider'),
-                'usage': judge.get('usage') or {},
+                "pass_index": pass_index,
+                "judge_index": judge_index,
+                "ranking": ranking,
+                "rationale": rationale,
+                "model": judge_model,
+                "provider": judge.get("provider"),
+                "usage": judge.get("usage") or {},
             }
             pass_ballots.append(ballot)
             judge_ballots.append(ballot)
             events.append(
                 EngineEvent(
-                    event_type='reasoning.judge_vote',
-                    message=f'Judge {judge_index + 1} voted on pass {pass_index}',
+                    event_type="reasoning.judge_vote",
+                    message=f"Judge {judge_index + 1} voted on pass {pass_index}",
                     payload=ballot,
                 )
             )
 
         scores = _borda_scores(pass_ballots)
-        winner = max(scores, key=lambda token: (scores[token], {'A': 2, 'AB': 1, 'B': 0}[token]))
+        winner = max(scores, key=lambda token: (scores[token], {"A": 2, "AB": 1, "B": 0}[token]))
         last_winner = winner
         pass_log.append(
             {
-                'pass_index': pass_index,
-                'critique': critique,
-                'scores': scores,
-                'winner': winner,
-                'candidate_lengths': {key: len(value) for key, value in candidates.items()},
+                "pass_index": pass_index,
+                "critique": critique,
+                "scores": scores,
+                "winner": winner,
+                "candidate_lengths": {key: len(value) for key, value in candidates.items()},
             }
         )
         events.append(
             EngineEvent(
-                event_type='reasoning.pass_scored',
-                message=f'Pass {pass_index} scored',
-                payload={'pass_index': pass_index, 'winner': winner, 'scores': scores},
+                event_type="reasoning.pass_scored",
+                message=f"Pass {pass_index} scored",
+                payload={"pass_index": pass_index, "winner": winner, "scores": scores},
             )
         )
 
-        if winner == 'A':
+        if winner == "A":
             incumbent_wins += 1
             events.append(
                 EngineEvent(
-                    event_type='reasoning.incumbent_retained',
-                    message=f'Incumbent retained on pass {pass_index}',
-                    payload={'pass_index': pass_index, 'winner': winner},
+                    event_type="reasoning.incumbent_retained",
+                    message=f"Incumbent retained on pass {pass_index}",
+                    payload={"pass_index": pass_index, "winner": winner},
                 )
             )
         else:
@@ -787,68 +835,78 @@ async def _run_llm_reasoning(manifest: dict[str, Any]) -> ReasoningExecutionResu
             incumbent_wins = 0
             events.append(
                 EngineEvent(
-                    event_type='reasoning.incumbent_replaced',
-                    message=f'Incumbent replaced with {winner} on pass {pass_index}',
-                    payload={'pass_index': pass_index, 'winner': winner},
+                    event_type="reasoning.incumbent_replaced",
+                    message=f"Incumbent replaced with {winner} on pass {pass_index}",
+                    payload={"pass_index": pass_index, "winner": winner},
                 )
             )
 
         if incumbent_wins >= convergence_wins:
             events.append(
                 EngineEvent(
-                    event_type='reasoning.converged',
-                    message=f'Autoreason converged after pass {pass_index}',
-                    payload={'pass_index': pass_index, 'winner': winner, 'convergence_wins': incumbent_wins},
+                    event_type="reasoning.converged",
+                    message=f"Autoreason converged after pass {pass_index}",
+                    payload={
+                        "pass_index": pass_index,
+                        "winner": winner,
+                        "convergence_wins": incumbent_wins,
+                    },
                 )
             )
             break
 
-    final_output_path = output_dir / 'final_output.md'
-    pass_log_path = output_dir / 'pass_log.json'
-    judge_ballots_path = output_dir / 'judge_ballots.json'
-    winner_summary_path = output_dir / 'winner_summary.json'
+    final_output_path = output_dir / "final_output.md"
+    pass_log_path = output_dir / "pass_log.json"
+    judge_ballots_path = output_dir / "judge_ballots.json"
+    winner_summary_path = output_dir / "winner_summary.json"
 
-    final_output_path.write_text(current_a, encoding='utf-8')
-    pass_log_path.write_text(_json_dump(pass_log), encoding='utf-8')
-    judge_ballots_path.write_text(_json_dump(judge_ballots), encoding='utf-8')
+    final_output_path.write_text(current_a, encoding="utf-8")
+    pass_log_path.write_text(_json_dump(pass_log), encoding="utf-8")
+    judge_ballots_path.write_text(_json_dump(judge_ballots), encoding="utf-8")
 
     summary = {
-        'winner': last_winner,
-        'pass_count': len(pass_log),
-        'judge_count': judge_count,
-        'driver': 'llm',
-        'converged': incumbent_wins >= convergence_wins,
-        'final_output_length': len(current_a),
+        "winner": last_winner,
+        "pass_count": len(pass_log),
+        "judge_count": judge_count,
+        "driver": "llm",
+        "converged": incumbent_wins >= convergence_wins,
+        "final_output_length": len(current_a),
     }
-    winner_summary_path.write_text(_json_dump(summary), encoding='utf-8')
+    winner_summary_path.write_text(_json_dump(summary), encoding="utf-8")
     events.append(
         EngineEvent(
-            event_type='reasoning.completed',
-            message='Autoreason workflow completed',
+            event_type="reasoning.completed",
+            message="Autoreason workflow completed",
             payload=summary,
         )
     )
 
     artifacts = [
-        EngineManagedOutput('final_output', 'markdown', final_output_path, 'final_output.md', 'text/markdown'),
-        EngineManagedOutput('pass_log', 'json', pass_log_path, 'pass_log.json', 'application/json'),
-        EngineManagedOutput('judge_ballots', 'json', judge_ballots_path, 'judge_ballots.json', 'application/json'),
-        EngineManagedOutput('winner_summary', 'json', winner_summary_path, 'winner_summary.json', 'application/json'),
+        EngineManagedOutput(
+            "final_output", "markdown", final_output_path, "final_output.md", "text/markdown"
+        ),
+        EngineManagedOutput("pass_log", "json", pass_log_path, "pass_log.json", "application/json"),
+        EngineManagedOutput(
+            "judge_ballots", "json", judge_ballots_path, "judge_ballots.json", "application/json"
+        ),
+        EngineManagedOutput(
+            "winner_summary", "json", winner_summary_path, "winner_summary.json", "application/json"
+        ),
     ]
     return ReasoningExecutionResult(
-        status='completed',
+        status="completed",
         output_text=current_a,
         summary=summary,
         artifacts=artifacts,
         events=events,
-        driver='llm',
+        driver="llm",
     )
 
 
 async def execute_reasoning_manifest(manifest: dict[str, Any]) -> ReasoningExecutionResult:
     readiness = get_reasoning_engine_readiness()
     if not readiness.enabled:
-        raise ReasoningEngineError('Reasoning workflows are disabled')
+        raise ReasoningEngineError("Reasoning workflows are disabled")
 
     if readiness.live_model_available:
         return await _run_llm_reasoning(manifest)

--- a/src/api/services/reasoning_jobs.py
+++ b/src/api/services/reasoning_jobs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 import json
 import logging
 import os
@@ -243,7 +243,7 @@ def validate_reasoning_job_inputs(job: ReasoningJob, artifacts: list[ReasoningAr
     missing = [
         input_name
         for input_name in required_names
-        if not str(parameters.get(input_name) or '').strip()
+        if not str(parameters.get(input_name) or "").strip()
     ]
 
     if missing:
@@ -280,7 +280,11 @@ def validate_dispatch_mode_artifacts(*, mode: str, artifacts: list[ReasoningArti
     if mode != "managed":
         return
 
-    invalid = [artifact.filename for artifact in artifacts if artifact.storage_backend not in MANAGED_STORAGE_BACKENDS]
+    invalid = [
+        artifact.filename
+        for artifact in artifacts
+        if artifact.storage_backend not in MANAGED_STORAGE_BACKENDS
+    ]
     if invalid:
         raise HTTPException(
             status_code=400,
@@ -498,7 +502,11 @@ async def dispatch_reasoning_job(
         run=job.run,
         event_type="reasoning.job_dispatched",
         message="Reasoning job dispatched",
-        payload={"job_id": str(job.id), "execution_mode": job.execution_mode, "template_id": job.template_id},
+        payload={
+            "job_id": str(job.id),
+            "execution_mode": job.execution_mode,
+            "template_id": job.template_id,
+        },
     )
     await db.commit()
     mutx_reasoning_jobs_total.labels(template_id=job.template_id, status="queued").inc()
@@ -561,9 +569,9 @@ async def append_reasoning_job_event(
         job.completed_at = timestamp
         job.run.completed_at = timestamp
 
-    if event.event_type.endswith('failed'):
+    if event.event_type.endswith("failed"):
         mutx_reasoning_jobs_total.labels(template_id=job.template_id, status="failed").inc()
-    elif event.event_type.endswith('completed'):
+    elif event.event_type.endswith("completed"):
         mutx_reasoning_jobs_total.labels(template_id=job.template_id, status="completed").inc()
 
     await db.commit()
@@ -579,7 +587,6 @@ async def claim_next_reasoning_job(
     ensure_reasoning_enabled()
     worker_identity = worker_name or f"{socket.gethostname()}:{os.getpid()}"
     now = _utcnow()
-    stale_cutoff = now - timedelta(seconds=stale_after_seconds)
 
     result = await db.execute(
         select(ReasoningJob)
@@ -587,20 +594,11 @@ async def claim_next_reasoning_job(
             selectinload(ReasoningJob.artifacts),
             selectinload(ReasoningJob.run).selectinload(AgentRun.traces),
         )
-        .where(
-            ReasoningJob.status.in_(["queued", "running"]),
-        )
+        .where(ReasoningJob.status == "queued")
         .order_by(ReasoningJob.dispatched_at.asc().nullsfirst(), ReasoningJob.created_at.asc())
     )
     candidates = result.scalars().all()
     for job in candidates:
-        if (
-            job.status == "running"
-            and job.last_heartbeat_at
-            and job.last_heartbeat_at > stale_cutoff
-        ):
-            continue
-
         claim_token = uuid.uuid4().hex
         job.status = "running"
         job.claimed_by = worker_identity

--- a/tests/api/test_reasoning.py
+++ b/tests/api/test_reasoning.py
@@ -12,7 +12,8 @@ def enable_reasoning_workflows(monkeypatch, tmp_path):
     settings = get_settings()
     monkeypatch.setattr(settings, "reasoning_enabled", True)
     monkeypatch.setattr(settings, "artifacts_dir", str(tmp_path / "artifacts"))
-    monkeypatch.setattr(settings, "document_max_upload_mb", 10)
+    monkeypatch.setattr(settings, "reasoning_max_upload_mb", 10)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
     yield
 
 
@@ -281,3 +282,31 @@ async def test_reasoning_jobs_appear_in_runs_listing(client):
     assert reasoning_run["agent_id"] is None
     assert reasoning_run["subject_label"] == "Autoreason Refine"
     assert reasoning_run["template_id"] == "autoreason_refine"
+
+
+@pytest.mark.asyncio
+async def test_builtin_reasoning_summary_reports_actual_winner(monkeypatch):
+    from src.api.services.reasoning_engine import execute_reasoning_manifest
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    manifest = {
+        "template_id": "autoreason_refine",
+        "parameters": {
+            "task_prompt": "Turn this into a concrete operator plan.",
+            "incumbent": "A vague answer.",
+            "max_passes": 1,
+            "judge_count": 1,
+            "convergence_wins": 2,
+            "rubric": "Concrete, structured, no filler.",
+        },
+        "artifacts": [],
+        "output_dir": None,
+    }
+
+    result = await execute_reasoning_manifest(manifest)
+
+    assert result.output_text != "A vague answer."
+    assert result.summary["winner"] != "A"


### PR DESCRIPTION
## Summary
- add a dedicated `/dashboard/reasoning` experience for browsing templates, launching jobs, tracking status, and downloading artifacts
- add `mutx reasoning` CLI support plus shared client/service models for managed and local reasoning workflow operations
- tighten reasoning backend behavior with the workflow migration, engine/job updates, and API tests for the current managed/local execution paths

## Why
The local `/Users/fortune/MUTX` worktree had mixed changes. This PR isolates the reasoning workflow slice into a clean reviewable unit against `main` instead of mixing it with unrelated marketing, Pico, or temp-artifact work.

## Impact
- operators can launch and inspect reasoning jobs from both the dashboard and CLI
- backend reasoning execution reports artifacts and terminal state more accurately
- the validation suite covers the current reasoning workflow contract more directly

## Validation
- `/Users/fortune/MUTX/.venv/bin/ruff check cli/main.py cli/services/__init__.py cli/services/models.py cli/commands/reasoning.py cli/services/reasoning.py src/api/services/reasoning_engine.py src/api/services/reasoning_jobs.py tests/api/test_reasoning.py`
- `/Users/fortune/MUTX/.venv/bin/black --check cli/main.py cli/services/__init__.py cli/services/models.py cli/commands/reasoning.py cli/services/reasoning.py src/api/services/reasoning_engine.py src/api/services/reasoning_jobs.py tests/api/test_reasoning.py`
- `/Users/fortune/MUTX/.venv/bin/python -m pytest tests/api/test_reasoning.py -q`
- `npm run typecheck`
- `npm run build`
