### PR TITLE
harden reasoning workflow worker plumbing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
 
 [project.scripts]
 mutx = "cli.main:cli"
+mutx-reasoning-worker = "src.api.reasoning_worker:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ mutx-reasoning-worker = "src.api.reasoning_worker:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["cli*"]
+include = ["cli*", "src*"]
 
 [tool.setuptools.package-data]
 cli = ["policies/*.fpl"]

--- a/src/api/services/reasoning_engine.py
+++ b/src/api/services/reasoning_engine.py
@@ -8,9 +8,6 @@ from pathlib import Path
 import tempfile
 from typing import Any
 
-from anthropic import AsyncAnthropic
-from openai import AsyncOpenAI
-
 from src.api.config import get_settings
 from src.api.services.reasoning_templates import get_reasoning_template
 
@@ -27,6 +24,9 @@ REASONING_TRACE_EVENT_TYPES = {
     "reasoning.incumbent_retained",
     "reasoning.incumbent_replaced",
     "reasoning.converged",
+    "reasoning.artifact_registered",
+    "reasoning.artifact_uploaded",
+    "reasoning.artifact_synced",
     "reasoning.completed",
     "reasoning.failed",
 }
@@ -261,6 +261,8 @@ async def _invoke_model(
     if normalized_model.startswith("openrouter/"):
         if not openrouter_key:
             raise ReasoningEngineError("OPENROUTER_API_KEY is required for openrouter/* models")
+        from openai import AsyncOpenAI
+
         client = AsyncOpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
         response = await client.chat.completions.create(
             model=normalized_model.removeprefix("openrouter/"),
@@ -279,6 +281,8 @@ async def _invoke_model(
 
     if normalized_model.startswith("anthropic/"):
         if anthropic_key:
+            from anthropic import AsyncAnthropic
+
             client = AsyncAnthropic(api_key=anthropic_key)
             response = await client.messages.create(
                 model=normalized_model.removeprefix("anthropic/"),
@@ -293,6 +297,8 @@ async def _invoke_model(
                 "provider": "anthropic",
             }
         if openrouter_key:
+            from openai import AsyncOpenAI
+
             client = AsyncOpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
             response = await client.chat.completions.create(
                 model=normalized_model,
@@ -314,6 +320,8 @@ async def _invoke_model(
         ("gpt-", "o1", "o3", "o4")
     ):
         if openai_key:
+            from openai import AsyncOpenAI
+
             client = AsyncOpenAI(api_key=openai_key)
             response = await client.chat.completions.create(
                 model=normalized_model.removeprefix("openai/"),
@@ -330,6 +338,8 @@ async def _invoke_model(
                 "provider": "openai",
             }
         if openrouter_key:
+            from openai import AsyncOpenAI
+
             client = AsyncOpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
             response = await client.chat.completions.create(
                 model=normalized_model.removeprefix("openai/"),
@@ -348,6 +358,8 @@ async def _invoke_model(
         raise ReasoningEngineError("No provider credentials available for openai model")
 
     if openrouter_key:
+        from openai import AsyncOpenAI
+
         client = AsyncOpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
         response = await client.chat.completions.create(
             model=normalized_model,
@@ -394,6 +406,7 @@ async def _run_builtin_reasoning(manifest: dict[str, Any]) -> ReasoningExecution
 
     current_a = incumbent
     incumbent_wins = 0
+    last_winner = "A"
     pass_log: list[dict[str, Any]] = []
     judge_ballots: list[dict[str, Any]] = []
     events: list[EngineEvent] = []
@@ -428,6 +441,7 @@ async def _run_builtin_reasoning(manifest: dict[str, Any]) -> ReasoningExecution
             )
         ]
         winner = ranking[0]
+        last_winner = winner
 
         for judge_index in range(judge_count):
             ballot = {
@@ -530,7 +544,7 @@ async def _run_builtin_reasoning(manifest: dict[str, Any]) -> ReasoningExecution
     judge_ballots_path.write_text(_json_dump(judge_ballots), encoding="utf-8")
 
     summary = {
-        "winner": "A",
+        "winner": last_winner,
         "pass_count": len(pass_log),
         "judge_count": judge_count,
         "driver": "builtin_fallback",
@@ -761,7 +775,7 @@ async def _run_llm_reasoning(manifest: dict[str, Any]) -> ReasoningExecutionResu
                     "Blind judge the candidates against the task and optional rubric."
                 ),
                 user_prompt=(
-                    f"TASK:\n{base_user_prompt}\n\nRUBRIC:\n{rubric or 'No rubric provided.'}\n\n"
+                    f'TASK:\n{base_user_prompt}\n\nRUBRIC:\n{rubric or "No rubric provided."}\n\n'
                     f"CANDIDATE A:\n{current_a}\n\nCANDIDATE B:\n{version_b}\n\nCANDIDATE AB:\n{version_ab}"
                 ),
                 temperature=judge_temperature,

--- a/src/api/services/reasoning_engine.py
+++ b/src/api/services/reasoning_engine.py
@@ -775,7 +775,7 @@ async def _run_llm_reasoning(manifest: dict[str, Any]) -> ReasoningExecutionResu
                     "Blind judge the candidates against the task and optional rubric."
                 ),
                 user_prompt=(
-                    f'TASK:\n{base_user_prompt}\n\nRUBRIC:\n{rubric or "No rubric provided."}\n\n'
+                    f"TASK:\n{base_user_prompt}\n\nRUBRIC:\n{rubric or 'No rubric provided.'}\n\n"
                     f"CANDIDATE A:\n{current_a}\n\nCANDIDATE B:\n{version_b}\n\nCANDIDATE AB:\n{version_ab}"
                 ),
                 temperature=judge_temperature,

--- a/src/api/services/reasoning_jobs.py
+++ b/src/api/services/reasoning_jobs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 import json
 import logging
 import os
@@ -587,7 +587,6 @@ async def claim_next_reasoning_job(
     ensure_reasoning_enabled()
     worker_identity = worker_name or f"{socket.gethostname()}:{os.getpid()}"
     now = _utcnow()
-    stale_cutoff = now - timedelta(seconds=stale_after_seconds)
 
     result = await db.execute(
         select(ReasoningJob)
@@ -595,20 +594,11 @@ async def claim_next_reasoning_job(
             selectinload(ReasoningJob.artifacts),
             selectinload(ReasoningJob.run).selectinload(AgentRun.traces),
         )
-        .where(
-            ReasoningJob.status.in_(["queued", "running"]),
-        )
+        .where(ReasoningJob.status == "queued")
         .order_by(ReasoningJob.dispatched_at.asc().nullsfirst(), ReasoningJob.created_at.asc())
     )
     candidates = result.scalars().all()
     for job in candidates:
-        if (
-            job.status == "running"
-            and job.last_heartbeat_at
-            and job.last_heartbeat_at > stale_cutoff
-        ):
-            continue
-
         claim_token = uuid.uuid4().hex
         job.status = "running"
         job.claimed_by = worker_identity

--- a/src/api/services/reasoning_jobs.py
+++ b/src/api/services/reasoning_jobs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from datetime import timedelta
 import json
 import logging
 import os
@@ -587,6 +588,7 @@ async def claim_next_reasoning_job(
     ensure_reasoning_enabled()
     worker_identity = worker_name or f"{socket.gethostname()}:{os.getpid()}"
     now = _utcnow()
+    stale_cutoff = now - timedelta(seconds=stale_after_seconds)
 
     result = await db.execute(
         select(ReasoningJob)
@@ -594,11 +596,18 @@ async def claim_next_reasoning_job(
             selectinload(ReasoningJob.artifacts),
             selectinload(ReasoningJob.run).selectinload(AgentRun.traces),
         )
-        .where(ReasoningJob.status == "queued")
+        .where(ReasoningJob.status.in_(["queued", "running"]))
         .order_by(ReasoningJob.dispatched_at.asc().nullsfirst(), ReasoningJob.created_at.asc())
     )
     candidates = result.scalars().all()
     for job in candidates:
+        if (
+            job.status == "running"
+            and job.last_heartbeat_at
+            and job.last_heartbeat_at > stale_cutoff
+        ):
+            continue
+
         claim_token = uuid.uuid4().hex
         job.status = "running"
         job.claimed_by = worker_identity

--- a/tests/api/test_reasoning.py
+++ b/tests/api/test_reasoning.py
@@ -12,7 +12,8 @@ def enable_reasoning_workflows(monkeypatch, tmp_path):
     settings = get_settings()
     monkeypatch.setattr(settings, "reasoning_enabled", True)
     monkeypatch.setattr(settings, "artifacts_dir", str(tmp_path / "artifacts"))
-    monkeypatch.setattr(settings, "document_max_upload_mb", 10)
+    monkeypatch.setattr(settings, "reasoning_max_upload_mb", 10)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
     yield
 
 
@@ -281,3 +282,31 @@ async def test_reasoning_jobs_appear_in_runs_listing(client):
     assert reasoning_run["agent_id"] is None
     assert reasoning_run["subject_label"] == "Autoreason Refine"
     assert reasoning_run["template_id"] == "autoreason_refine"
+
+
+@pytest.mark.asyncio
+async def test_builtin_reasoning_summary_reports_actual_winner(monkeypatch):
+    from src.api.services.reasoning_engine import execute_reasoning_manifest
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    manifest = {
+        "template_id": "autoreason_refine",
+        "parameters": {
+            "task_prompt": "Turn this into a concrete operator plan.",
+            "incumbent": "A vague answer.",
+            "max_passes": 1,
+            "judge_count": 1,
+            "convergence_wins": 2,
+            "rubric": "Concrete, structured, no filler.",
+        },
+        "artifacts": [],
+        "output_dir": None,
+    }
+
+    result = await execute_reasoning_manifest(manifest)
+
+    assert result.output_text != "A vague answer."
+    assert result.summary["winner"] != "A"

--- a/tests/api/test_reasoning.py
+++ b/tests/api/test_reasoning.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+from datetime import timedelta
 
 import pytest
 
@@ -186,6 +187,54 @@ async def test_managed_reasoning_lifecycle_executes_through_worker(
     assert run_payload["template_id"] == "autoreason_refine"
     assert run_payload["execution_mode"] == "managed"
     assert any(trace["event_type"] == "reasoning.completed" for trace in run_payload["traces"])
+
+
+@pytest.mark.asyncio
+async def test_stale_running_reasoning_job_is_reclaimed(client, db_session):
+    from src.api.services.reasoning_jobs import claim_next_reasoning_job
+
+    create_response = await client.post(
+        "/v1/reasoning/jobs",
+        json={
+            "template_id": "autoreason_refine",
+            "execution_mode": "managed",
+            "parameters": {
+                "task_prompt": "Write a tighter launch memo for MUTX.",
+                "incumbent": "Initial answer with loose structure.",
+            },
+        },
+    )
+    assert create_response.status_code == 201
+    job_id = create_response.json()["id"]
+
+    dispatch_response = await client.post(
+        f"/v1/reasoning/jobs/{job_id}/dispatch",
+        json={"mode": "managed"},
+    )
+    assert dispatch_response.status_code == 200
+
+    first_claim = await claim_next_reasoning_job(db_session, worker_name="worker-one")
+    assert first_claim is not None
+
+    stale_heartbeat = first_claim.job.last_heartbeat_at - timedelta(seconds=600)
+    first_claim.job.claimed_by = "worker-one"
+    first_claim.job.claimed_at = stale_heartbeat
+    first_claim.job.last_heartbeat_at = stale_heartbeat
+    first_claim.job.run.status = "running"
+    await db_session.commit()
+
+    reclaimed = await claim_next_reasoning_job(
+        db_session,
+        worker_name="worker-two",
+        stale_after_seconds=60,
+    )
+
+    assert reclaimed is not None
+    assert reclaimed.job.id == first_claim.job.id
+    assert reclaimed.worker_name == "worker-two"
+    assert reclaimed.claim_token != first_claim.claim_token
+    assert reclaimed.job.claimed_by == "worker-two"
+    assert reclaimed.job.attempts == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_distribution.py
+++ b/tests/test_cli_distribution.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import os
 from pathlib import Path
 
 
@@ -61,3 +62,18 @@ def test_installed_cli_entrypoint_exposes_setup_commands_without_repo_on_sys_pat
     assert metadata_name.stdout.strip() == "mutx-cli"
     assert result.returncode == 0
     assert "Guided assistant-first onboarding." in result.stdout
+
+    worker_result = subprocess.run(
+        [str(venv_dir / "bin" / "mutx-reasoning-worker")],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            **os.environ,
+            "MUTX_REASONING_ENABLED": "false",
+            "REASONING_ENABLED": "false",
+        },
+    )
+
+    assert worker_result.returncode == 0


### PR DESCRIPTION
## Summary
- harden reasoning workflow worker plumbing and summary handling
- refine reasoning job claim behavior and related backend tests
- expose the reasoning worker entrypoint in Python packaging metadata

## Test Plan
- source .venv/bin/activate
- python -m pytest tests/api/test_reasoning.py -q
- python3 -m compileall src/api
