### PR TITLE
dashboard: aggregate telemetry into observability proxy

### DIFF
--- a/app/api/dashboard/observability/route.ts
+++ b/app/api/dashboard/observability/route.ts
@@ -1,14 +1,81 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-import { getApiBaseUrl } from "@/app/api/_lib/controlPlane";
-import { proxyJson } from "@/app/api/_lib/proxy";
-import { withErrorHandling } from "@/app/api/_lib/errors";
+import {
+  applyAuthCookies,
+  authenticatedFetch,
+  getApiBaseUrl,
+  hasAuthSession,
+} from "@/app/api/_lib/controlPlane";
+import { unauthorized, withErrorHandling } from "@/app/api/_lib/errors";
 
 
 export const dynamic = "force-dynamic";
 
+type AuthTokens = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+};
+
+type ResourceFetchResult = {
+  response: Response;
+  payload: unknown;
+  error: string | null;
+  tokenRefreshed: boolean;
+  refreshedTokens?: AuthTokens;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function extractErrorMessage(payload: unknown, fallback: string) {
+  if (typeof payload === "string" && payload.trim().length > 0) {
+    return payload;
+  }
+
+  if (!isRecord(payload)) {
+    return fallback;
+  }
+
+  const detail = payload.detail;
+  if (typeof detail === "string" && detail.trim().length > 0) {
+    return detail;
+  }
+
+  const message = payload.message;
+  if (typeof message === "string" && message.trim().length > 0) {
+    return message;
+  }
+
+  return fallback;
+}
+
+async function fetchResource(
+  request: NextRequest,
+  url: string,
+  fallbackMessage: string,
+): Promise<ResourceFetchResult> {
+  const { response, tokenRefreshed, refreshedTokens } = await authenticatedFetch(request, url, {
+    cache: "no-store",
+  });
+  const payload = response.status === 204 ? null : await response.json().catch(() => null);
+
+  return {
+    response,
+    payload,
+    error: response.ok ? null : extractErrorMessage(payload, fallbackMessage),
+    tokenRefreshed,
+    refreshedTokens,
+  };
+}
+
 export async function GET(request: NextRequest) {
   return withErrorHandling(async () => {
+    if (!hasAuthSession(request)) {
+      return unauthorized();
+    }
+
     const targetUrl = new URL(`${getApiBaseUrl()}/v1/observability/runs`);
     request.nextUrl.searchParams.forEach((value, key) => {
       targetUrl.searchParams.set(key, value);
@@ -18,9 +85,67 @@ export async function GET(request: NextRequest) {
       targetUrl.searchParams.set("limit", "50");
     }
 
-    return proxyJson(request, targetUrl.toString(), {
-      method: "GET",
-      fallbackMessage: "Failed to fetch observability runs",
-    });
+    const apiBaseUrl = getApiBaseUrl();
+    const [runsResult, telemetryConfigResult, telemetryHealthResult] = await Promise.all([
+      fetchResource(request, targetUrl.toString(), "Failed to fetch observability runs"),
+      fetchResource(
+        request,
+        `${apiBaseUrl}/v1/telemetry/config`,
+        "Failed to fetch telemetry configuration",
+      ),
+      fetchResource(
+        request,
+        `${apiBaseUrl}/v1/telemetry/health`,
+        "Failed to fetch telemetry health",
+      ),
+    ]);
+
+    const refreshedTokens =
+      runsResult.refreshedTokens ||
+      telemetryConfigResult.refreshedTokens ||
+      telemetryHealthResult.refreshedTokens;
+
+    if (!runsResult.response.ok) {
+      const nextResponse = NextResponse.json(
+        runsResult.payload ?? { detail: "Failed to fetch observability runs" },
+        { status: runsResult.response.status },
+      );
+
+      if (refreshedTokens) {
+        applyAuthCookies(nextResponse, request, refreshedTokens);
+      }
+
+      return nextResponse;
+    }
+
+    const runsPayload = isRecord(runsResult.payload) ? runsResult.payload : {};
+    const telemetryErrors: Record<string, string> = {};
+
+    if (telemetryConfigResult.error) {
+      telemetryErrors.config = telemetryConfigResult.error;
+    }
+
+    if (telemetryHealthResult.error) {
+      telemetryErrors.health = telemetryHealthResult.error;
+    }
+
+    const nextResponse = NextResponse.json(
+      {
+        ...runsPayload,
+        items: Array.isArray(runsPayload.items) ? runsPayload.items : [],
+        telemetry: {
+          config: telemetryConfigResult.response.ok ? telemetryConfigResult.payload : null,
+          health: telemetryHealthResult.response.ok ? telemetryHealthResult.payload : null,
+          errors: Object.keys(telemetryErrors).length > 0 ? telemetryErrors : null,
+        },
+      },
+      { status: runsResult.response.status },
+    );
+
+    if (refreshedTokens) {
+      applyAuthCookies(nextResponse, request, refreshedTokens);
+    }
+
+    return nextResponse;
   })(request);
 }

--- a/app/api/dashboard/observability/route.ts
+++ b/app/api/dashboard/observability/route.ts
@@ -29,6 +29,91 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function normalizeCollection(
+  payload: unknown,
+  keys: string[] = ["items", "sessions", "data"],
+) {
+  if (Array.isArray(payload)) return payload;
+  if (!isRecord(payload)) return [];
+
+  for (const key of keys) {
+    const value = payload[key];
+    if (Array.isArray(value)) return value;
+  }
+
+  return [];
+}
+
+function pickString(record: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function pickBoolean(record: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+
+  return false;
+}
+
+function toTimestamp(value: unknown) {
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value > 1_000_000_000_000 ? value : value * 1000;
+  }
+
+  return null;
+}
+
+function summarizeSessions(payload: unknown) {
+  const sessions = normalizeCollection(payload, ["sessions", "items", "data"]).filter(isRecord);
+  const channels = new Set<string>();
+  const sources = new Set<string>();
+  let active = 0;
+  let latestActivityAt: string | null = null;
+  let latestTimestamp = 0;
+
+  for (const session of sessions) {
+    const channel = pickString(session, ["channel"]);
+    if (channel) channels.add(channel);
+
+    const source = pickString(session, ["source"]);
+    if (source) sources.add(source);
+
+    if (pickBoolean(session, ["active"])) {
+      active += 1;
+    }
+
+    const timestamp = toTimestamp(session.last_activity ?? session.lastActivity);
+    if (timestamp && timestamp > latestTimestamp) {
+      latestTimestamp = timestamp;
+      latestActivityAt = new Date(timestamp).toISOString();
+    }
+  }
+
+  return {
+    total: sessions.length,
+    active,
+    channels: channels.size,
+    sources: sources.size,
+    latestActivityAt,
+  };
+}
+
 function extractErrorMessage(payload: unknown, fallback: string) {
   if (typeof payload === "string" && payload.trim().length > 0) {
     return payload;
@@ -86,7 +171,7 @@ export async function GET(request: NextRequest) {
     }
 
     const apiBaseUrl = getApiBaseUrl();
-    const [runsResult, telemetryConfigResult, telemetryHealthResult] = await Promise.all([
+    const [runsResult, telemetryConfigResult, telemetryHealthResult, sessionsResult] = await Promise.all([
       fetchResource(request, targetUrl.toString(), "Failed to fetch observability runs"),
       fetchResource(
         request,
@@ -98,12 +183,14 @@ export async function GET(request: NextRequest) {
         `${apiBaseUrl}/v1/telemetry/health`,
         "Failed to fetch telemetry health",
       ),
+      fetchResource(request, `${apiBaseUrl}/v1/sessions?limit=100`, "Failed to fetch session summary"),
     ]);
 
     const refreshedTokens =
       runsResult.refreshedTokens ||
       telemetryConfigResult.refreshedTokens ||
-      telemetryHealthResult.refreshedTokens;
+      telemetryHealthResult.refreshedTokens ||
+      sessionsResult.refreshedTokens;
 
     if (!runsResult.response.ok) {
       const nextResponse = NextResponse.json(
@@ -138,6 +225,8 @@ export async function GET(request: NextRequest) {
           health: telemetryHealthResult.response.ok ? telemetryHealthResult.payload : null,
           errors: Object.keys(telemetryErrors).length > 0 ? telemetryErrors : null,
         },
+        sessionSummary: sessionsResult.response.ok ? summarizeSessions(sessionsResult.payload) : null,
+        sessionSummaryError: sessionsResult.error,
       },
       { status: runsResult.response.status },
     );

--- a/components/dashboard/ObservabilityPageClient.tsx
+++ b/components/dashboard/ObservabilityPageClient.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { ArrowRight } from "lucide-react";
 
 import { ApiRequestError, readJson } from "@/components/app/http";
 import {
@@ -9,9 +11,12 @@ import {
   LiveErrorState,
   LiveKpiGrid,
   LiveLoading,
+  LiveMiniStat,
+  LiveMiniStatGrid,
   LivePanel,
   LiveStatCard,
   asDashboardStatus,
+  formatRelativeTime,
 } from "@/components/dashboard/livePrimitives";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 
@@ -52,11 +57,39 @@ interface MutxRun {
   run_metadata?: Record<string, unknown>;
 }
 
+interface TelemetryConfig {
+  otel_enabled?: boolean;
+  exporter_type?: string;
+  endpoint?: string | null;
+}
+
+interface TelemetryHealth {
+  configured?: boolean;
+  endpoint_reachable?: boolean;
+  using_grpc?: boolean;
+  endpoint?: string | null;
+}
+
+interface SessionSummary {
+  total: number;
+  active: number;
+  channels: number;
+  sources: number;
+  latestActivityAt: string | null;
+}
+
 interface ObservabilityResponse {
   items: MutxRun[];
   total: number;
   skip: number;
   limit: number;
+  telemetry?: {
+    config: TelemetryConfig | null;
+    health: TelemetryHealth | null;
+    errors: Record<string, string> | null;
+  } | null;
+  sessionSummary?: SessionSummary | null;
+  sessionSummaryError?: string | null;
 }
 
 export function ObservabilityPageClient() {
@@ -65,6 +98,9 @@ export function ObservabilityPageClient() {
   const [error, setError] = useState<string | null>(null);
   const [runs, setRuns] = useState<MutxRun[]>([]);
   const [selectedRun, setSelectedRun] = useState<MutxRun | null>(null);
+  const [telemetry, setTelemetry] = useState<ObservabilityResponse["telemetry"]>(null);
+  const [sessionSummary, setSessionSummary] = useState<SessionSummary | null>(null);
+  const [sessionSummaryError, setSessionSummaryError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -78,6 +114,9 @@ export function ObservabilityPageClient() {
         const response = await readJson<ObservabilityResponse>("/api/dashboard/observability?limit=50");
         if (!cancelled) {
           setRuns(response.items ?? []);
+          setTelemetry(response.telemetry ?? null);
+          setSessionSummary(response.sessionSummary ?? null);
+          setSessionSummaryError(response.sessionSummaryError ?? null);
           if (response.items?.length > 0 && !selectedRun) {
             setSelectedRun(response.items[0]);
           }
@@ -108,9 +147,27 @@ export function ObservabilityPageClient() {
     const completed = runs.filter((run) => run.status === "completed").length;
     const failed = runs.filter((run) => run.status === "failed").length;
     const running = runs.filter((run) => run.status === "running").length;
-    const totalCost = runs.reduce((sum, run) => sum + (run.cost?.cost_usd || 0), 0);
-    return { completed, failed, running, totalCost };
+    return { completed, failed, running };
   }, [runs]);
+
+  const telemetryStatus = useMemo(() => {
+    if (telemetry?.errors) return "degraded";
+    if (!telemetry?.health?.configured) return "not configured";
+    if (telemetry.health.endpoint_reachable) return "healthy";
+    return "unreachable";
+  }, [telemetry]);
+
+  const telemetryDetail = useMemo(() => {
+    if (!telemetry?.health?.configured) {
+      return "Telemetry exporter has not been configured yet.";
+    }
+
+    if (telemetry?.config?.endpoint) {
+      return `${telemetry.config.exporter_type || "otlp"} · ${telemetry.config.endpoint}`;
+    }
+
+    return telemetry?.config?.exporter_type || "Configured without an endpoint summary.";
+  }, [telemetry]);
 
   if (loading) return <LiveLoading title="Observability" />;
   if (authRequired) {
@@ -145,149 +202,269 @@ export function ObservabilityPageClient() {
           detail="Runs that encountered errors."
           status={totals.failed > 0 ? "error" : undefined}
         />
+        <LiveStatCard
+          label="Telemetry"
+          value={telemetryStatus}
+          detail={telemetryDetail}
+          status={asDashboardStatus(telemetryStatus)}
+        />
+        <LiveStatCard
+          label="Sessions"
+          value={String(sessionSummary?.total ?? 0)}
+          detail={
+            sessionSummary
+              ? `${sessionSummary.active} active · ${sessionSummary.channels} channels · ${sessionSummary.sources} sources`
+              : "Session summary is not available from the current dashboard feed."
+          }
+          status={asDashboardStatus((sessionSummary?.active ?? 0) > 0 ? "running" : "idle")}
+        />
       </LiveKpiGrid>
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <LivePanel title="Agent Runs" meta={`${runs.length} records`}>
-          {runs.length === 0 ? (
-            <LiveEmptyState
-              title="No runs yet"
-              message="Agent run observability data will appear here once agents emit runs."
-            />
-          ) : (
-            <div className="space-y-2">
-              {runs.map((run) => (
-                <button
-                  key={run.id}
-                  onClick={() => setSelectedRun(run)}
-                  className={`w-full rounded-lg border p-3 text-left transition-colors ${
-                    selectedRun?.id === run.id
-                      ? "border-cyan-500/50 bg-cyan-500/10"
-                      : "border-white/10 bg-white/[0.02] hover:bg-white/[0.05]"
-                  }`}
+      <div className="grid gap-4 xl:grid-cols-[minmax(280px,0.72fr)_minmax(0,1.28fr)]">
+        <div className="space-y-4">
+          <LivePanel title="Telemetry rail" meta={telemetry?.config?.exporter_type || "operator summary"}>
+            <LiveMiniStatGrid>
+              <LiveMiniStat
+                label="Exporter"
+                value={telemetry?.config?.exporter_type || "not configured"}
+                detail={telemetry?.config?.endpoint || "No OTLP endpoint has been configured yet."}
+              />
+              <LiveMiniStat
+                label="Reachability"
+                value={
+                  !telemetry?.health?.configured
+                    ? "not configured"
+                    : telemetry.health.endpoint_reachable
+                      ? "reachable"
+                      : "degraded"
+                }
+                detail={
+                  telemetry?.health?.endpoint
+                    ? `Health check via ${telemetry.health.endpoint}`
+                    : "Health follows the configured telemetry backend."
+                }
+              />
+              <LiveMiniStat
+                label="Live sessions"
+                value={String(sessionSummary?.total ?? 0)}
+                detail={
+                  sessionSummary
+                    ? `${sessionSummary.active} active across ${sessionSummary.channels} channels and ${sessionSummary.sources} sources.`
+                    : "Session summary is unavailable."
+                }
+              />
+              <LiveMiniStat
+                label="Last activity"
+                value={
+                  sessionSummary?.latestActivityAt
+                    ? formatRelativeTime(sessionSummary.latestActivityAt)
+                    : "Not recorded"
+                }
+                detail={
+                  sessionSummary?.latestActivityAt
+                    ? `Latest session activity ${sessionSummary.latestActivityAt}`
+                    : "No recent session activity has been returned yet."
+                }
+              />
+            </LiveMiniStatGrid>
+
+            {telemetry?.errors ? (
+              <div className="mt-4 rounded-xl border border-amber-500/20 bg-amber-500/10 p-3 text-sm text-amber-100">
+                {Object.entries(telemetry.errors).map(([scope, message]) => (
+                  <div key={scope}>
+                    <span className="font-medium capitalize">{scope}</span>
+                    {" "}
+                    {message}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            {sessionSummaryError ? (
+              <div className="mt-4 rounded-xl border border-amber-500/20 bg-amber-500/10 p-3 text-sm text-amber-100">
+                <span className="font-medium">Sessions</span>{" "}
+                {sessionSummaryError}
+              </div>
+            ) : null}
+          </LivePanel>
+
+          <LivePanel title="Next routes" meta="follow the signal">
+            <div className="space-y-3">
+              {[
+                {
+                  href: "/dashboard/traces",
+                  label: "Trace stream",
+                  detail: "Inspect per-run trace events and sequence details.",
+                },
+                {
+                  href: "/dashboard/sessions",
+                  label: "Sessions",
+                  detail: "Review channel activity, active sessions, and gateway posture.",
+                },
+                {
+                  href: "/dashboard/security",
+                  label: "Security",
+                  detail: "Check auth and operator posture when observability degrades unexpectedly.",
+                },
+              ].map((destination) => (
+                <Link
+                  key={destination.href}
+                  href={destination.href}
+                  className="flex items-center justify-between rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 text-sm text-slate-300 transition hover:border-white/20 hover:text-white"
                 >
-                  <div className="flex items-center justify-between">
-                    <span className="truncate font-mono text-sm text-white">{run.id.slice(0, 16)}...</span>
-                    <StatusBadge
-                      status={asDashboardStatus(run.status)}
-                      label={run.status}
-                    />
+                  <div>
+                    <div className="font-medium text-white">{destination.label}</div>
+                    <div className="mt-1 text-xs text-slate-500">{destination.detail}</div>
                   </div>
-                  <div className="mt-1 text-xs text-slate-400">
-                    {run.agent_id.slice(0, 12)} · {run.model || "no model"}
-                  </div>
-                  {run.cost && (
-                    <div className="mt-1 text-xs text-slate-500">
-                      ${run.cost.cost_usd?.toFixed(4)} · {run.cost.input_tokens + run.cost.output_tokens} tokens
-                    </div>
-                  )}
-                </button>
+                  <ArrowRight className="h-4 w-4 shrink-0 text-cyan-300" />
+                </Link>
               ))}
             </div>
-          )}
-        </LivePanel>
+          </LivePanel>
+        </div>
 
-        <LivePanel title="Run Detail" meta={selectedRun ? selectedRun.id.slice(0, 16) : "-"}>
-          {selectedRun ? (
-            <div className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <div className="text-xs text-slate-500">Status</div>
-                  <div className="text-sm text-white">{selectedRun.status}</div>
-                </div>
-                <div>
-                  <div className="text-xs text-slate-500">Agent</div>
-                  <div className="truncate text-sm text-white">{selectedRun.agent_id}</div>
-                </div>
-                <div>
-                  <div className="text-xs text-slate-500">Model</div>
-                  <div className="text-sm text-white">{selectedRun.model || "-"}</div>
-                </div>
-                <div>
-                  <div className="text-xs text-slate-500">Provider</div>
-                  <div className="text-sm text-white">{selectedRun.provider || "-"}</div>
-                </div>
-                <div>
-                  <div className="text-xs text-slate-500">Duration</div>
-                  <div className="text-sm text-white">
-                    {selectedRun.duration_ms ? `${(selectedRun.duration_ms / 1000).toFixed(2)}s` : "-"}
+        <div className="grid gap-4 md:grid-cols-2">
+          <LivePanel title="Agent Runs" meta={`${runs.length} records`}>
+            {runs.length === 0 ? (
+              <LiveEmptyState
+                title="No runs yet"
+                message="Agent run observability data will appear here once agents emit runs."
+              />
+            ) : (
+              <div className="space-y-2">
+                {runs.map((run) => (
+                  <button
+                    key={run.id}
+                    onClick={() => setSelectedRun(run)}
+                    className={`w-full rounded-lg border p-3 text-left transition-colors ${
+                      selectedRun?.id === run.id
+                        ? "border-cyan-500/50 bg-cyan-500/10"
+                        : "border-white/10 bg-white/[0.02] hover:bg-white/[0.05]"
+                    }`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="truncate font-mono text-sm text-white">{run.id.slice(0, 16)}...</span>
+                      <StatusBadge
+                        status={asDashboardStatus(run.status)}
+                        label={run.status}
+                      />
+                    </div>
+                    <div className="mt-1 text-xs text-slate-400">
+                      {run.agent_id.slice(0, 12)} · {run.model || "no model"}
+                    </div>
+                    {run.cost && (
+                      <div className="mt-1 text-xs text-slate-500">
+                        ${run.cost.cost_usd?.toFixed(4)} · {run.cost.input_tokens + run.cost.output_tokens} tokens
+                      </div>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+          </LivePanel>
+
+          <LivePanel title="Run Detail" meta={selectedRun ? selectedRun.id.slice(0, 16) : "-"}>
+            {selectedRun ? (
+              <div className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <div className="text-xs text-slate-500">Status</div>
+                    <div className="text-sm text-white">{selectedRun.status}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-slate-500">Agent</div>
+                    <div className="truncate text-sm text-white">{selectedRun.agent_id}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-slate-500">Model</div>
+                    <div className="text-sm text-white">{selectedRun.model || "-"}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-slate-500">Provider</div>
+                    <div className="text-sm text-white">{selectedRun.provider || "-"}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-slate-500">Duration</div>
+                    <div className="text-sm text-white">
+                      {selectedRun.duration_ms ? `${(selectedRun.duration_ms / 1000).toFixed(2)}s` : "-"}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-slate-500">Steps</div>
+                    <div className="text-sm text-white">{selectedRun.steps?.length || 0}</div>
                   </div>
                 </div>
-                <div>
-                  <div className="text-xs text-slate-500">Steps</div>
-                  <div className="text-sm text-white">{selectedRun.steps?.length || 0}</div>
-                </div>
-              </div>
 
-              {selectedRun.cost && (
-                <div>
-                  <div className="mb-2 text-xs text-slate-500">Cost Breakdown</div>
-                  <div className="rounded-lg border border-white/10 bg-white/[0.02] p-3">
-                    <div className="grid grid-cols-3 gap-2 text-center">
-                      <div>
-                        <div className="text-lg text-white">{selectedRun.cost.input_tokens.toLocaleString()}</div>
-                        <div className="text-xs text-slate-500">Input</div>
-                      </div>
-                      <div>
-                        <div className="text-lg text-white">{selectedRun.cost.output_tokens.toLocaleString()}</div>
-                        <div className="text-xs text-slate-500">Output</div>
-                      </div>
-                      <div>
-                        <div className="text-lg text-cyan-400">${selectedRun.cost.cost_usd?.toFixed(4) || "0"}</div>
-                        <div className="text-xs text-slate-500">Cost</div>
+                {selectedRun.cost && (
+                  <div>
+                    <div className="mb-2 text-xs text-slate-500">Cost Breakdown</div>
+                    <div className="rounded-lg border border-white/10 bg-white/[0.02] p-3">
+                      <div className="grid grid-cols-3 gap-2 text-center">
+                        <div>
+                          <div className="text-lg text-white">{selectedRun.cost.input_tokens.toLocaleString()}</div>
+                          <div className="text-xs text-slate-500">Input</div>
+                        </div>
+                        <div>
+                          <div className="text-lg text-white">{selectedRun.cost.output_tokens.toLocaleString()}</div>
+                          <div className="text-xs text-slate-500">Output</div>
+                        </div>
+                        <div>
+                          <div className="text-lg text-cyan-400">${selectedRun.cost.cost_usd?.toFixed(4) || "0"}</div>
+                          <div className="text-xs text-slate-500">Cost</div>
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-              )}
+                )}
 
-              {selectedRun.steps && selectedRun.steps.length > 0 && (
-                <div>
-                  <div className="mb-2 text-xs text-slate-500">Steps ({selectedRun.steps.length})</div>
-                  <div className="max-h-64 space-y-1 overflow-y-auto">
-                    {selectedRun.steps.slice(0, 20).map((step, i) => (
-                      <div
-                        key={step.id}
-                        className="flex items-center gap-2 rounded border border-white/5 bg-white/[0.02] p-2 text-xs"
-                      >
-                        <span className="w-6 text-slate-500">{i + 1}</span>
-                        <span
-                          className={`rounded px-1.5 py-0.5 text-[10px] ${
-                            step.type === "tool_call"
-                              ? "bg-blue-500/20 text-blue-300"
-                              : step.type === "reasoning"
-                                ? "bg-purple-500/20 text-purple-300"
-                                : "bg-slate-500/20 text-slate-300"
-                          }`}
+                {selectedRun.steps && selectedRun.steps.length > 0 && (
+                  <div>
+                    <div className="mb-2 text-xs text-slate-500">Steps ({selectedRun.steps.length})</div>
+                    <div className="max-h-64 space-y-1 overflow-y-auto">
+                      {selectedRun.steps.slice(0, 20).map((step, i) => (
+                        <div
+                          key={step.id}
+                          className="flex items-center gap-2 rounded border border-white/5 bg-white/[0.02] p-2 text-xs"
                         >
-                          {step.type}
-                        </span>
-                        <span className="flex-1 truncate text-slate-300">{step.tool_name || "-"}</span>
-                        {step.success !== undefined && (
-                          <span className={step.success ? "text-green-400" : "text-red-400"}>
-                            {step.success ? "✓" : "✗"}
+                          <span className="w-6 text-slate-500">{i + 1}</span>
+                          <span
+                            className={`rounded px-1.5 py-0.5 text-[10px] ${
+                              step.type === "tool_call"
+                                ? "bg-blue-500/20 text-blue-300"
+                                : step.type === "reasoning"
+                                  ? "bg-purple-500/20 text-purple-300"
+                                  : "bg-slate-500/20 text-slate-300"
+                            }`}
+                          >
+                            {step.type}
                           </span>
-                        )}
-                        {step.duration_ms && <span className="text-slate-500">{step.duration_ms}ms</span>}
-                      </div>
-                    ))}
+                          <span className="flex-1 truncate text-slate-300">{step.tool_name || "-"}</span>
+                          {step.success !== undefined && (
+                            <span className={step.success ? "text-green-400" : "text-red-400"}>
+                              {step.success ? "✓" : "✗"}
+                            </span>
+                          )}
+                          {step.duration_ms && <span className="text-slate-500">{step.duration_ms}ms</span>}
+                        </div>
+                      ))}
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
 
-              {selectedRun.error && (
-                <div>
-                  <div className="mb-2 text-xs text-slate-500">Error</div>
-                  <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-300">
-                    {selectedRun.error}
+                {selectedRun.error && (
+                  <div>
+                    <div className="mb-2 text-xs text-slate-500">Error</div>
+                    <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-300">
+                      {selectedRun.error}
+                    </div>
                   </div>
-                </div>
-              )}
-            </div>
-          ) : (
-            <LiveEmptyState title="No run selected" message="Select a run from the list to view details." />
-          )}
-        </LivePanel>
+                )}
+              </div>
+            ) : (
+              <LiveEmptyState title="No run selected" message="Select a run from the list to view details." />
+            )}
+          </LivePanel>
+        </div>
       </div>
     </div>
   );

--- a/tests/unit/dashboardRoutes.test.ts
+++ b/tests/unit/dashboardRoutes.test.ts
@@ -784,6 +784,216 @@ describe('dashboard route proxies', () => {
     expect(response.status).toBe(200)
   })
 
+  it('returns 401 from dashboard observability proxy when no auth session exists', async () => {
+    hasAuthSession.mockReturnValue(false)
+    const { GET } = await import('../../app/api/dashboard/observability/route')
+
+    const response = await GET(mockRequest('http://localhost:3000/api/dashboard/observability'))
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      status: 'error',
+      error: { code: 'UNAUTHORIZED', message: 'Unauthorized' },
+    })
+  })
+
+  it('aggregates telemetry and session summary into dashboard observability responses', async () => {
+    hasAuthSession.mockReturnValue(true)
+    authenticatedFetch
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({
+          items: [{ id: 'run_123', agent_id: 'agent_123', status: 'running' }],
+          total: 1,
+          skip: 0,
+          limit: 25,
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        tokenRefreshed: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({
+          otel_enabled: true,
+          exporter_type: 'otlp',
+          endpoint: 'http://collector:4318',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        tokenRefreshed: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({
+          configured: true,
+          endpoint_reachable: true,
+          using_grpc: false,
+          endpoint: 'http://collector:4318',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        tokenRefreshed: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({
+          sessions: [
+            {
+              id: 'sess_1',
+              active: true,
+              channel: 'web',
+              source: 'gateway',
+              last_activity: '2026-04-14T10:00:00Z',
+            },
+            {
+              id: 'sess_2',
+              active: false,
+              channel: 'cli',
+              source: 'desktop',
+              last_activity: '2026-04-14T11:00:00Z',
+            },
+          ],
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        tokenRefreshed: false,
+      })
+
+    const { GET } = await import('../../app/api/dashboard/observability/route')
+    const request = mockRequest('http://localhost:3000/api/dashboard/observability?limit=25')
+    const response = await GET(request)
+
+    expect(authenticatedFetch).toHaveBeenNthCalledWith(
+      1,
+      request,
+      'http://localhost:8000/v1/observability/runs?limit=25',
+      { cache: 'no-store' },
+    )
+    expect(authenticatedFetch).toHaveBeenNthCalledWith(
+      2,
+      request,
+      'http://localhost:8000/v1/telemetry/config',
+      { cache: 'no-store' },
+    )
+    expect(authenticatedFetch).toHaveBeenNthCalledWith(
+      3,
+      request,
+      'http://localhost:8000/v1/telemetry/health',
+      { cache: 'no-store' },
+    )
+    expect(authenticatedFetch).toHaveBeenNthCalledWith(
+      4,
+      request,
+      'http://localhost:8000/v1/sessions?limit=100',
+      { cache: 'no-store' },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      items: [{ id: 'run_123', agent_id: 'agent_123', status: 'running' }],
+      total: 1,
+      skip: 0,
+      limit: 25,
+      telemetry: {
+        config: {
+          otel_enabled: true,
+          exporter_type: 'otlp',
+          endpoint: 'http://collector:4318',
+        },
+        health: {
+          configured: true,
+          endpoint_reachable: true,
+          using_grpc: false,
+          endpoint: 'http://collector:4318',
+        },
+        errors: null,
+      },
+      sessionSummary: {
+        total: 2,
+        active: 1,
+        channels: 2,
+        sources: 2,
+        latestActivityAt: '2026-04-14T11:00:00.000Z',
+      },
+      sessionSummaryError: null,
+    })
+  })
+
+  it('keeps observability runs available when telemetry summary calls fail', async () => {
+    hasAuthSession.mockReturnValue(true)
+    authenticatedFetch
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({
+          items: [],
+          total: 0,
+          skip: 0,
+          limit: 50,
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        tokenRefreshed: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ detail: 'telemetry unavailable' }), {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        tokenRefreshed: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({
+          configured: false,
+          endpoint_reachable: false,
+          using_grpc: true,
+          endpoint: null,
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        tokenRefreshed: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ sessions: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        tokenRefreshed: false,
+      })
+
+    const { GET } = await import('../../app/api/dashboard/observability/route')
+    const response = await GET(mockRequest('http://localhost:3000/api/dashboard/observability'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      items: [],
+      total: 0,
+      skip: 0,
+      limit: 50,
+      telemetry: {
+        config: null,
+        health: {
+          configured: false,
+          endpoint_reachable: false,
+          using_grpc: true,
+          endpoint: null,
+        },
+        errors: {
+          config: 'telemetry unavailable',
+        },
+      },
+      sessionSummary: {
+        total: 0,
+        active: 0,
+        channels: 0,
+        sources: 0,
+        latestActivityAt: null,
+      },
+      sessionSummaryError: null,
+    })
+  })
+
   it('proxies dashboard budget usage with forwarded query params', async () => {
     proxyJson.mockResolvedValue(
       new Response(JSON.stringify({ usage_by_agent: [] }), {


### PR DESCRIPTION
## Summary
- widen `/api/dashboard/observability` to fetch runs, telemetry config, and telemetry health together
- preserve the existing runs payload shape and `items` field for the current client
- attach telemetry data and partial-error details in a backward-compatible response envelope

## Validation
- git diff --check
- npm run build

Refs #3593