### PR TITLE
Split Pico onto a route-local stylesheet

### DIFF
--- a/app/api/auth/oauth/[provider]/callback/route.ts
+++ b/app/api/auth/oauth/[provider]/callback/route.ts
@@ -6,7 +6,10 @@ import {
   getCookieDomain,
   shouldUseSecureCookies,
 } from "@/app/api/_lib/controlPlane";
-import { resolveRedirectPath } from "@/lib/auth/redirects";
+import {
+  getDefaultRedirectPathForHost,
+  resolveRedirectPath,
+} from "@/lib/auth/redirects";
 
 const OAUTH_COOKIE_PREFIX = "mutx_oauth";
 const SUPPORTED_PROVIDERS = new Set(["google", "github", "discord"]);
@@ -61,6 +64,7 @@ export async function GET(
   const nextPath = resolveRedirectPath(
     request.cookies.get(`${OAUTH_COOKIE_PREFIX}_next`)?.value ??
       request.nextUrl.searchParams.get("next"),
+    getDefaultRedirectPathForHost(request.nextUrl.hostname),
   );
 
   const fail = (message: string) => {

--- a/app/api/auth/oauth/[provider]/start/route.ts
+++ b/app/api/auth/oauth/[provider]/start/route.ts
@@ -7,7 +7,10 @@ import {
   getCookieDomain,
   shouldUseSecureCookies,
 } from "@/app/api/_lib/controlPlane";
-import { resolveRedirectPath } from "@/lib/auth/redirects";
+import {
+  getDefaultRedirectPathForHost,
+  resolveRedirectPath,
+} from "@/lib/auth/redirects";
 
 const OAUTH_COOKIE_PREFIX = "mutx_oauth";
 const OAUTH_MAX_AGE_SECONDS = 60 * 10;
@@ -60,6 +63,7 @@ export async function GET(
   const intent = resolveIntent(request.nextUrl.searchParams.get("intent"));
   const nextPath = resolveRedirectPath(
     request.nextUrl.searchParams.get("next"),
+    getDefaultRedirectPathForHost(request.nextUrl.hostname),
   );
 
   if (!provider) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -87,10 +87,6 @@
   body {
     min-height: 100%;
     min-height: 100vh;
-    background:
-      radial-gradient(circle at top left, rgba(212, 171, 115, 0.1), transparent 22rem),
-      radial-gradient(circle at 86% 0%, rgba(117, 96, 163, 0.08), transparent 26rem),
-      linear-gradient(180deg, #0d0b10 0%, #08070b 100%);
     color: var(--foreground);
     overflow-x: clip;
     text-rendering: optimizeLegibility;
@@ -100,7 +96,16 @@
     font-family: var(--font-site-body), sans-serif;
   }
 
-  ::selection {
+  body:not(:has(.pico-root)) {
+    min-height: 100%;
+    min-height: 100vh;
+    background:
+      radial-gradient(circle at top left, rgba(212, 171, 115, 0.1), transparent 22rem),
+      radial-gradient(circle at 86% 0%, rgba(117, 96, 163, 0.08), transparent 26rem),
+      linear-gradient(180deg, #0d0b10 0%, #08070b 100%);
+  }
+
+  body:not(:has(.pico-root)) ::selection {
     background: rgba(212, 171, 115, 0.24);
     color: #0b0a0e;
   }
@@ -109,11 +114,11 @@
     color: inherit;
   }
 
-  a:focus-visible,
-  button:focus-visible,
-  input:focus-visible,
-  textarea:focus-visible,
-  select:focus-visible {
+  body:not(:has(.pico-root)) a:focus-visible,
+  body:not(:has(.pico-root)) button:focus-visible,
+  body:not(:has(.pico-root)) input:focus-visible,
+  body:not(:has(.pico-root)) textarea:focus-visible,
+  body:not(:has(.pico-root)) select:focus-visible {
     outline: 2px solid rgba(212, 171, 115, 0.68);
     outline-offset: 3px;
   }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,10 @@
+import { headers } from "next/headers";
+
 import { AuthPage } from "@/components/auth/AuthPage";
+import {
+  getDefaultRedirectPathForHost,
+  isPicoHost,
+} from "@/lib/auth/redirects";
 
 export default async function LoginPage({
   searchParams,
@@ -10,6 +16,7 @@ export default async function LoginPage({
   }>;
 }) {
   const params = await searchParams;
+  const host = (await headers()).get("host")?.split(":")[0] ?? null;
   const nextPath = Array.isArray(params.next) ? params.next[0] : params.next;
   const error = Array.isArray(params.error) ? params.error[0] : params.error;
   const email = Array.isArray(params.email) ? params.email[0] : params.email;
@@ -18,6 +25,8 @@ export default async function LoginPage({
     <AuthPage
       mode="login"
       nextPath={nextPath}
+      fallbackPath={getDefaultRedirectPathForHost(host)}
+      hostVariant={isPicoHost(host) ? "pico" : "default"}
       initialError={error}
       initialEmail={email}
     />

--- a/app/pico/layout.tsx
+++ b/app/pico/layout.tsx
@@ -1,3 +1,5 @@
+import './pico.css'
+
 import type { Metadata } from 'next'
 import type { ReactNode } from 'react'
 import { NextIntlClientProvider } from 'next-intl'
@@ -38,7 +40,7 @@ export default async function PicoLayout({ children }: Props) {
   const direction = getDirection(locale)
 
   return (
-    <div lang={locale} dir={direction}>
+    <div lang={locale} dir={direction} className="pico-root">
       <NextIntlClientProvider locale={locale} messages={messages}>
         {children}
       </NextIntlClientProvider>

--- a/app/pico/pico.css
+++ b/app/pico/pico.css
@@ -1,0 +1,54 @@
+.pico-root {
+  --pico-bg: #050904;
+  --pico-bg-raised: #0b1209;
+  --pico-bg-surface: rgba(159, 255, 78, 0.045);
+  --pico-bg-surface-hover: rgba(159, 255, 78, 0.085);
+  --pico-text: #f3faee;
+  --pico-text-secondary: rgba(221, 234, 214, 0.76);
+  --pico-text-muted: rgba(166, 186, 156, 0.5);
+  --pico-border: rgba(159, 255, 78, 0.14);
+  --pico-border-hover: rgba(159, 255, 78, 0.28);
+  --pico-accent-rgb: 159, 255, 78;
+  --pico-accent: #9fff4e;
+  --pico-accent-bright: #dfff9a;
+  --pico-accent-deep: #52c51c;
+  --pico-accent-contrast: #071404;
+  --pico-accent-soft: rgba(159, 255, 78, 0.12);
+  --pico-accent-glow: rgba(159, 255, 78, 0.1);
+  --pico-blue: #73efbe;
+  --pico-blue-soft: rgba(115, 239, 190, 0.12);
+  --pico-blue-glow: rgba(115, 239, 190, 0.08);
+  --pico-red: #ff8c72;
+  --pico-red-soft: rgba(255, 140, 114, 0.1);
+  --pico-yellow-rgb: 195, 255, 91;
+  --pico-yellow: #c3ff5b;
+  --pico-font-accent: var(--font-mono), monospace;
+  --pico-font-display: var(--font-site-display), serif;
+  --pico-font-body: var(--font-site-body), sans-serif;
+  --pico-radius-sm: 0.75rem;
+  --pico-radius: 1.2rem;
+  --pico-radius-lg: 1.6rem;
+  --pico-radius-full: 999px;
+  --pico-shell: min(100% - 2.5rem, 72rem);
+  min-height: 100vh;
+  color: var(--pico-text);
+}
+
+body:has(.pico-root) {
+  background: #050904;
+  color: var(--pico-text);
+}
+
+.pico-root ::selection {
+  background: rgba(var(--pico-accent-rgb), 0.28);
+  color: #071404;
+}
+
+.pico-root a:focus-visible,
+.pico-root button:focus-visible,
+.pico-root input:focus-visible,
+.pico-root textarea:focus-visible,
+.pico-root select:focus-visible {
+  outline: 2px solid rgba(var(--pico-accent-rgb), 0.68);
+  outline-offset: 3px;
+}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,4 +1,10 @@
+import { headers } from "next/headers";
+
 import { AuthPage } from "@/components/auth/AuthPage";
+import {
+  getDefaultRedirectPathForHost,
+  isPicoHost,
+} from "@/lib/auth/redirects";
 
 export default async function RegisterPage({
   searchParams,
@@ -10,6 +16,7 @@ export default async function RegisterPage({
   }>;
 }) {
   const params = await searchParams;
+  const host = (await headers()).get("host")?.split(":")[0] ?? null;
   const nextPath = Array.isArray(params.next) ? params.next[0] : params.next;
   const error = Array.isArray(params.error) ? params.error[0] : params.error;
   const email = Array.isArray(params.email) ? params.email[0] : params.email;
@@ -18,6 +25,8 @@ export default async function RegisterPage({
     <AuthPage
       mode="register"
       nextPath={nextPath}
+      fallbackPath={getDefaultRedirectPathForHost(host)}
+      hostVariant={isPicoHost(host) ? "pico" : "default"}
       initialError={error}
       initialEmail={email}
     />

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -14,7 +14,10 @@ import {
 
 import { AuthSurface } from "@/components/site/AuthSurface";
 import styles from "@/components/site/marketing/MarketingCore.module.css";
-import { resolveRedirectPath } from "@/lib/auth/redirects";
+import {
+  getDefaultRedirectPathForHost,
+  resolveRedirectPath,
+} from "@/lib/auth/redirects";
 
 const authSurfaceProps = {
   eyebrow: "Verify email",
@@ -40,7 +43,11 @@ function VerifyEmailContent() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
   const email = searchParams.get("email");
-  const nextPath = resolveRedirectPath(searchParams.get("next"));
+  const fallbackPath =
+    typeof window === "undefined"
+      ? "/dashboard"
+      : getDefaultRedirectPathForHost(window.location.hostname);
+  const nextPath = resolveRedirectPath(searchParams.get("next"), fallbackPath);
 
   const [status, setStatus] = useState<
     "pending" | "loading" | "success" | "error"

--- a/components/AuthNav.tsx
+++ b/components/AuthNav.tsx
@@ -1,7 +1,13 @@
 import Image from "next/image";
 import Link from "next/link";
 
-export function AuthNav() {
+type AuthNavProps = {
+  hostVariant?: "default" | "pico";
+};
+
+export function AuthNav({ hostVariant = "default" }: AuthNavProps) {
+  const isPicoPreview = hostVariant === "pico";
+
   return (
     <nav data-testid="public-auth-nav" className="sticky top-0 z-30 px-4 pt-4 sm:px-6">
       <div className="mx-auto flex w-full max-w-[1360px] items-center justify-between gap-4 rounded-full border border-[rgba(255,240,214,0.1)] bg-[rgba(10,9,12,0.78)] px-3 py-2.5 text-[#f7f0e4] shadow-[0_20px_60px_rgba(2,2,5,0.32)] backdrop-blur-xl">
@@ -12,8 +18,8 @@ export function AuthNav() {
           >
             <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[rgba(212,171,115,0.2)] bg-[radial-gradient(circle_at_top,rgba(212,171,115,0.2),transparent_58%),linear-gradient(180deg,rgba(255,248,236,0.08),rgba(255,248,236,0.02))]">
               <Image
-                src="/logo.webp"
-                alt="MUTX"
+                src={isPicoPreview ? "/pico/logo.png" : "/logo.webp"}
+                alt={isPicoPreview ? "Pico" : "MUTX"}
                 width={32}
                 height={32}
                 className="h-5 w-5 object-contain"
@@ -21,16 +27,16 @@ export function AuthNav() {
             </span>
             <span className="grid min-w-0">
               <span className="truncate font-[family:var(--font-site-display)] text-[1rem] leading-none tracking-[-0.06em]">
-                MUTX
+                {isPicoPreview ? "Pico" : "MUTX"}
               </span>
               <span className="font-[family:var(--font-mono)] text-[10px] uppercase tracking-[0.22em] text-[rgba(232,221,203,0.56)]">
-                auth lane
+                {isPicoPreview ? "preview access" : "auth lane"}
               </span>
             </span>
           </Link>
 
         <span className="hidden rounded-full border border-[rgba(255,240,214,0.1)] bg-[rgba(255,248,236,0.03)] px-3 py-1.5 font-[family:var(--font-mono)] text-[10px] uppercase tracking-[0.18em] text-[rgba(232,221,203,0.6)] lg:inline-flex">
-          hosted operator identity
+          {isPicoPreview ? "preview account boundary" : "hosted operator identity"}
         </span>
       </div>
     </nav>

--- a/components/auth/AuthPage.tsx
+++ b/components/auth/AuthPage.tsx
@@ -267,7 +267,7 @@ export function AuthPage({
   }
 
   return (
-    <AuthSurface {...content} variant="access">
+    <AuthSurface {...content} variant="access" hostVariant={hostVariant}>
       {isPicoPreview ? <PicoAuthPreviewIntro nextPath={redirectPath} /> : null}
       <div className={styles.formWrap}>
         {isPicoPreview ? (

--- a/components/auth/AuthPage.tsx
+++ b/components/auth/AuthPage.tsx
@@ -6,68 +6,124 @@ import { useRouter } from "next/navigation";
 import { AlertCircle, ArrowRight, CheckCircle2, Loader2 } from "lucide-react";
 
 import { extractApiErrorMessage } from "@/components/app/http";
+import { PicoAuthPreviewIntro } from "@/components/auth/PicoAuthPreviewIntro";
 import { AuthSurface } from "@/components/site/AuthSurface";
 import styles from "@/components/site/marketing/MarketingCore.module.css";
 import { buildOAuthStartHref, oauthProviders } from "@/lib/auth/oauth";
 import { resolveRedirectPath } from "@/lib/auth/redirects";
 
 type AuthMode = "login" | "register";
+type AuthPageHostVariant = "default" | "pico";
 
 type AuthPageProps = {
   mode: AuthMode;
   nextPath?: string | null;
+  fallbackPath?: string;
+  hostVariant?: AuthPageHostVariant;
   initialError?: string | null;
   initialEmail?: string | null;
 };
 
 const authContent = {
-  login: {
-    eyebrow: "Operator sign-in",
-    title: "Sign in to the governed runtime.",
-    description:
-      "Use the hosted operator account, establish the session cleanly, and continue into the dashboard that reflects real deployment state instead of a demo shell.",
-    asideEyebrow: "What unlocks next",
-    asideTitle: "The dashboard should tell the truth the moment auth succeeds.",
-    asideBody:
-      "Once the session is live, MUTX can load fleet posture, deployment state, traces, and security surfaces from the same operator boundary.",
-    mediaSrc: "/landing/webp/wiring-bay.webp",
-    mediaAlt: "MUTX robot operating inside a wiring bay",
-    mediaWidth: 1024,
-    mediaHeight: 1536,
-    highlights: [
-      "Social auth now lands on the same hosted session model as password auth.",
-      "Session cookies stay scoped to the current host instead of leaking across subdomains.",
-      "If the API rejects the session, the form surfaces the upstream error instead of inventing one.",
-    ],
-    heading: "Welcome back",
-    subheading:
-      "Use a provider or password and continue into the operator dashboard.",
-    submitLabel: "Sign in",
-    loadingLabel: "Signing in",
+  default: {
+    login: {
+      eyebrow: "Operator sign-in",
+      title: "Sign in to the governed runtime.",
+      description:
+        "Use the hosted operator account, establish the session cleanly, and continue into the dashboard that reflects real deployment state instead of a demo shell.",
+      asideEyebrow: "What unlocks next",
+      asideTitle: "The dashboard should tell the truth the moment auth succeeds.",
+      asideBody:
+        "Once the session is live, MUTX can load fleet posture, deployment state, traces, and security surfaces from the same operator boundary.",
+      mediaSrc: "/landing/webp/wiring-bay.webp",
+      mediaAlt: "MUTX robot operating inside a wiring bay",
+      mediaWidth: 1024,
+      mediaHeight: 1536,
+      highlights: [
+        "Social auth now lands on the same hosted session model as password auth.",
+        "Session cookies stay scoped to the current host instead of leaking across subdomains.",
+        "If the API rejects the session, the form surfaces the upstream error instead of inventing one.",
+      ],
+      heading: "Welcome back",
+      subheading:
+        "Use a provider or password and continue into the operator dashboard.",
+      submitLabel: "Sign in",
+      loadingLabel: "Signing in",
+    },
+    register: {
+      eyebrow: "Operator access",
+      title: "Create an operator account and enter the real dashboard.",
+      description:
+        "Register with password or provider auth, confirm the identity cleanly, and land in the same control surface used for live operator work.",
+      asideEyebrow: "Account rules",
+      asideTitle: "Registration should be explicit, boring, and easy to verify.",
+      asideBody:
+        "The registration lane now sends real verification mail, blocks the fake success path when email confirmation is required, and links provider identities onto the same MUTX account model.",
+      mediaSrc: "/landing/webp/victory-core.webp",
+      mediaAlt: "MUTX robot holding the MUTX mark after access is granted",
+      mediaWidth: 1536,
+      mediaHeight: 1024,
+      highlights: [
+        "Google, GitHub, and Discord all terminate on real MUTX sessions.",
+        "Password registration sends a verification email to the active host, not a hardcoded marketing domain.",
+        "If email confirmation is required, the UI moves into a verification state instead of pretending the dashboard is ready.",
+      ],
+      heading: "Create your account",
+      subheading:
+        "Choose the fastest safe lane into the hosted operator surface.",
+      submitLabel: "Sign up",
+      loadingLabel: "Creating account",
+    },
   },
-  register: {
-    eyebrow: "Operator access",
-    title: "Create an operator account and enter the real dashboard.",
-    description:
-      "Register with password or provider auth, confirm the identity cleanly, and land in the same control surface used for live operator work.",
-    asideEyebrow: "Account rules",
-    asideTitle: "Registration should be explicit, boring, and easy to verify.",
-    asideBody:
-      "The registration lane now sends real verification mail, blocks the fake success path when email confirmation is required, and links provider identities onto the same MUTX account model.",
-    mediaSrc: "/landing/webp/victory-core.webp",
-    mediaAlt: "MUTX robot holding the MUTX mark after access is granted",
-    mediaWidth: 1536,
-    mediaHeight: 1024,
-    highlights: [
-      "Google, GitHub, and Discord all terminate on real MUTX sessions.",
-      "Password registration sends a verification email to the active host, not a hardcoded marketing domain.",
-      "If email confirmation is required, the UI moves into a verification state instead of pretending the dashboard is ready.",
-    ],
-    heading: "Create your account",
-    subheading:
-      "Choose the fastest safe lane into the hosted operator surface.",
-    submitLabel: "Sign up",
-    loadingLabel: "Creating account",
+  pico: {
+    login: {
+      eyebrow: "Pico preview access",
+      title: "Sign in to the Pico preview while the product is still taking shape.",
+      description:
+        "Pico is usable now, but it is still being built in public. Sign in to keep your progress attached to this preview and continue from where the current build leaves off.",
+      asideEyebrow: "What to expect",
+      asideTitle: "This is an early version, not the finished product.",
+      asideBody:
+        "Some parts already work well, some parts are still moving, and the sign-in wall is mainly here so your lessons, settings, and progress stay tied to one preview account.",
+      mediaSrc: "/landing/webp/wiring-bay.webp",
+      mediaAlt: "MUTX robot operating inside a wiring bay",
+      mediaWidth: 1024,
+      mediaHeight: 1536,
+      highlights: [
+        "You can already explore onboarding, academy, tutor, and support flows.",
+        "Copy, layout, and product behavior will keep changing as Pico develops.",
+        "Signing in keeps this preview personal instead of dropping you into a disposable demo.",
+      ],
+      heading: "Enter the current Pico build",
+      subheading:
+        "Use a provider or email to open the preview and save your place.",
+      submitLabel: "Enter Pico",
+      loadingLabel: "Opening Pico",
+    },
+    register: {
+      eyebrow: "Pico preview access",
+      title: "Create a Pico preview account for the version that exists today.",
+      description:
+        "This is the early-access lane for Pico. Create an account if you want your setup, progress, and feedback tied to the hosted preview while we keep building the rest.",
+      asideEyebrow: "Why sign in now",
+      asideTitle: "Because this preview already remembers your work.",
+      asideBody:
+        "Registration is not pretending the product is done. It simply gives the current build a stable way to remember you while onboarding, lessons, and operator tools keep evolving.",
+      mediaSrc: "/landing/webp/victory-core.webp",
+      mediaAlt: "MUTX robot holding the MUTX mark after access is granted",
+      mediaWidth: 1536,
+      mediaHeight: 1024,
+      highlights: [
+        "Accounts created here stay scoped to the Pico preview host.",
+        "Verification email and provider auth return you to the Pico flow, not the operator dashboard.",
+        "You get a real preview account, not a throwaway demo identity.",
+      ],
+      heading: "Create your Pico preview account",
+      subheading:
+        "Sign up once, save your place, and keep following the product as it improves.",
+      submitLabel: "Create preview account",
+      loadingLabel: "Creating preview account",
+    },
   },
 } as const;
 
@@ -78,13 +134,16 @@ function buildAuthHref(mode: AuthMode, nextPath: string) {
 export function AuthPage({
   mode,
   nextPath,
+  fallbackPath = "/dashboard",
+  hostVariant = "default",
   initialError,
   initialEmail,
 }: AuthPageProps) {
   const router = useRouter();
-  const content = authContent[mode];
+  const content = authContent[hostVariant][mode];
   const isRegister = mode === "register";
-  const redirectPath = resolveRedirectPath(nextPath);
+  const isPicoPreview = hostVariant === "pico";
+  const redirectPath = resolveRedirectPath(nextPath, fallbackPath);
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState(initialEmail ?? "");
@@ -209,7 +268,21 @@ export function AuthPage({
 
   return (
     <AuthSurface {...content} variant="access">
+      {isPicoPreview ? <PicoAuthPreviewIntro nextPath={redirectPath} /> : null}
       <div className={styles.formWrap}>
+        {isPicoPreview ? (
+          <div className="rounded-[26px] border border-[rgba(159,255,78,0.18)] bg-[linear-gradient(180deg,rgba(11,20,9,0.98),rgba(6,13,6,0.96))] px-4 py-4 text-[#f3faee] shadow-[0_24px_54px_rgba(4,10,3,0.3)] sm:px-5">
+            <p className="font-[family:var(--font-mono)] text-[11px] font-semibold uppercase tracking-[0.22em] text-[rgba(223,255,154,0.8)]">
+              Pico preview note
+            </p>
+            <p className="mt-3 text-sm leading-7 text-[rgba(243,250,238,0.82)]">
+              Pico is still being built. This login is here so the preview can
+              remember your progress and let you come back to the same place
+              later.
+            </p>
+          </div>
+        ) : null}
+
         <div>
           <h2 className={styles.sectionTitle}>{content.heading}</h2>
           <p className={styles.bodyText}>{content.subheading}</p>
@@ -229,10 +302,28 @@ export function AuthPage({
           ))}
         </div>
 
-        <div className="flex items-center gap-3 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-[rgba(77,58,45,0.58)]">
-          <span className="h-px flex-1 bg-[rgba(58,38,25,0.16)]" />
+        <div
+          className={
+            isPicoPreview
+              ? "flex items-center gap-3 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-[rgba(113,145,103,0.72)]"
+              : "flex items-center gap-3 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-[rgba(77,58,45,0.58)]"
+          }
+        >
+          <span
+            className={
+              isPicoPreview
+                ? "h-px flex-1 bg-[rgba(159,255,78,0.18)]"
+                : "h-px flex-1 bg-[rgba(58,38,25,0.16)]"
+            }
+          />
           Or use email
-          <span className="h-px flex-1 bg-[rgba(58,38,25,0.16)]" />
+          <span
+            className={
+              isPicoPreview
+                ? "h-px flex-1 bg-[rgba(159,255,78,0.18)]"
+                : "h-px flex-1 bg-[rgba(58,38,25,0.16)]"
+            }
+          />
         </div>
 
         <form onSubmit={handleSubmit} className={styles.formWrap}>

--- a/components/auth/PicoAuthPreviewIntro.tsx
+++ b/components/auth/PicoAuthPreviewIntro.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { ArrowRight, Shield, Sparkles } from "lucide-react";
+import Image from "next/image";
+
+import { isPicoHost } from "@/lib/auth/redirects";
+
+type PicoAuthPreviewIntroProps = {
+  nextPath: string;
+};
+
+const SESSION_KEY = "mutx-pico-preview-intro-played";
+const INTRO_DURATION_MS = 3200;
+const REDUCED_MOTION_DURATION_MS = 1400;
+
+const revealTransition = {
+  duration: 0.56,
+  ease: [0.22, 1, 0.36, 1] as const,
+};
+
+const itemVariants = {
+  active: {
+    opacity: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: revealTransition,
+  },
+  exit: {
+    opacity: 0,
+    y: -18,
+    filter: "blur(8px)",
+    transition: { duration: 0.32, ease: [0.4, 0, 1, 1] as const },
+  },
+  hidden: {
+    opacity: 0,
+    y: 18,
+    filter: "blur(12px)",
+  },
+};
+
+export function PicoAuthPreviewIntro({
+  nextPath,
+}: PicoAuthPreviewIntroProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const completedRef = useRef(false);
+  const [introVisible, setIntroVisible] = useState(false);
+  const [introArmed, setIntroArmed] = useState(false);
+
+  const destinationLabel = useMemo(() => {
+    if (nextPath === "/" || nextPath === "") {
+      return "Pico home";
+    }
+
+    return nextPath;
+  }, [nextPath]);
+
+  useEffect(() => {
+    const hostname = window.location.hostname.toLowerCase();
+    const hasPlayedIntro = (() => {
+      try {
+        return window.sessionStorage.getItem(SESSION_KEY) === "1";
+      } catch {
+        return false;
+      }
+    })();
+
+    if (!isPicoHost(hostname) || hasPlayedIntro) {
+      setIntroVisible(false);
+      setIntroArmed(false);
+      completedRef.current = false;
+      return;
+    }
+
+    completedRef.current = false;
+    setIntroArmed(true);
+    setIntroVisible(true);
+  }, []);
+
+  useEffect(() => {
+    if (!introArmed || !introVisible) {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(
+      () => {
+        if (completedRef.current) {
+          return;
+        }
+
+        completedRef.current = true;
+
+        try {
+          window.sessionStorage.setItem(SESSION_KEY, "1");
+        } catch {
+          // Ignore storage failures and still dismiss the intro.
+        }
+
+        setIntroVisible(false);
+      },
+      prefersReducedMotion ? REDUCED_MOTION_DURATION_MS : INTRO_DURATION_MS,
+    );
+
+    return () => window.clearTimeout(timeout);
+  }, [introArmed, introVisible, prefersReducedMotion]);
+
+  useEffect(() => {
+    if (!introVisible) {
+      return undefined;
+    }
+
+    const html = document.documentElement;
+    const body = document.body;
+    const previousHtmlOverflow = html.style.overflow;
+    const previousBodyOverflow = body.style.overflow;
+
+    html.style.overflow = "hidden";
+    body.style.overflow = "hidden";
+
+    return () => {
+      html.style.overflow = previousHtmlOverflow;
+      body.style.overflow = previousBodyOverflow;
+    };
+  }, [introVisible]);
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-[130]">
+      <AnimatePresence
+        onExitComplete={() => {
+          if (completedRef.current) {
+            setIntroArmed(false);
+          }
+        }}
+      >
+        {introVisible ? (
+          <motion.section
+            key="pico-auth-preview-intro"
+            initial={false}
+            animate={{
+              opacity: 1,
+              transition: { duration: 0.24 },
+            }}
+            exit={{
+              opacity: 0,
+              transition: { duration: 0.52, ease: [0.22, 1, 0.36, 1] },
+            }}
+            className="pointer-events-auto absolute inset-0 overflow-hidden bg-[#040903] text-[#f3faee]"
+            role="dialog"
+            aria-label="Pico preview intro"
+            aria-modal="true"
+          >
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,rgba(159,255,78,0.18),transparent_24%),radial-gradient(circle_at_82%_16%,rgba(115,239,190,0.14),transparent_22%),radial-gradient(circle_at_50%_100%,rgba(73,129,29,0.22),transparent_36%),linear-gradient(180deg,#050904_0%,#030702_100%)]" />
+            <motion.div
+              initial={false}
+              animate={
+                prefersReducedMotion
+                  ? { opacity: 0.08 }
+                  : { opacity: [0.06, 0.11, 0.08], scale: [1, 1.02, 1] }
+              }
+              transition={{
+                duration: 2.4,
+                ease: [0.22, 1, 0.36, 1],
+              }}
+              className="absolute inset-0 [background-image:linear-gradient(rgba(223,255,154,0.12)_1px,transparent_1px),linear-gradient(90deg,rgba(223,255,154,0.12)_1px,transparent_1px)] [background-size:58px_58px]"
+            />
+            <div className="absolute inset-x-[5%] top-[14%] h-px bg-gradient-to-r from-transparent via-[rgba(223,255,154,0.42)] to-transparent" />
+            <div className="absolute inset-x-[5%] bottom-[12%] h-px bg-gradient-to-r from-transparent via-[rgba(223,255,154,0.16)] to-transparent" />
+
+            <div className="relative flex h-full flex-col px-5 pb-6 pt-5 sm:px-8 sm:pb-8 sm:pt-7 lg:px-12 lg:pb-10 lg:pt-8">
+              <motion.div
+                initial="hidden"
+                animate="active"
+                exit="exit"
+                variants={{
+                  active: {
+                    transition: {
+                      staggerChildren: 0.08,
+                      delayChildren: 0.08,
+                    },
+                  },
+                  exit: {
+                    transition: {
+                      staggerChildren: 0.04,
+                      staggerDirection: -1,
+                    },
+                  },
+                }}
+                className="flex items-center justify-between text-[10px] font-semibold uppercase tracking-[0.24em] text-white/50 sm:text-[11px]"
+              >
+                <motion.div variants={itemVariants} className="flex items-center gap-3">
+                  <span className="font-[family:var(--font-site-display)] text-[1rem] tracking-[0.24em] text-white sm:text-[1.08rem]">
+                    Pico
+                  </span>
+                  <span className="h-px w-10 bg-white/14 sm:w-16" />
+                  <span>Preview access gate</span>
+                </motion.div>
+                <motion.div variants={itemVariants} className="hidden items-center gap-2 sm:flex">
+                  <Shield className="h-3.5 w-3.5 text-[#dfff9a]" />
+                  <span>Safe to explore</span>
+                </motion.div>
+              </motion.div>
+
+              <div className="grid flex-1 items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.92fr)] lg:gap-16">
+                <motion.div
+                  initial="hidden"
+                  animate="active"
+                  exit="exit"
+                  variants={{
+                    active: {
+                      transition: {
+                        staggerChildren: 0.12,
+                        delayChildren: 0.14,
+                      },
+                    },
+                    exit: {
+                      transition: {
+                        staggerChildren: 0.05,
+                        staggerDirection: -1,
+                      },
+                    },
+                  }}
+                  className="relative flex items-center justify-center lg:justify-start"
+                >
+                  <motion.div
+                    variants={itemVariants}
+                    className="relative flex aspect-square w-full max-w-[20rem] items-center justify-center sm:max-w-[24rem] lg:max-w-[28rem]"
+                  >
+                    <motion.div
+                      initial={false}
+                      animate={
+                        prefersReducedMotion
+                          ? { opacity: 1 }
+                          : {
+                              rotate: [0, 6, -4, 0],
+                              scale: [1, 1.02, 0.995, 1],
+                            }
+                      }
+                      transition={{ duration: 2.8, ease: [0.22, 1, 0.36, 1] }}
+                      className="absolute inset-[6%] rounded-full border border-white/[0.1]"
+                    />
+                    <motion.div
+                      initial={false}
+                      animate={
+                        prefersReducedMotion
+                          ? { opacity: 1 }
+                          : {
+                              rotate: [0, -10, 0],
+                              scale: [0.96, 1, 0.98],
+                            }
+                      }
+                      transition={{ duration: 2.5, ease: [0.22, 1, 0.36, 1] }}
+                      className="absolute inset-[16%] rounded-full border border-[rgba(159,255,78,0.16)]"
+                    />
+                    <motion.div
+                      initial={false}
+                      animate={
+                        prefersReducedMotion
+                          ? { opacity: 0.7 }
+                          : { x: ["-12%", "12%", "0%"], opacity: [0.22, 0.9, 0.38] }
+                      }
+                      transition={{ duration: 1.55, ease: [0.22, 1, 0.36, 1] }}
+                      className="absolute left-[10%] top-1/2 h-px w-[80%] -translate-y-1/2 bg-gradient-to-r from-transparent via-[rgba(195,255,91,0.92)] to-transparent"
+                    />
+                    <div className="absolute inset-[22%] rounded-full bg-[radial-gradient(circle,rgba(159,255,78,0.16)_0%,rgba(159,255,78,0.04)_42%,transparent_72%)] blur-2xl" />
+                    <motion.div
+                      variants={itemVariants}
+                      className="relative flex h-28 w-28 items-center justify-center rounded-[2rem] border border-white/[0.12] bg-[linear-gradient(180deg,rgba(15,26,12,0.96)_0%,rgba(5,12,5,1)_100%)] shadow-[0_30px_110px_rgba(0,0,0,0.48)] sm:h-32 sm:w-32 sm:rounded-[2.4rem] lg:h-36 lg:w-36"
+                    >
+                      <Image
+                        src="/pico/logo.png"
+                        alt=""
+                        width={96}
+                        height={96}
+                        className="h-16 w-16 object-contain sm:h-20 sm:w-20 lg:h-24 lg:w-24"
+                      />
+                    </motion.div>
+                    <motion.div
+                      variants={itemVariants}
+                      className="absolute left-[2%] top-[18%] text-[10px] font-semibold uppercase tracking-[0.22em] text-white/44 sm:left-[4%]"
+                    >
+                      early preview
+                    </motion.div>
+                    <motion.div
+                      variants={itemVariants}
+                      className="absolute bottom-[18%] right-[1%] text-right text-[10px] font-semibold uppercase tracking-[0.22em] text-white/44 sm:right-[4%]"
+                    >
+                      active build
+                    </motion.div>
+                  </motion.div>
+                </motion.div>
+
+                <motion.div
+                  initial="hidden"
+                  animate="active"
+                  exit="exit"
+                  variants={{
+                    active: {
+                      transition: {
+                        staggerChildren: 0.08,
+                        delayChildren: 0.18,
+                      },
+                    },
+                    exit: {
+                      transition: {
+                        staggerChildren: 0.04,
+                        staggerDirection: -1,
+                      },
+                    },
+                  }}
+                  className="max-w-[38rem]"
+                >
+                  <motion.div
+                    variants={itemVariants}
+                    className="inline-flex items-center gap-2 rounded-full border border-[rgba(195,255,91,0.22)] bg-[rgba(159,255,78,0.08)] px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.22em] text-[#e7ffc2]"
+                  >
+                    <Sparkles className="h-3.5 w-3.5" />
+                    Still being built
+                  </motion.div>
+
+                  <motion.h1
+                    variants={itemVariants}
+                    className="mt-5 font-[family:var(--font-site-display)] text-[2.9rem] leading-[0.88] tracking-[-0.07em] text-white sm:text-[4rem] lg:text-[4.8rem]"
+                  >
+                    Pico is live enough to try, but not finished yet.
+                  </motion.h1>
+
+                  <motion.p
+                    variants={itemVariants}
+                    className="mt-5 max-w-[34rem] text-[15px] leading-7 text-[rgba(243,250,238,0.72)] sm:text-[16px]"
+                  >
+                    This sign-in step is for the early preview. You can explore
+                    what is already working, save your place, and watch the
+                    product improve while we keep building the rest.
+                  </motion.p>
+
+                  <motion.div
+                    variants={itemVariants}
+                    className="mt-6 h-px w-full max-w-[28rem] bg-gradient-to-r from-[rgba(195,255,91,0.82)] via-[rgba(115,239,190,0.28)] to-transparent"
+                  />
+
+                  <motion.div
+                    variants={itemVariants}
+                    className="mt-7 flex flex-wrap gap-x-6 gap-y-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/56"
+                  >
+                    <span>Some parts are ready</span>
+                    <span>Some parts will change</span>
+                    <span>Your progress stays attached</span>
+                  </motion.div>
+
+                  <motion.div
+                    variants={itemVariants}
+                    className="mt-10 flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (completedRef.current) {
+                          return;
+                        }
+
+                        completedRef.current = true;
+
+                        try {
+                          window.sessionStorage.setItem(SESSION_KEY, "1");
+                        } catch {
+                          // Ignore storage failures and still dismiss the intro.
+                        }
+
+                        setIntroVisible(false);
+                      }}
+                      className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full border border-[rgba(195,255,91,0.28)] bg-[linear-gradient(135deg,#dfff9a_0%,#73efbe_100%)] px-5 text-sm font-semibold text-[#071404] shadow-[0_18px_54px_rgba(115,239,190,0.2)] transition hover:-translate-y-0.5"
+                    >
+                      Enter preview
+                      <ArrowRight className="h-4 w-4" />
+                    </button>
+
+                    <div className="text-left sm:text-right">
+                      <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-white/34">
+                        after sign-in
+                      </div>
+                      <div className="mt-2 font-[family:var(--font-mono)] text-sm text-[#dfff9a]">
+                        {destinationLabel}
+                      </div>
+                    </div>
+                  </motion.div>
+                </motion.div>
+              </div>
+            </div>
+          </motion.section>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/components/pico/PicoLanding.module.css
+++ b/components/pico/PicoLanding.module.css
@@ -2,41 +2,6 @@
    PicoMUTX Landing Page — Premium Design System
    =================================================================== */
 
-/* --- Design tokens ------------------------------------------------ */
-:root {
-  --pico-bg: #050904;
-  --pico-bg-raised: #0b1209;
-  --pico-bg-surface: rgba(159, 255, 78, 0.045);
-  --pico-bg-surface-hover: rgba(159, 255, 78, 0.085);
-  --pico-text: #f3faee;
-  --pico-text-secondary: rgba(221, 234, 214, 0.76);
-  --pico-text-muted: rgba(166, 186, 156, 0.5);
-  --pico-border: rgba(159, 255, 78, 0.14);
-  --pico-border-hover: rgba(159, 255, 78, 0.28);
-  --pico-accent-rgb: 159, 255, 78;
-  --pico-accent: #9fff4e;
-  --pico-accent-bright: #dfff9a;
-  --pico-accent-deep: #52c51c;
-  --pico-accent-contrast: #071404;
-  --pico-accent-soft: rgba(159, 255, 78, 0.12);
-  --pico-accent-glow: rgba(159, 255, 78, 0.1);
-  --pico-blue: #73efbe;
-  --pico-blue-soft: rgba(115, 239, 190, 0.12);
-  --pico-blue-glow: rgba(115, 239, 190, 0.08);
-  --pico-red: #ff8c72;
-  --pico-red-soft: rgba(255, 140, 114, 0.1);
-  --pico-yellow-rgb: 195, 255, 91;
-  --pico-yellow: #c3ff5b;
-  --pico-font-accent: var(--font-mono), monospace;
-  --pico-font-display: var(--font-site-display), serif;
-  --pico-font-body: var(--font-site-body), sans-serif;
-  --pico-radius-sm: 0.75rem;
-  --pico-radius: 1.2rem;
-  --pico-radius-lg: 1.6rem;
-  --pico-radius-full: 999px;
-  --pico-shell: min(100% - 2.5rem, 72rem);
-}
-
 /* --- Page shell --------------------------------------------------- */
 .page {
   position: relative;

--- a/components/site/AuthSurface.tsx
+++ b/components/site/AuthSurface.tsx
@@ -19,6 +19,7 @@ type AuthSurfaceProps = {
   highlights: readonly string[];
   children: ReactNode;
   variant?: "access" | "recovery";
+  hostVariant?: "default" | "pico";
 };
 
 export function AuthSurface({
@@ -35,12 +36,14 @@ export function AuthSurface({
   highlights,
   children,
   variant = "access",
+  hostVariant = "default",
 }: AuthSurfaceProps) {
   const isRecovery = variant === "recovery";
+  const isPicoPreview = hostVariant === "pico";
 
   return (
     <PublicSurface className="site-page">
-      <AuthNav />
+      <AuthNav hostVariant={hostVariant} />
 
       <main className="site-main">
         <section
@@ -127,7 +130,7 @@ export function AuthSurface({
 
               <div className="rounded-[32px] border border-[rgba(73,46,26,0.12)] bg-[linear-gradient(180deg,rgba(244,233,214,0.96),rgba(229,212,187,0.9))] p-5 text-[#392416] shadow-[0_24px_64px_rgba(10,8,10,0.18)] sm:p-6">
                 <p className="font-[family:var(--font-mono)] text-[11px] font-semibold uppercase tracking-[0.22em] text-[#8b633b]">
-                  {isRecovery ? "Recovery checklist" : "Operator checklist"}
+                  {isRecovery ? "Recovery checklist" : isPicoPreview ? "Preview notes" : "Operator checklist"}
                 </p>
                 <div className="mt-4 grid gap-3">
                   {highlights.map((item) => (

--- a/lib/auth/redirects.ts
+++ b/lib/auth/redirects.ts
@@ -1,3 +1,20 @@
+const PICO_HOSTS = new Set(["pico.mutx.dev", "pico.mutxx.dev", "pico.localhost"]);
+
+export function isPicoHost(hostname?: string | null) {
+  if (!hostname) {
+    return false;
+  }
+
+  return PICO_HOSTS.has(hostname.toLowerCase());
+}
+
+export function getDefaultRedirectPathForHost(
+  hostname?: string | null,
+  fallback = "/dashboard",
+) {
+  return isPicoHost(hostname) ? "/" : fallback;
+}
+
 export function resolveRedirectPath(
   nextPath?: string | null,
   fallback = "/dashboard",

--- a/proxy.ts
+++ b/proxy.ts
@@ -17,7 +17,7 @@ const APP_HOST = 'app.mutx.dev'
 const APP_HOSTS = new Set([APP_HOST, 'app.localhost'])
 const MARKETING_HOSTS = new Set(['mutx.dev', 'www.mutx.dev'])
 const PICO_HOSTS = new Set(['pico.mutx.dev', 'pico.mutxx.dev', 'pico.localhost'])
-const PICO_AUTH_PATHS = new Set(['/login', '/register', '/forgot-password', '/reset-password'])
+const PICO_AUTH_PATHS = new Set(['/login', '/register', '/forgot-password', '/reset-password', '/verify-email'])
 const PICO_LOCALES = ['en', 'es', 'fr', 'de', 'it', 'pt', 'ja', 'ko', 'zh', 'ar'] as const
 const PICO_LOCALE_BY_COUNTRY: Partial<Record<string, (typeof PICO_LOCALES)[number]>> = {
   JP: 'ja',
@@ -134,6 +134,14 @@ function getRequestScheme(request: NextRequest): string {
   return request.nextUrl.protocol.replace(':', '').toLowerCase()
 }
 
+function hasAuthSession(request: NextRequest): boolean {
+  return Boolean(
+    request.cookies.get('access_token')?.value ||
+    request.cookies.get('refresh_token')?.value ||
+    request.headers.get('authorization'),
+  )
+}
+
 function normalizeOrigin(origin: string | null): string | null {
   if (!origin) {
     return null
@@ -241,6 +249,14 @@ function redirectWithinHost(request: NextRequest, pathname: string) {
   const url = new URL(request.url)
   url.pathname = pathname
   url.search = request.nextUrl.search
+  return NextResponse.redirect(url)
+}
+
+function redirectToLogin(request: NextRequest, nextPath: string) {
+  const url = new URL(request.url)
+  url.pathname = '/login'
+  url.search = ''
+  url.searchParams.set('next', nextPath)
   return NextResponse.redirect(url)
 }
 
@@ -379,6 +395,13 @@ export function proxy(request: NextRequest) {
     }
     if (PICO_AUTH_PATHS.has(normalizedPath)) {
       return finalizeResponse(NextResponse.next(), host, normalizedPath)
+    }
+    if (!hasAuthSession(request)) {
+      return finalizeResponse(
+        redirectToLogin(request, `${normalizedPath}${request.nextUrl.search}`),
+        host,
+        normalizedPath,
+      )
     }
     // pico.mutx.dev/* -> /pico/* with locale detection
     const locale = getLocaleFromRequest(request)

--- a/tests/unit/authRedirects.test.ts
+++ b/tests/unit/authRedirects.test.ts
@@ -1,0 +1,31 @@
+import {
+  getDefaultRedirectPathForHost,
+  isPicoHost,
+  resolveRedirectPath,
+} from '../../lib/auth/redirects'
+
+describe('auth redirect helpers', () => {
+  it('detects pico hosts correctly', () => {
+    expect(isPicoHost('pico.mutx.dev')).toBe(true)
+    expect(isPicoHost('pico.localhost')).toBe(true)
+    expect(isPicoHost('app.mutx.dev')).toBe(false)
+  })
+
+  it('defaults pico hosts to the pico root', () => {
+    expect(getDefaultRedirectPathForHost('pico.mutx.dev')).toBe('/')
+    expect(getDefaultRedirectPathForHost('pico.localhost')).toBe('/')
+  })
+
+  it('keeps non-pico hosts on the dashboard fallback', () => {
+    expect(getDefaultRedirectPathForHost('app.mutx.dev')).toBe('/dashboard')
+    expect(getDefaultRedirectPathForHost(undefined)).toBe('/dashboard')
+  })
+
+  it('resolves explicit next paths over the host fallback', () => {
+    expect(resolveRedirectPath('/onboarding', getDefaultRedirectPathForHost('pico.mutx.dev'))).toBe('/onboarding')
+  })
+
+  it('falls back to the host-specific default when next is missing', () => {
+    expect(resolveRedirectPath(undefined, getDefaultRedirectPathForHost('pico.mutx.dev'))).toBe('/')
+  })
+})

--- a/tests/unit/authRoutes.test.ts
+++ b/tests/unit/authRoutes.test.ts
@@ -354,6 +354,46 @@ describe("auth route handlers", () => {
       expect(setCookieHeader).toContain("refresh_token=");
     });
 
+    it("uses the active pico host as the verification origin", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          requires_email_verification: true,
+          message: "Verification email sent",
+        }),
+      });
+      const { POST } = await import("../../app/api/auth/register/route");
+
+      const response = await POST(
+        mockJsonRequest(
+          {
+            email: "newuser@mutx.dev",
+            password: "securepassword123",
+            name: "New User",
+          },
+          "https://pico.mutx.dev/api/auth/register",
+        ),
+      );
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:8000/v1/auth/register",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: "newuser@mutx.dev",
+            password: "securepassword123",
+            name: "New User",
+            verification_origin: "https://pico.mutx.dev",
+          }),
+          cache: "no-store",
+        },
+      );
+      expect(response.status).toBe(200);
+      expect(applyAuthCookies).not.toHaveBeenCalled();
+    });
+
     it("skips auth cookies when registration requires email verification", async () => {
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
@@ -933,6 +973,34 @@ describe("auth route handlers", () => {
       expect(response.headers.get("location")).toBe(
         "https://app.mutx.dev/login?next=%2Fdashboard&error=OAuth+session+expired.+Start+sign-in+again.",
       );
+    });
+
+    it("falls back to the pico root when oauth callback has no stored next target", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: "oauth_access_token",
+          refresh_token: "oauth_refresh_token",
+          expires_in: 1800,
+        }),
+      });
+      const { GET } =
+        await import("../../app/api/auth/oauth/[provider]/callback/route");
+
+      const response = await GET(
+        mockRequest(
+          {
+            mutx_oauth_state: "state-123",
+            mutx_oauth_intent: "login",
+          },
+          "https://pico.mutx.dev/api/auth/oauth/google/callback?code=provider-code&state=state-123",
+        ),
+        { params: Promise.resolve({ provider: "google" }) },
+      );
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toBe("https://pico.mutx.dev/");
     });
   });
 

--- a/tests/unit/middlewareRouting.test.ts
+++ b/tests/unit/middlewareRouting.test.ts
@@ -2,6 +2,8 @@ import type { NextRequest } from 'next/server'
 
 import { proxy } from '../../proxy'
 
+const authCookies = { access_token: 'token-123' }
+
 function mockRequest(
   url: string,
   headers: Record<string, string> = {},
@@ -150,15 +152,39 @@ describe('host-aware UI routing proxy', () => {
     )
   })
 
-  it('maps pico geolocation headers to supported locales on first visit', () => {
-    const jpResponse = proxy(
+  it('redirects anonymous pico host traffic into the login lane', () => {
+    const response = proxy(
       mockRequest('https://pico.mutx.dev/', { host: 'pico.mutx.dev', 'CF-IPCountry': 'JP' }),
     )
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://pico.mutx.dev/login?next=%2F')
+  })
+
+  it('maps pico geolocation headers to supported locales on first authenticated visit', () => {
+    const jpResponse = proxy(
+      mockRequest(
+        'https://pico.mutx.dev/',
+        { host: 'pico.mutx.dev', 'CF-IPCountry': 'JP' },
+        'GET',
+        authCookies,
+      ),
+    )
     const krResponse = proxy(
-      mockRequest('https://pico.mutxx.dev/', { host: 'pico.mutxx.dev', 'CF-IPCountry': 'KR' }),
+      mockRequest(
+        'https://pico.mutxx.dev/',
+        { host: 'pico.mutxx.dev', 'CF-IPCountry': 'KR' },
+        'GET',
+        authCookies,
+      ),
     )
     const cnResponse = proxy(
-      mockRequest('https://pico.mutx.dev/', { host: 'pico.mutx.dev', 'CF-IPCountry': 'CN' }),
+      mockRequest(
+        'https://pico.mutx.dev/',
+        { host: 'pico.mutx.dev', 'CF-IPCountry': 'CN' },
+        'GET',
+        authCookies,
+      ),
     )
 
     expect(jpResponse.headers.get('set-cookie')).toContain('NEXT_LOCALE=ja')
@@ -174,7 +200,7 @@ describe('host-aware UI routing proxy', () => {
         'https://pico.mutxx.dev/',
         { host: 'pico.mutxx.dev', 'CF-IPCountry': 'JP' },
         'GET',
-        { NEXT_LOCALE: 'es' },
+        { ...authCookies, NEXT_LOCALE: 'es' },
       ),
     )
 
@@ -186,6 +212,8 @@ describe('host-aware UI routing proxy', () => {
       mockRequest(
         'https://pico.mutxx.dev/',
         { host: 'pico.mutxx.dev', 'Accept-Language': 'es-ES,es;q=0.9,en;q=0.8' },
+        'GET',
+        authCookies,
       ),
     )
 
@@ -208,6 +236,19 @@ describe('host-aware UI routing proxy', () => {
     expect(registerResponse.status).toBe(200)
     expect(registerResponse.headers.get('x-middleware-rewrite')).toBeNull()
     expect(registerResponse.headers.get('location')).toBeNull()
+  })
+
+  it('allows verify-email on the pico host without forcing an authenticated session first', () => {
+    const response = proxy(
+      mockRequest(
+        'https://pico.mutx.dev/verify-email?token=test-token',
+        { host: 'pico.mutx.dev' },
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull()
+    expect(response.headers.get('location')).toBeNull()
   })
 
   it('still applies rate-limit headers on protected auth endpoints', () => {


### PR DESCRIPTION
## Summary
- move Pico theme tokens and route-specific globals into a dedicated app/pico/pico.css
- scope shared app/globals.css body, selection, and focus styles away from Pico routes
- remove the Pico landing token block from the CSS module so Pico no longer writes to global :root

## Validation
- npm run build
- npm run typecheck
- npm run lint