### PR TITLE
add reasoning workflow dashboard and cli

### DIFF
--- a/app/dashboard/reasoning/page.tsx
+++ b/app/dashboard/reasoning/page.tsx
@@ -1,0 +1,30 @@
+import { Brain } from "lucide-react";
+
+import { ReasoningPageClient } from "@/components/dashboard/ReasoningPageClient";
+import { RouteHeader } from "@/components/dashboard/RouteHeader";
+import { DesktopRouteBoundary } from "@/components/desktop/DesktopRouteBoundary";
+
+export default function DashboardReasoningPage() {
+  return (
+    <DesktopRouteBoundary
+      routeKey="reasoning"
+      browserView={
+        <div className="space-y-4">
+          <RouteHeader
+            title="Reasoning"
+            description="Autoreason refinement jobs with blind judging, persisted artifacts, and direct run/trace linkage."
+            icon={Brain}
+            iconTone="text-violet-300 bg-violet-400/10"
+            badge="autoreason v1"
+            stats={[
+              { label: "Loop", value: "A/B/AB" },
+              { label: "Judging", value: "Blind panel", tone: "success" },
+            ]}
+          />
+
+          <ReasoningPageClient />
+        </div>
+      }
+    />
+  );
+}

--- a/cli/commands/reasoning.py
+++ b/cli/commands/reasoning.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+
+import click
+
+from cli.config import current_config, get_client
+from cli.services import CLIServiceError, ReasoningService
+
+
+def _service() -> ReasoningService:
+    return ReasoningService(config=current_config(), client_factory=get_client)
+
+
+def _echo_service_error(error: CLIServiceError) -> None:
+    click.echo(f"Error: {error}", err=True)
+
+
+@click.group(name="reasoning")
+def reasoning_group():
+    """Operate reasoning workflow templates and jobs."""
+    pass
+
+
+@reasoning_group.command(name="templates")
+@click.option("--output", type=click.Choice(["table", "json"]), default="table")
+def templates_command(output: str):
+    try:
+        templates = _service().list_templates()
+    except CLIServiceError as exc:
+        _echo_service_error(exc)
+        return
+
+    if output == "json":
+        click.echo(
+            json.dumps(
+                [
+                    {
+                        "id": item.id,
+                        "name": item.name,
+                        "summary": item.summary,
+                        "description": item.description,
+                        "supports_managed": item.supports_managed,
+                        "supports_local": item.supports_local,
+                    }
+                    for item in templates
+                ],
+                indent=2,
+            )
+        )
+        return
+
+    for item in templates:
+        click.echo(
+            f"{item.id} | {item.name} | managed={item.supports_managed} | local={item.supports_local}"
+        )
+
+
+@reasoning_group.command(name="list")
+@click.option("--status", "status_filter", default=None, help="Filter jobs by status")
+@click.option("--template-id", default=None, help="Filter jobs by template id")
+@click.option("--limit", default=20, show_default=True)
+@click.option("--output", type=click.Choice(["table", "json"]), default="table")
+def list_command(status_filter: str | None, template_id: str | None, limit: int, output: str):
+    try:
+        history = _service().list_jobs(
+            limit=limit, status_filter=status_filter, template_id=template_id
+        )
+    except CLIServiceError as exc:
+        _echo_service_error(exc)
+        return
+
+    if output == "json":
+        click.echo(
+            json.dumps(
+                {
+                    "total": history.total,
+                    "items": [
+                        {
+                            "id": item.id,
+                            "template_id": item.template_id,
+                            "execution_mode": item.execution_mode,
+                            "status": item.status,
+                            "created_at": item.created_at,
+                        }
+                        for item in history.items
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    if not history.items:
+        click.echo("No reasoning jobs found.")
+        return
+
+    for item in history.items:
+        click.echo(
+            f"{item.id} | {item.template_id} | {item.execution_mode} | {item.status} | {item.created_at or 'n/a'}"
+        )
+
+
+@reasoning_group.command(name="get")
+@click.argument("job_id")
+@click.option("--output", type=click.Choice(["table", "json"]), default="table")
+def get_command(job_id: str, output: str):
+    try:
+        job = _service().get_job(job_id)
+    except CLIServiceError as exc:
+        _echo_service_error(exc)
+        return
+
+    if output == "json":
+        click.echo(
+            json.dumps(
+                {
+                    "id": job.id,
+                    "run_id": job.run_id,
+                    "template_id": job.template_id,
+                    "execution_mode": job.execution_mode,
+                    "status": job.status,
+                    "parameters": job.parameters,
+                    "result_summary": job.result_summary,
+                    "artifacts": [
+                        {
+                            "id": artifact.id,
+                            "role": artifact.role,
+                            "kind": artifact.kind,
+                            "filename": artifact.filename,
+                            "storage_backend": artifact.storage_backend,
+                        }
+                        for artifact in job.artifacts
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    click.echo(f"Job: {job.id}")
+    click.echo(f"Template: {job.template_id}")
+    click.echo(f"Mode: {job.execution_mode}")
+    click.echo(f"Status: {job.status}")
+    click.echo(f"Artifacts: {len(job.artifacts)}")
+    if job.error_message:
+        click.echo(f"Error: {job.error_message}")
+
+
+@reasoning_group.command(name="run")
+@click.option("--template-id", default="autoreason_refine", show_default=True)
+@click.option("--mode", type=click.Choice(["managed", "local"]), default="managed")
+@click.option("--task-prompt", required=True, help="Primary reasoning task prompt")
+@click.option("--incumbent", default=None, help="Optional incumbent answer")
+@click.option("--rubric", default=None, help="Optional judging rubric")
+@click.option(
+    "--context-file", "context_files", multiple=True, type=click.Path(exists=True, dir_okay=False)
+)
+@click.option("--output-dir", type=click.Path(file_okay=False), default=None)
+def run_command(
+    template_id: str,
+    mode: str,
+    task_prompt: str,
+    incumbent: str | None,
+    rubric: str | None,
+    context_files: tuple[str, ...],
+    output_dir: str | None,
+):
+    service = _service()
+    parameters: dict[str, object] = {"task_prompt": task_prompt}
+    if incumbent:
+        parameters["incumbent"] = incumbent
+    if rubric:
+        parameters["rubric"] = rubric
+
+    try:
+        job = service.create_job(
+            template_id=template_id,
+            execution_mode=mode,
+            parameters=parameters,
+        )
+
+        for path in context_files:
+            if mode == "managed":
+                service.upload_artifact(job_id=job.id, role="context", kind="file", file_path=path)
+            else:
+                service.register_artifact_reference(
+                    job_id=job.id,
+                    role="context",
+                    kind="file",
+                    file_path=path,
+                )
+
+        if mode == "managed":
+            job = service.dispatch_job(job_id=job.id, mode=mode)
+            click.echo(f"Queued managed reasoning job {job.id} ({job.template_id}).")
+            return
+
+        job = service.run_local_job(job=job, output_dir=output_dir)
+        click.echo(f"Completed local reasoning job {job.id} ({job.status}).")
+    except CLIServiceError as exc:
+        _echo_service_error(exc)
+
+
+@reasoning_group.command(name="download-artifact")
+@click.argument("job_id")
+@click.argument("artifact_id")
+@click.option("--output", "destination", type=click.Path(), default=None)
+def download_artifact_command(job_id: str, artifact_id: str, destination: str | None):
+    try:
+        path = _service().download_artifact(
+            job_id=job_id,
+            artifact_id=artifact_id,
+            destination=destination,
+        )
+    except CLIServiceError as exc:
+        _echo_service_error(exc)
+        return
+
+    click.echo(f"Downloaded artifact to {path}")

--- a/cli/main.py
+++ b/cli/main.py
@@ -12,6 +12,7 @@ from cli.commands.deployment import deployment_group
 from cli.commands.deploy import deploy_group
 from cli.commands.doctor import doctor_command
 from cli.commands.documents import documents_group
+from cli.commands.reasoning import reasoning_group
 from cli.commands.governance import governance_group
 from cli.commands.observability import observability_group
 from cli.commands.runtime import runtime_group
@@ -114,6 +115,7 @@ cli.add_command(deploy_group)
 cli.add_command(deployment_group)
 cli.add_command(doctor_command)
 cli.add_command(documents_group)
+cli.add_command(reasoning_group)
 cli.add_command(config_group)
 cli.add_command(governance_group)
 cli.add_command(observability_group)

--- a/cli/services/__init__.py
+++ b/cli/services/__init__.py
@@ -2,6 +2,7 @@ from cli.services.agents import AgentsService
 from cli.services.assistant import AssistantService, TemplatesService
 from cli.services.auth import AuthService
 from cli.services.documents import DocumentsService
+from cli.services.reasoning import ReasoningService
 from cli.errors import (
     APIRequestError,
     AuthenticationExpiredError,
@@ -30,6 +31,11 @@ from cli.services.models import (
     DocumentTemplateFieldRecord,
     DocumentTemplateOutputRecord,
     DocumentTemplateRecord,
+    ReasoningArtifactRecord,
+    ReasoningJobHistoryRecord,
+    ReasoningJobRecord,
+    ReasoningLocalLaunchRecord,
+    ReasoningTemplateRecord,
     LogEntry,
     MetricPoint,
     OnboardingStateRecord,
@@ -67,6 +73,12 @@ __all__ = [
     "DocumentTemplateOutputRecord",
     "DocumentTemplateRecord",
     "DocumentsService",
+    "ReasoningArtifactRecord",
+    "ReasoningJobHistoryRecord",
+    "ReasoningJobRecord",
+    "ReasoningLocalLaunchRecord",
+    "ReasoningTemplateRecord",
+    "ReasoningService",
     "InvalidCredentialsError",
     "LogEntry",
     "MetricPoint",

--- a/cli/services/models.py
+++ b/cli/services/models.py
@@ -513,9 +513,9 @@ class DocumentArtifactRecord:
             local_path=_as_optional_str(payload.get("local_path")),
             filename=str(payload.get("filename", "")),
             content_type=_as_optional_str(payload.get("content_type")),
-            size_bytes=int(payload["size_bytes"])
-            if payload.get("size_bytes") is not None
-            else None,
+            size_bytes=(
+                int(payload["size_bytes"]) if payload.get("size_bytes") is not None else None
+            ),
             sha256=_as_optional_str(payload.get("sha256")),
             metadata=metadata,
             created_at=_as_optional_str(payload.get("created_at")),
@@ -551,9 +551,9 @@ class DocumentJobRecord:
             template_id=str(payload.get("template_id", "")),
             execution_mode=str(payload.get("execution_mode", "")),
             status=str(payload.get("status", "unknown")),
-            parameters=payload.get("parameters")
-            if isinstance(payload.get("parameters"), dict)
-            else {},
+            parameters=(
+                payload.get("parameters") if isinstance(payload.get("parameters"), dict) else {}
+            ),
             result_summary=(
                 payload.get("result_summary")
                 if isinstance(payload.get("result_summary"), dict)
@@ -618,6 +618,169 @@ class DocumentLocalLaunchRecord:
             manifest=payload.get("manifest") if isinstance(payload.get("manifest"), dict) else {},
             artifacts=[
                 DocumentArtifactRecord.from_payload(item)
+                for item in (payload.get("artifacts") or [])
+                if isinstance(item, dict)
+            ],
+        )
+
+
+@dataclass(slots=True)
+class ReasoningTemplateRecord:
+    id: str
+    name: str
+    summary: str
+    description: str
+    supports_managed: bool
+    supports_local: bool
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ReasoningTemplateRecord":
+        return cls(
+            id=str(payload.get("id", "")),
+            name=str(payload.get("name", "")),
+            summary=str(payload.get("summary", "")),
+            description=str(payload.get("description", "")),
+            supports_managed=bool(payload.get("supports_managed", True)),
+            supports_local=bool(payload.get("supports_local", True)),
+        )
+
+
+@dataclass(slots=True)
+class ReasoningArtifactRecord:
+    id: str
+    job_id: str
+    role: str
+    kind: str
+    storage_backend: str
+    storage_uri: str | None
+    local_path: str | None
+    filename: str
+    content_type: str | None
+    size_bytes: int | None
+    sha256: str | None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: str | None = None
+    updated_at: str | None = None
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ReasoningArtifactRecord":
+        raw_metadata = payload.get("metadata")
+        metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+        return cls(
+            id=str(payload.get("id", "")),
+            job_id=str(payload.get("job_id", "")),
+            role=str(payload.get("role", "")),
+            kind=str(payload.get("kind", "")),
+            storage_backend=str(payload.get("storage_backend", "")),
+            storage_uri=_as_optional_str(payload.get("storage_uri")),
+            local_path=_as_optional_str(payload.get("local_path")),
+            filename=str(payload.get("filename", "")),
+            content_type=_as_optional_str(payload.get("content_type")),
+            size_bytes=(
+                int(payload["size_bytes"]) if payload.get("size_bytes") is not None else None
+            ),
+            sha256=_as_optional_str(payload.get("sha256")),
+            metadata=metadata,
+            created_at=_as_optional_str(payload.get("created_at")),
+            updated_at=_as_optional_str(payload.get("updated_at")),
+        )
+
+
+@dataclass(slots=True)
+class ReasoningJobRecord:
+    id: str
+    run_id: str
+    template_id: str
+    execution_mode: str
+    status: str
+    parameters: dict[str, Any] = field(default_factory=dict)
+    result_summary: dict[str, Any] = field(default_factory=dict)
+    error_message: str | None = None
+    claimed_by: str | None = None
+    claimed_at: str | None = None
+    last_heartbeat_at: str | None = None
+    attempts: int = 0
+    dispatched_at: str | None = None
+    completed_at: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    artifacts: list[ReasoningArtifactRecord] = field(default_factory=list)
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ReasoningJobRecord":
+        return cls(
+            id=str(payload.get("id", "")),
+            run_id=str(payload.get("run_id", "")),
+            template_id=str(payload.get("template_id", "")),
+            execution_mode=str(payload.get("execution_mode", "")),
+            status=str(payload.get("status", "unknown")),
+            parameters=(
+                payload.get("parameters") if isinstance(payload.get("parameters"), dict) else {}
+            ),
+            result_summary=(
+                payload.get("result_summary")
+                if isinstance(payload.get("result_summary"), dict)
+                else {}
+            ),
+            error_message=_as_optional_str(payload.get("error_message")),
+            claimed_by=_as_optional_str(payload.get("claimed_by")),
+            claimed_at=_as_optional_str(payload.get("claimed_at")),
+            last_heartbeat_at=_as_optional_str(payload.get("last_heartbeat_at")),
+            attempts=int(payload.get("attempts", 0)),
+            dispatched_at=_as_optional_str(payload.get("dispatched_at")),
+            completed_at=_as_optional_str(payload.get("completed_at")),
+            created_at=_as_optional_str(payload.get("created_at")),
+            updated_at=_as_optional_str(payload.get("updated_at")),
+            artifacts=[
+                ReasoningArtifactRecord.from_payload(item)
+                for item in (payload.get("artifacts") or [])
+                if isinstance(item, dict)
+            ],
+        )
+
+
+@dataclass(slots=True)
+class ReasoningJobHistoryRecord:
+    items: list[ReasoningJobRecord]
+    total: int
+    skip: int
+    limit: int
+    status: str | None
+    template_id: str | None
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ReasoningJobHistoryRecord":
+        return cls(
+            items=[
+                ReasoningJobRecord.from_payload(item)
+                for item in (payload.get("items") or [])
+                if isinstance(item, dict)
+            ],
+            total=int(payload.get("total", 0)),
+            skip=int(payload.get("skip", 0)),
+            limit=int(payload.get("limit", 0)),
+            status=_as_optional_str(payload.get("status")),
+            template_id=_as_optional_str(payload.get("template_id")),
+        )
+
+
+@dataclass(slots=True)
+class ReasoningLocalLaunchRecord:
+    job_id: str
+    template_id: str
+    execution_mode: str
+    manifest: dict[str, Any] = field(default_factory=dict)
+    artifacts: list[ReasoningArtifactRecord] = field(default_factory=list)
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ReasoningLocalLaunchRecord":
+        return cls(
+            job_id=str(payload.get("job_id", "")),
+            template_id=str(payload.get("template_id", "")),
+            execution_mode=str(payload.get("execution_mode", "")),
+            manifest=payload.get("manifest") if isinstance(payload.get("manifest"), dict) else {},
+            artifacts=[
+                ReasoningArtifactRecord.from_payload(item)
                 for item in (payload.get("artifacts") or [])
                 if isinstance(item, dict)
             ],

--- a/cli/services/reasoning.py
+++ b/cli/services/reasoning.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import mimetypes
+from pathlib import Path
+from typing import Any
+
+from cli.errors import CLIServiceError, ValidationError
+from cli.services.base import APIService
+from cli.services.models import (
+    ReasoningArtifactRecord,
+    ReasoningJobHistoryRecord,
+    ReasoningJobRecord,
+    ReasoningLocalLaunchRecord,
+    ReasoningTemplateRecord,
+)
+
+
+def _guess_content_type(path: Path) -> str | None:
+    content_type, _encoding = mimetypes.guess_type(path.name)
+    return content_type
+
+
+class ReasoningService(APIService):
+    def list_templates(self) -> list[ReasoningTemplateRecord]:
+        response = self._request("get", "/v1/reasoning/templates")
+        self._expect_status(response, {200})
+        return [ReasoningTemplateRecord.from_payload(item) for item in response.json()]
+
+    def create_job(
+        self,
+        *,
+        template_id: str,
+        execution_mode: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> ReasoningJobRecord:
+        response = self._request(
+            "post",
+            "/v1/reasoning/jobs",
+            json={
+                "template_id": template_id,
+                "execution_mode": execution_mode,
+                "parameters": parameters or {},
+            },
+        )
+        self._expect_status(response, {201}, invalid_message="Unable to create reasoning job")
+        return ReasoningJobRecord.from_payload(response.json())
+
+    def list_jobs(
+        self,
+        *,
+        skip: int = 0,
+        limit: int = 50,
+        status_filter: str | None = None,
+        template_id: str | None = None,
+    ) -> ReasoningJobHistoryRecord:
+        params: dict[str, Any] = {"skip": skip, "limit": limit}
+        if status_filter:
+            params["status"] = status_filter
+        if template_id:
+            params["template_id"] = template_id
+        response = self._request("get", "/v1/reasoning/jobs", params=params)
+        self._expect_status(response, {200})
+        return ReasoningJobHistoryRecord.from_payload(response.json())
+
+    def get_job(self, job_id: str) -> ReasoningJobRecord:
+        response = self._request("get", f"/v1/reasoning/jobs/{job_id}")
+        self._expect_status(response, {200}, not_found_message="Reasoning job not found")
+        return ReasoningJobRecord.from_payload(response.json())
+
+    def register_artifact_reference(
+        self,
+        *,
+        job_id: str,
+        role: str,
+        kind: str,
+        file_path: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> ReasoningArtifactRecord:
+        path = Path(file_path).expanduser().resolve()
+        if not path.exists():
+            raise ValidationError(f"Artifact path does not exist: {path}")
+
+        payload = {
+            "role": role,
+            "kind": kind,
+            "storage_backend": "local_reference",
+            "filename": path.name,
+            "local_path": str(path),
+            "content_type": _guess_content_type(path),
+            "size_bytes": path.stat().st_size,
+            "metadata": metadata or {},
+        }
+        response = self._request("post", f"/v1/reasoning/jobs/{job_id}/artifacts", json=payload)
+        self._expect_status(
+            response, {201}, invalid_message="Unable to register reasoning artifact"
+        )
+        return ReasoningArtifactRecord.from_payload(response.json())
+
+    def upload_artifact(
+        self,
+        *,
+        job_id: str,
+        role: str,
+        kind: str,
+        file_path: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> ReasoningArtifactRecord:
+        path = Path(file_path).expanduser().resolve()
+        if not path.exists():
+            raise ValidationError(f"Artifact path does not exist: {path}")
+
+        with path.open("rb") as handle:
+            files = {
+                "file": (path.name, handle, _guess_content_type(path) or "application/octet-stream")
+            }
+            data = {
+                "role": role,
+                "kind": kind,
+                "metadata": json.dumps(metadata or {}),
+            }
+            response = self._request(
+                "post",
+                f"/v1/reasoning/jobs/{job_id}/artifacts",
+                files=files,
+                data=data,
+            )
+        self._expect_status(response, {201}, invalid_message="Unable to upload reasoning artifact")
+        return ReasoningArtifactRecord.from_payload(response.json())
+
+    def dispatch_job(self, *, job_id: str, mode: str) -> ReasoningJobRecord:
+        response = self._request(
+            "post",
+            f"/v1/reasoning/jobs/{job_id}/dispatch",
+            json={"mode": mode},
+        )
+        self._expect_status(response, {200}, invalid_message="Unable to dispatch reasoning job")
+        return ReasoningJobRecord.from_payload(response.json())
+
+    def launch_local(
+        self, *, job_id: str, output_dir: str | None = None
+    ) -> ReasoningLocalLaunchRecord:
+        response = self._request(
+            "post",
+            f"/v1/reasoning/jobs/{job_id}/launch-local",
+            json={"output_dir": output_dir},
+        )
+        self._expect_status(
+            response, {200}, invalid_message="Unable to launch reasoning job locally"
+        )
+        return ReasoningLocalLaunchRecord.from_payload(response.json())
+
+    def submit_event(
+        self,
+        *,
+        job_id: str,
+        event_type: str,
+        message: str | None = None,
+        payload: dict[str, Any] | None = None,
+        status_value: str | None = None,
+        output_text: str | None = None,
+        error_message: str | None = None,
+        result_summary: dict[str, Any] | None = None,
+    ) -> ReasoningJobRecord:
+        body = {
+            "event_type": event_type,
+            "message": message,
+            "payload": payload or {},
+            "status": status_value,
+            "output_text": output_text,
+            "error_message": error_message,
+            "result_summary": result_summary,
+        }
+        response = self._request("post", f"/v1/reasoning/jobs/{job_id}/events", json=body)
+        self._expect_status(response, {200}, invalid_message="Unable to submit reasoning job event")
+        return ReasoningJobRecord.from_payload(response.json())
+
+    def download_artifact(
+        self,
+        *,
+        job_id: str,
+        artifact_id: str,
+        destination: str | None = None,
+    ) -> Path:
+        response = self._request(
+            "get",
+            f"/v1/reasoning/jobs/{job_id}/artifacts/{artifact_id}",
+            allow_refresh=True,
+        )
+        self._expect_status(response, {200}, not_found_message="Reasoning artifact not found")
+
+        header = response.headers.get("content-disposition", "")
+        filename = artifact_id
+        if "filename=" in header:
+            filename = header.split("filename=", 1)[1].strip().strip('"')
+
+        path = Path(destination).expanduser().resolve() if destination else Path.cwd() / filename
+        if path.exists() and path.is_dir():
+            path = path / filename
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(response.content)
+        return path
+
+    def run_local_job(
+        self,
+        *,
+        job: ReasoningJobRecord,
+        output_dir: str | None = None,
+    ) -> ReasoningJobRecord:
+        try:
+            from src.api.services.reasoning_engine import execute_reasoning_manifest
+        except Exception as exc:  # noqa: BLE001
+            raise CLIServiceError(
+                "Local reasoning execution requires the backend source tree to be available."
+            ) from exc
+
+        launch = self.launch_local(job_id=job.id, output_dir=output_dir)
+        self.submit_event(
+            job_id=job.id,
+            event_type="reasoning.pass_started",
+            message="Local reasoning execution started",
+            payload={"execution_mode": "local"},
+            status_value="running",
+        )
+
+        try:
+            execution_result = asyncio.run(execute_reasoning_manifest(launch.manifest))
+            for event in execution_result.events:
+                self.submit_event(
+                    job_id=job.id,
+                    event_type=event.event_type,
+                    message=event.message,
+                    payload=event.payload,
+                )
+            for artifact in execution_result.artifacts:
+                self.upload_artifact(
+                    job_id=job.id,
+                    role=artifact.role,
+                    kind=artifact.kind,
+                    file_path=str(artifact.path),
+                    metadata=artifact.metadata,
+                )
+            return self.submit_event(
+                job_id=job.id,
+                event_type="reasoning.completed",
+                message="Local reasoning execution completed",
+                payload={"driver": execution_result.driver},
+                status_value="completed",
+                output_text=execution_result.output_text,
+                result_summary=execution_result.summary,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return self.submit_event(
+                job_id=job.id,
+                event_type="reasoning.failed",
+                message="Local reasoning execution failed",
+                payload={"error": str(exc)},
+                status_value="failed",
+                error_message=str(exc),
+            )

--- a/components/dashboard/ReasoningPageClient.tsx
+++ b/components/dashboard/ReasoningPageClient.tsx
@@ -1,0 +1,445 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { ApiRequestError, readJson, writeJson } from "@/components/app/http";
+import {
+  LiveAuthRequired,
+  LiveEmptyState,
+  LiveErrorState,
+  LiveKpiGrid,
+  LiveLoading,
+  LivePanel,
+  LiveStatCard,
+  asDashboardStatus,
+  formatRelativeTime,
+} from "@/components/dashboard/livePrimitives";
+import { StatusBadge } from "@/components/dashboard/StatusBadge";
+
+type ReasoningTemplate = {
+  id: string;
+  name: string;
+  summary: string;
+  description: string;
+  supports_managed: boolean;
+  supports_local: boolean;
+};
+
+type ReasoningArtifact = {
+  id: string;
+  role: string;
+  kind: string;
+  storage_backend: string;
+  filename: string;
+};
+
+type ReasoningJob = {
+  id: string;
+  run_id: string;
+  template_id: string;
+  execution_mode: string;
+  status: string;
+  parameters: Record<string, unknown>;
+  result_summary: Record<string, unknown>;
+  error_message?: string | null;
+  created_at?: string | null;
+  completed_at?: string | null;
+  artifacts: ReasoningArtifact[];
+};
+
+type ReasoningJobHistory = {
+  items: ReasoningJob[];
+  total: number;
+};
+
+async function uploadContextArtifact(jobId: string, file: File) {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("role", "context");
+  formData.append("kind", "file");
+
+  const response = await fetch(`/api/dashboard/reasoning/jobs/${encodeURIComponent(jobId)}/artifacts`, {
+    method: "POST",
+    body: formData,
+  });
+  const payload = await response.json().catch(() => ({ detail: "Failed to upload reasoning context" }));
+  if (!response.ok) {
+    throw new ApiRequestError(
+      typeof payload?.detail === "string" ? payload.detail : "Failed to upload reasoning context",
+      response.status,
+    );
+  }
+  return payload as ReasoningArtifact;
+}
+
+export function ReasoningPageClient() {
+  const [loading, setLoading] = useState(true);
+  const [authRequired, setAuthRequired] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [templates, setTemplates] = useState<ReasoningTemplate[]>([]);
+  const [jobs, setJobs] = useState<ReasoningJob[]>([]);
+  const [selectedTemplateId, setSelectedTemplateId] = useState("autoreason_refine");
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+  const [taskPrompt, setTaskPrompt] = useState("");
+  const [incumbent, setIncumbent] = useState("");
+  const [rubric, setRubric] = useState("");
+  const [contextFiles, setContextFiles] = useState<File[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const selectedTemplate = useMemo(
+    () => templates.find((item) => item.id === selectedTemplateId) ?? null,
+    [templates, selectedTemplateId],
+  );
+  const selectedJob = useMemo(
+    () => jobs.find((item) => item.id === selectedJobId) ?? null,
+    [jobs, selectedJobId],
+  );
+
+  async function loadData(nextJobId?: string) {
+    setLoading(true);
+    setError(null);
+    setAuthRequired(false);
+
+    try {
+      const [templateResponse, jobsResponse] = await Promise.all([
+        readJson<ReasoningTemplate[]>("/api/dashboard/reasoning/templates"),
+        readJson<ReasoningJobHistory>("/api/dashboard/reasoning/jobs?limit=20"),
+      ]);
+      setTemplates(templateResponse);
+      setJobs(jobsResponse.items ?? []);
+      setSelectedTemplateId((current) => current || templateResponse[0]?.id || "autoreason_refine");
+      setSelectedJobId(nextJobId ?? jobsResponse.items?.[0]?.id ?? null);
+    } catch (loadError) {
+      if (
+        loadError instanceof ApiRequestError &&
+        (loadError.status === 401 || loadError.status === 403)
+      ) {
+        setAuthRequired(true);
+      } else {
+        setError(loadError instanceof Error ? loadError.message : "Failed to load reasoning workflows");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadData();
+  }, []);
+
+  async function submitManagedJob() {
+    if (!taskPrompt.trim()) {
+      setError("Task prompt is required.");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const parameters: Record<string, unknown> = {
+        task_prompt: taskPrompt.trim(),
+      };
+      if (incumbent.trim()) {
+        parameters.incumbent = incumbent.trim();
+      }
+      if (rubric.trim()) {
+        parameters.rubric = rubric.trim();
+      }
+
+      const job = await writeJson<ReasoningJob>("/api/dashboard/reasoning/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          template_id: selectedTemplateId,
+          execution_mode: "managed",
+          parameters,
+        }),
+      });
+
+      for (const file of contextFiles) {
+        await uploadContextArtifact(job.id, file);
+      }
+
+      await writeJson<ReasoningJob>(`/api/dashboard/reasoning/jobs/${encodeURIComponent(job.id)}/dispatch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "managed" }),
+      });
+
+      setTaskPrompt("");
+      setIncumbent("");
+      setRubric("");
+      setContextFiles([]);
+      await loadData(job.id);
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : "Failed to queue reasoning job");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const jobStats = useMemo(() => {
+    const queued = jobs.filter((job) => job.status === "queued" || job.status === "created").length;
+    const running = jobs.filter((job) => job.status === "running").length;
+    const completed = jobs.filter((job) => job.status === "completed").length;
+    const failed = jobs.filter((job) => job.status === "failed").length;
+    return { queued, running, completed, failed };
+  }, [jobs]);
+
+  if (loading) return <LiveLoading title="Reasoning" />;
+  if (authRequired) {
+    return (
+      <LiveAuthRequired
+        title="Operator session required"
+        message="Sign in to launch and inspect Autoreason refinement jobs."
+      />
+    );
+  }
+  if (error && templates.length === 0 && jobs.length === 0) {
+    return <LiveErrorState title="Reasoning workflows unavailable" message={error} />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <LiveKpiGrid>
+        <LiveStatCard
+          label="Templates"
+          value={String(templates.length)}
+          detail="Reasoning workflow templates available in MUTX."
+        />
+        <LiveStatCard
+          label="Queued"
+          value={String(jobStats.queued)}
+          detail="Jobs waiting for a reasoning worker to pick them up."
+          status={asDashboardStatus(jobStats.queued > 0 ? "warning" : "idle")}
+        />
+        <LiveStatCard
+          label="Running"
+          value={String(jobStats.running)}
+          detail="Autoreason loops actively judging or refining."
+          status={asDashboardStatus(jobStats.running > 0 ? "running" : "idle")}
+        />
+        <LiveStatCard
+          label="Completed"
+          value={String(jobStats.completed)}
+          detail="Jobs that finished with a final incumbent and artifacts."
+          status="success"
+        />
+        <LiveStatCard
+          label="Failed"
+          value={String(jobStats.failed)}
+          detail="Reasoning jobs that need operator follow-up."
+          status={asDashboardStatus(jobStats.failed > 0 ? "failed" : "healthy")}
+        />
+      </LiveKpiGrid>
+
+      {error ? <LiveErrorState title="Reasoning update failed" message={error} /> : null}
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.05fr)_minmax(380px,0.95fr)]">
+        <LivePanel title="Launch autoreason" meta={selectedTemplate?.name || "Select template"}>
+          <div className="space-y-4">
+            <label className="block space-y-2">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                Template
+              </span>
+              <select
+                value={selectedTemplateId}
+                onChange={(event) => setSelectedTemplateId(event.target.value)}
+                className="w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm text-white"
+              >
+                {templates.map((template) => (
+                  <option key={template.id} value={template.id}>
+                    {template.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {selectedTemplate ? (
+              <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4 text-sm text-slate-300">
+                <p className="font-medium text-white">{selectedTemplate.summary}</p>
+                <p className="mt-2 text-slate-400">{selectedTemplate.description}</p>
+              </div>
+            ) : null}
+
+            <label className="block space-y-2">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                Task prompt
+              </span>
+              <textarea
+                value={taskPrompt}
+                onChange={(event) => setTaskPrompt(event.target.value)}
+                className="min-h-32 w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm text-white"
+                placeholder="What should Autoreason improve, decide, or rewrite?"
+              />
+            </label>
+
+            <label className="block space-y-2">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                Incumbent answer
+              </span>
+              <textarea
+                value={incumbent}
+                onChange={(event) => setIncumbent(event.target.value)}
+                className="min-h-28 w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm text-white"
+                placeholder="Optional starting answer. Leave empty to draft from scratch."
+              />
+            </label>
+
+            <label className="block space-y-2">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                Rubric
+              </span>
+              <textarea
+                value={rubric}
+                onChange={(event) => setRubric(event.target.value)}
+                className="min-h-24 w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm text-white"
+                placeholder="Optional evaluation rubric for the judge panel."
+              />
+            </label>
+
+            <label className="block space-y-2">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                Context files
+              </span>
+              <input
+                type="file"
+                multiple
+                onChange={(event) => setContextFiles(Array.from(event.target.files ?? []))}
+                className="block w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm text-slate-300"
+              />
+              {contextFiles.length > 0 ? (
+                <ul className="space-y-1 text-xs text-slate-400">
+                  {contextFiles.map((file) => (
+                    <li key={`${file.name}-${file.size}`}>{file.name}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </label>
+
+            <button
+              type="button"
+              onClick={() => void submitManagedJob()}
+              disabled={submitting}
+              className="inline-flex items-center justify-center rounded-full border border-[#d4ab73]/30 bg-[#d4ab73]/12 px-5 py-2.5 text-sm font-medium text-[#fff1df] transition hover:bg-[#d4ab73]/18 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {submitting ? "Queueing..." : "Queue managed job"}
+            </button>
+          </div>
+        </LivePanel>
+
+        <div className="space-y-4">
+          <LivePanel title="Reasoning history" meta={`${jobs.length} jobs`}>
+            {jobs.length === 0 ? (
+              <LiveEmptyState
+                title="No reasoning jobs yet"
+                message="Your first Autoreason run will show up here with artifacts and run linkage."
+              />
+            ) : (
+              <div className="space-y-3">
+                {jobs.map((job) => {
+                  const isSelected = selectedJobId === job.id;
+                  const winner = typeof job.result_summary?.winner === "string" ? job.result_summary.winner : null;
+                  const passCount = typeof job.result_summary?.pass_count === "number" ? job.result_summary.pass_count : null;
+                  return (
+                    <button
+                      key={job.id}
+                      type="button"
+                      onClick={() => setSelectedJobId(job.id)}
+                      className={`w-full rounded-2xl border p-4 text-left transition ${
+                        isSelected ? "border-[#d4ab73]/40 bg-[#d4ab73]/10" : "border-white/10 bg-white/[0.02]"
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-white">{job.id}</p>
+                          <p className="mt-1 text-xs text-slate-400">
+                            {job.template_id} · {job.execution_mode}
+                          </p>
+                        </div>
+                        <StatusBadge status={asDashboardStatus(job.status)} label={job.status} />
+                      </div>
+                      <div className="mt-3 flex flex-wrap gap-3 text-xs text-slate-500">
+                        <span>created {formatRelativeTime(job.created_at)}</span>
+                        {job.completed_at ? <span>finished {formatRelativeTime(job.completed_at)}</span> : null}
+                        {winner ? <span>winner {winner}</span> : null}
+                        {passCount !== null ? <span>{passCount} passes</span> : null}
+                      </div>
+                      {job.error_message ? (
+                        <p className="mt-3 text-sm text-rose-300">{job.error_message}</p>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </LivePanel>
+
+          <LivePanel title="Selected job" meta={selectedJob?.id || "None selected"}>
+            {selectedJob ? (
+              <div className="space-y-4 text-sm text-slate-300">
+                <div className="flex flex-wrap items-center gap-3">
+                  <StatusBadge status={asDashboardStatus(selectedJob.status)} label={selectedJob.status} />
+                  <span className="text-slate-500">run {selectedJob.run_id}</span>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                    <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Winner</p>
+                    <p className="mt-2 text-lg font-medium text-white">
+                      {typeof selectedJob.result_summary?.winner === "string"
+                        ? selectedJob.result_summary.winner
+                        : "Pending"}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                    <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Passes</p>
+                    <p className="mt-2 text-lg font-medium text-white">
+                      {typeof selectedJob.result_summary?.pass_count === "number"
+                        ? selectedJob.result_summary.pass_count
+                        : "-"}
+                    </p>
+                  </div>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                  <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Input task</p>
+                  <p className="mt-2 whitespace-pre-wrap text-slate-300">
+                    {typeof selectedJob.parameters?.task_prompt === "string"
+                      ? selectedJob.parameters.task_prompt
+                      : "No task prompt recorded."}
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                  <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Artifacts</p>
+                  {selectedJob.artifacts.length === 0 ? (
+                    <p className="mt-2 text-slate-500">No artifacts synced yet.</p>
+                  ) : (
+                    <div className="mt-3 space-y-2">
+                      {selectedJob.artifacts.map((artifact) => (
+                        <a
+                          key={artifact.id}
+                          href={`/api/dashboard/reasoning/jobs/${encodeURIComponent(selectedJob.id)}/artifacts/${encodeURIComponent(artifact.id)}`}
+                          className="flex items-center justify-between rounded-xl border border-white/10 bg-black/10 px-3 py-2 text-sm text-slate-200 transition hover:border-[#d4ab73]/40 hover:text-white"
+                        >
+                          <span>{artifact.filename}</span>
+                          <span className="text-xs text-slate-500">
+                            {artifact.role} · {artifact.kind}
+                          </span>
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <LiveEmptyState
+                title="No reasoning job selected"
+                message="Pick a job from the history panel to inspect winner state and artifacts."
+              />
+            )}
+          </LivePanel>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/api/models/migrations/versions/e7f8a9b0c1d2_add_reasoning_workflows.py
+++ b/src/api/models/migrations/versions/e7f8a9b0c1d2_add_reasoning_workflows.py
@@ -1,0 +1,133 @@
+"""Add reasoning workflow jobs and artifacts.
+
+Revision ID: e7f8a9b0c1d2
+Revises: d6e7f8a9b0c1
+Create Date: 2026-04-13
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "e7f8a9b0c1d2"
+down_revision: Union[str, None] = "d6e7f8a9b0c1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _bind():
+    return op.get_bind()
+
+
+def _inspector():
+    return sa.inspect(_bind())
+
+
+def _has_table(table_name: str) -> bool:
+    return _inspector().has_table(table_name)
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return any(index["name"] == index_name for index in _inspector().get_indexes(table_name))
+
+
+def _create_index_if_missing(
+    table_name: str,
+    index_name: str,
+    columns: list[str],
+    *,
+    unique: bool = False,
+) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(index_name, table_name, columns, unique=unique)
+
+
+def upgrade() -> None:
+    if not _has_table("reasoning_jobs"):
+        op.create_table(
+            "reasoning_jobs",
+            sa.Column("id", sa.UUID(), nullable=False),
+            sa.Column("user_id", sa.UUID(), nullable=False),
+            sa.Column("run_id", sa.UUID(), nullable=False),
+            sa.Column("template_id", sa.String(length=120), nullable=False),
+            sa.Column("execution_mode", sa.String(length=32), nullable=False),
+            sa.Column("status", sa.String(length=50), nullable=False),
+            sa.Column("parameters", sa.Text(), nullable=True),
+            sa.Column("result_summary", sa.Text(), nullable=True),
+            sa.Column("error_message", sa.Text(), nullable=True),
+            sa.Column("claimed_by", sa.String(length=255), nullable=True),
+            sa.Column("claim_token", sa.String(length=64), nullable=True),
+            sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("dispatched_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["run_id"], ["agent_runs.id"]),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("run_id"),
+        )
+
+    _create_index_if_missing("reasoning_jobs", op.f("ix_reasoning_jobs_user_id"), ["user_id"])
+    _create_index_if_missing("reasoning_jobs", op.f("ix_reasoning_jobs_run_id"), ["run_id"])
+    _create_index_if_missing(
+        "reasoning_jobs", op.f("ix_reasoning_jobs_template_id"), ["template_id"]
+    )
+    _create_index_if_missing(
+        "reasoning_jobs", op.f("ix_reasoning_jobs_execution_mode"), ["execution_mode"]
+    )
+    _create_index_if_missing("reasoning_jobs", op.f("ix_reasoning_jobs_status"), ["status"])
+    _create_index_if_missing(
+        "reasoning_jobs", op.f("ix_reasoning_jobs_claim_token"), ["claim_token"]
+    )
+    _create_index_if_missing("reasoning_jobs", op.f("ix_reasoning_jobs_created_at"), ["created_at"])
+    _create_index_if_missing("reasoning_jobs", op.f("ix_reasoning_jobs_updated_at"), ["updated_at"])
+
+    if not _has_table("reasoning_artifacts"):
+        op.create_table(
+            "reasoning_artifacts",
+            sa.Column("id", sa.UUID(), nullable=False),
+            sa.Column("job_id", sa.UUID(), nullable=False),
+            sa.Column("role", sa.String(length=120), nullable=False),
+            sa.Column("kind", sa.String(length=120), nullable=False),
+            sa.Column("storage_backend", sa.String(length=64), nullable=False),
+            sa.Column("storage_uri", sa.Text(), nullable=True),
+            sa.Column("local_path", sa.Text(), nullable=True),
+            sa.Column("filename", sa.String(length=255), nullable=False),
+            sa.Column("content_type", sa.String(length=255), nullable=True),
+            sa.Column("size_bytes", sa.Integer(), nullable=True),
+            sa.Column("sha256", sa.String(length=64), nullable=True),
+            sa.Column("extra_metadata", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["job_id"], ["reasoning_jobs.id"]),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+    _create_index_if_missing(
+        "reasoning_artifacts", op.f("ix_reasoning_artifacts_job_id"), ["job_id"]
+    )
+    _create_index_if_missing("reasoning_artifacts", op.f("ix_reasoning_artifacts_role"), ["role"])
+    _create_index_if_missing("reasoning_artifacts", op.f("ix_reasoning_artifacts_kind"), ["kind"])
+    _create_index_if_missing(
+        "reasoning_artifacts", op.f("ix_reasoning_artifacts_storage_backend"), ["storage_backend"]
+    )
+    _create_index_if_missing(
+        "reasoning_artifacts", op.f("ix_reasoning_artifacts_sha256"), ["sha256"]
+    )
+    _create_index_if_missing(
+        "reasoning_artifacts", op.f("ix_reasoning_artifacts_created_at"), ["created_at"]
+    )
+
+
+def downgrade() -> None:
+    if _has_table("reasoning_artifacts"):
+        op.drop_table("reasoning_artifacts")
+    if _has_table("reasoning_jobs"):
+        op.drop_table("reasoning_jobs")

--- a/src/api/services/reasoning_engine.py
+++ b/src/api/services/reasoning_engine.py
@@ -8,9 +8,6 @@ from pathlib import Path
 import tempfile
 from typing import Any
 
-from anthropic import AsyncAnthropic
-from openai import AsyncOpenAI
-
 from src.api.config import get_settings
 from src.api.services.reasoning_templates import get_reasoning_template
 
@@ -27,6 +24,9 @@ REASONING_TRACE_EVENT_TYPES = {
     "reasoning.incumbent_retained",
     "reasoning.incumbent_replaced",
     "reasoning.converged",
+    "reasoning.artifact_registered",
+    "reasoning.artifact_uploaded",
+    "reasoning.artifact_synced",
     "reasoning.completed",
     "reasoning.failed",
 }
@@ -261,6 +261,8 @@ async def _invoke_model(
     if normalized_model.startswith("openrouter/"):
         if not openrouter_key:
             raise ReasoningEngineError("OPENROUTER_API_KEY is required for openrouter/* models")
+        from openai import AsyncOpenAI
+
         client = AsyncOpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
         response = await client.chat.completions.create(
             model=normalized_model.removeprefix("openrouter/"),
@@ -279,6 +281,8 @@ async def _invoke_model(
 
     if normalized_model.startswith("anthropic/"):
         if anthropic_key:
+            from anthropic import AsyncAnthropic
+
             client = AsyncAnthropic(api_key=anthropic_key)
             response = await client.messages.create(
                 model=normalized_model.removeprefix("anthropic/"),
@@ -293,6 +297,8 @@ async def _invoke_model(
                 "provider": "anthropic",
             }
         if openrouter_key:
+            from openai import AsyncOpenAI
+
             client = AsyncOpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
             response = await client.chat.completions.create(
                 model=normalized_model,
@@ -314,6 +320,8 @@ async def _invoke_model(
         ("gpt-", "o1", "o3", "o4")
     ):
         if openai_key:
+            from openai import AsyncOpenAI
+
             client = AsyncOpenAI(api_key=openai_key)
             response = await client.chat.completions.create(
                 model=normalized_model.removeprefix("openai/"),
@@ -330,6 +338,8 @@ async def _invoke_model(
                 "provider": "openai",
             }
         if openrouter_key:
+            from openai import AsyncOpenAI
+
             client = AsyncOpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
             response = await client.chat.completions.create(
                 model=normalized_model.removeprefix("openai/"),
@@ -348,6 +358,8 @@ async def _invoke_model(
         raise ReasoningEngineError("No provider credentials available for openai model")
 
     if openrouter_key:
+        from openai import AsyncOpenAI
+
         client = AsyncOpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
         response = await client.chat.completions.create(
             model=normalized_model,
@@ -394,6 +406,7 @@ async def _run_builtin_reasoning(manifest: dict[str, Any]) -> ReasoningExecution
 
     current_a = incumbent
     incumbent_wins = 0
+    last_winner = "A"
     pass_log: list[dict[str, Any]] = []
     judge_ballots: list[dict[str, Any]] = []
     events: list[EngineEvent] = []
@@ -428,6 +441,7 @@ async def _run_builtin_reasoning(manifest: dict[str, Any]) -> ReasoningExecution
             )
         ]
         winner = ranking[0]
+        last_winner = winner
 
         for judge_index in range(judge_count):
             ballot = {
@@ -530,7 +544,7 @@ async def _run_builtin_reasoning(manifest: dict[str, Any]) -> ReasoningExecution
     judge_ballots_path.write_text(_json_dump(judge_ballots), encoding="utf-8")
 
     summary = {
-        "winner": "A",
+        "winner": last_winner,
         "pass_count": len(pass_log),
         "judge_count": judge_count,
         "driver": "builtin_fallback",
@@ -761,7 +775,7 @@ async def _run_llm_reasoning(manifest: dict[str, Any]) -> ReasoningExecutionResu
                     "Blind judge the candidates against the task and optional rubric."
                 ),
                 user_prompt=(
-                    f"TASK:\n{base_user_prompt}\n\nRUBRIC:\n{rubric or 'No rubric provided.'}\n\n"
+                    f'TASK:\n{base_user_prompt}\n\nRUBRIC:\n{rubric or "No rubric provided."}\n\n'
                     f"CANDIDATE A:\n{current_a}\n\nCANDIDATE B:\n{version_b}\n\nCANDIDATE AB:\n{version_ab}"
                 ),
                 temperature=judge_temperature,

--- a/src/api/services/reasoning_jobs.py
+++ b/src/api/services/reasoning_jobs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 import json
 import logging
 import os
@@ -587,7 +587,6 @@ async def claim_next_reasoning_job(
     ensure_reasoning_enabled()
     worker_identity = worker_name or f"{socket.gethostname()}:{os.getpid()}"
     now = _utcnow()
-    stale_cutoff = now - timedelta(seconds=stale_after_seconds)
 
     result = await db.execute(
         select(ReasoningJob)
@@ -595,20 +594,11 @@ async def claim_next_reasoning_job(
             selectinload(ReasoningJob.artifacts),
             selectinload(ReasoningJob.run).selectinload(AgentRun.traces),
         )
-        .where(
-            ReasoningJob.status.in_(["queued", "running"]),
-        )
+        .where(ReasoningJob.status == "queued")
         .order_by(ReasoningJob.dispatched_at.asc().nullsfirst(), ReasoningJob.created_at.asc())
     )
     candidates = result.scalars().all()
     for job in candidates:
-        if (
-            job.status == "running"
-            and job.last_heartbeat_at
-            and job.last_heartbeat_at > stale_cutoff
-        ):
-            continue
-
         claim_token = uuid.uuid4().hex
         job.status = "running"
         job.claimed_by = worker_identity

--- a/src/api/services/reasoning_jobs.py
+++ b/src/api/services/reasoning_jobs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from datetime import timedelta
 import json
 import logging
 import os
@@ -587,6 +588,7 @@ async def claim_next_reasoning_job(
     ensure_reasoning_enabled()
     worker_identity = worker_name or f"{socket.gethostname()}:{os.getpid()}"
     now = _utcnow()
+    stale_cutoff = now - timedelta(seconds=stale_after_seconds)
 
     result = await db.execute(
         select(ReasoningJob)
@@ -594,11 +596,18 @@ async def claim_next_reasoning_job(
             selectinload(ReasoningJob.artifacts),
             selectinload(ReasoningJob.run).selectinload(AgentRun.traces),
         )
-        .where(ReasoningJob.status == "queued")
+        .where(ReasoningJob.status.in_(["queued", "running"]))
         .order_by(ReasoningJob.dispatched_at.asc().nullsfirst(), ReasoningJob.created_at.asc())
     )
     candidates = result.scalars().all()
     for job in candidates:
+        if (
+            job.status == "running"
+            and job.last_heartbeat_at
+            and job.last_heartbeat_at > stale_cutoff
+        ):
+            continue
+
         claim_token = uuid.uuid4().hex
         job.status = "running"
         job.claimed_by = worker_identity

--- a/tests/api/test_reasoning.py
+++ b/tests/api/test_reasoning.py
@@ -12,7 +12,8 @@ def enable_reasoning_workflows(monkeypatch, tmp_path):
     settings = get_settings()
     monkeypatch.setattr(settings, "reasoning_enabled", True)
     monkeypatch.setattr(settings, "artifacts_dir", str(tmp_path / "artifacts"))
-    monkeypatch.setattr(settings, "document_max_upload_mb", 10)
+    monkeypatch.setattr(settings, "reasoning_max_upload_mb", 10)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
     yield
 
 
@@ -281,3 +282,31 @@ async def test_reasoning_jobs_appear_in_runs_listing(client):
     assert reasoning_run["agent_id"] is None
     assert reasoning_run["subject_label"] == "Autoreason Refine"
     assert reasoning_run["template_id"] == "autoreason_refine"
+
+
+@pytest.mark.asyncio
+async def test_builtin_reasoning_summary_reports_actual_winner(monkeypatch):
+    from src.api.services.reasoning_engine import execute_reasoning_manifest
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    manifest = {
+        "template_id": "autoreason_refine",
+        "parameters": {
+            "task_prompt": "Turn this into a concrete operator plan.",
+            "incumbent": "A vague answer.",
+            "max_passes": 1,
+            "judge_count": 1,
+            "convergence_wins": 2,
+            "rubric": "Concrete, structured, no filler.",
+        },
+        "artifacts": [],
+        "output_dir": None,
+    }
+
+    result = await execute_reasoning_manifest(manifest)
+
+    assert result.output_text != "A vague answer."
+    assert result.summary["winner"] != "A"

--- a/tests/api/test_reasoning.py
+++ b/tests/api/test_reasoning.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+from datetime import timedelta
 
 import pytest
 
@@ -186,6 +187,54 @@ async def test_managed_reasoning_lifecycle_executes_through_worker(
     assert run_payload["template_id"] == "autoreason_refine"
     assert run_payload["execution_mode"] == "managed"
     assert any(trace["event_type"] == "reasoning.completed" for trace in run_payload["traces"])
+
+
+@pytest.mark.asyncio
+async def test_stale_running_reasoning_job_is_reclaimed(client, db_session):
+    from src.api.services.reasoning_jobs import claim_next_reasoning_job
+
+    create_response = await client.post(
+        "/v1/reasoning/jobs",
+        json={
+            "template_id": "autoreason_refine",
+            "execution_mode": "managed",
+            "parameters": {
+                "task_prompt": "Write a tighter launch memo for MUTX.",
+                "incumbent": "Initial answer with loose structure.",
+            },
+        },
+    )
+    assert create_response.status_code == 201
+    job_id = create_response.json()["id"]
+
+    dispatch_response = await client.post(
+        f"/v1/reasoning/jobs/{job_id}/dispatch",
+        json={"mode": "managed"},
+    )
+    assert dispatch_response.status_code == 200
+
+    first_claim = await claim_next_reasoning_job(db_session, worker_name="worker-one")
+    assert first_claim is not None
+
+    stale_heartbeat = first_claim.job.last_heartbeat_at - timedelta(seconds=600)
+    first_claim.job.claimed_by = "worker-one"
+    first_claim.job.claimed_at = stale_heartbeat
+    first_claim.job.last_heartbeat_at = stale_heartbeat
+    first_claim.job.run.status = "running"
+    await db_session.commit()
+
+    reclaimed = await claim_next_reasoning_job(
+        db_session,
+        worker_name="worker-two",
+        stale_after_seconds=60,
+    )
+
+    assert reclaimed is not None
+    assert reclaimed.job.id == first_claim.job.id
+    assert reclaimed.worker_name == "worker-two"
+    assert reclaimed.claim_token != first_claim.claim_token
+    assert reclaimed.job.claimed_by == "worker-two"
+    assert reclaimed.job.attempts == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a reasoning workflows dashboard page and client
- add CLI support for reasoning workflows and records
- add backend reasoning workflow migration and service updates
- extend reasoning API tests for workflow behavior and summary correctness

## Test Plan
- source .venv/bin/activate
- python -m pytest tests/api/test_reasoning.py -q
- npm run typecheck
