### PR TITLE
Webhook and API-key product depth: unify lifecycle status across dashboard, CLI, and API

### DIFF
--- a/app/api/api-keys/route.ts
+++ b/app/api/api-keys/route.ts
@@ -10,6 +10,38 @@ import {
 
 export const dynamic = 'force-dynamic'
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeApiKeyListPayload(payload: unknown) {
+  if (Array.isArray(payload)) {
+    return {
+      items: payload,
+      total: payload.length,
+      skip: 0,
+      limit: payload.length,
+    }
+  }
+
+  if (!isRecord(payload)) {
+    return {
+      items: [],
+      total: 0,
+      skip: 0,
+      limit: 0,
+    }
+  }
+
+  return {
+    ...payload,
+    items: Array.isArray(payload.items) ? payload.items : [],
+    total: typeof payload.total === 'number' ? payload.total : Array.isArray(payload.items) ? payload.items.length : 0,
+    skip: typeof payload.skip === 'number' ? payload.skip : 0,
+    limit: typeof payload.limit === 'number' ? payload.limit : Array.isArray(payload.items) ? payload.items.length : 0,
+  }
+}
+
 export async function GET(request: NextRequest) {
   try {
     if (!hasAuthSession(request)) {
@@ -25,7 +57,8 @@ export async function GET(request: NextRequest) {
     )
 
     const payload = await response.json().catch(() => ({ detail: 'Failed to fetch API keys' }))
-    const nextResponse = NextResponse.json(payload, { status: response.status })
+    const body = response.status >= 200 && response.status < 300 ? normalizeApiKeyListPayload(payload) : payload
+    const nextResponse = NextResponse.json(body, { status: response.status })
 
     if (tokenRefreshed && refreshedTokens) {
       applyAuthCookies(nextResponse, request, refreshedTokens)

--- a/app/api/webhooks/[id]/deliveries/route.ts
+++ b/app/api/webhooks/[id]/deliveries/route.ts
@@ -42,7 +42,20 @@ export async function GET(
 
     const payload = await response.json().catch(() => ({}));
     const nextResponse = response.ok
-      ? NextResponse.json({ deliveries: payload }, { status: response.status })
+      ? NextResponse.json(
+          {
+            deliveries: Array.isArray(payload)
+              ? payload
+              : Array.isArray(payload?.deliveries)
+                ? payload.deliveries
+                : Array.isArray(payload?.items)
+                  ? payload.items
+                  : Array.isArray(payload?.data)
+                    ? payload.data
+                    : [],
+          },
+          { status: response.status }
+        )
       : NextResponse.json(
           { error: payload.detail || "Failed to fetch webhook deliveries" },
           { status: response.status }

--- a/app/api/webhooks/route.ts
+++ b/app/api/webhooks/route.ts
@@ -29,7 +29,15 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const payload = await response.json().catch(() => ({}));
     const nextResponse = response.ok
       ? NextResponse.json({
-          webhooks: Array.isArray(payload) ? payload : payload?.webhooks ?? [],
+          webhooks: Array.isArray(payload)
+            ? payload
+            : Array.isArray(payload?.webhooks)
+              ? payload.webhooks
+              : Array.isArray(payload?.items)
+                ? payload.items
+                : Array.isArray(payload?.data)
+                  ? payload.data
+                  : [],
         })
       : NextResponse.json(
           { error: payload.detail || "Failed to fetch webhooks" },

--- a/cli/commands/api_keys.py
+++ b/cli/commands/api_keys.py
@@ -1,4 +1,5 @@
 import click
+from datetime import datetime, timezone
 from typing import Optional
 
 from cli.config import current_config, get_client
@@ -8,6 +9,40 @@ from cli.config import current_config, get_client
 def api_keys_group():
     """Manage API keys"""
     pass
+
+
+def _normalize_key_collection(payload):
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("items", "keys", "api_keys", "data"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+    return []
+
+
+def _parse_timestamp(value: str | None):
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except ValueError:
+        return None
+
+
+def _render_key_state(key: dict) -> str:
+    if key.get("is_active") is False:
+        return "revoked"
+
+    expires_at = _parse_timestamp(key.get("expires_at"))
+    if expires_at and expires_at <= datetime.now(timezone.utc):
+        return "expired"
+
+    return "active"
 
 
 @api_keys_group.command(name="list")
@@ -29,15 +64,17 @@ def list_api_keys():
         click.echo(f"Error: {response.text}", err=True)
         return
 
-    keys = response.json()
+    keys = _normalize_key_collection(response.json())
     if not keys:
         click.echo("No API keys found.")
         return
 
     for key in keys:
-        active = "active" if key.get("is_active") else "revoked"
         expires = key.get("expires_at") or "never"
-        click.echo(f"{key['id']} | {key['name']} | {active} | expires: {expires}")
+        last_used = key.get("last_used_at") or key.get("last_used") or "never"
+        click.echo(
+            f"{key['id']} | {key['name']} | {_render_key_state(key)} | expires: {expires} | last used: {last_used}"
+        )
 
 
 @api_keys_group.command(name="create")

--- a/cli/commands/webhooks.py
+++ b/cli/commands/webhooks.py
@@ -10,6 +10,17 @@ def webhooks_group():
     pass
 
 
+def _normalize_collection(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in keys:
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+    return []
+
+
 @webhooks_group.command(name="list")
 @click.option("--limit", "-l", default=50, help="Number of webhooks to fetch")
 @click.option("--skip", "-s", default=0, help="Number of webhooks to skip")
@@ -31,7 +42,7 @@ def list_webhooks(limit: int, skip: int):
         click.echo(f"Error: {response.text}", err=True)
         return
 
-    webhooks = response.json()
+    webhooks = _normalize_collection(response.json(), "webhooks", "items", "data")
     if not webhooks:
         click.echo("No webhooks found.")
         return
@@ -78,7 +89,7 @@ def webhook_deliveries(
         click.echo(f"Error: {response.text}", err=True)
         return
 
-    deliveries = response.json()
+    deliveries = _normalize_collection(response.json(), "deliveries", "items", "data")
     if not deliveries:
         click.echo("No webhook deliveries found.")
         return
@@ -118,3 +129,23 @@ def get_webhook(webhook_id: str):
     click.echo(f"{webhook['id']} | {webhook['url']} | {active}")
     click.echo(f"Events: {','.join(webhook.get('events', [])) or '*'}")
     click.echo(f"Created: {webhook.get('created_at')}")
+
+    latest_delivery_response = client.get(
+        f"/v1/webhooks/{webhook_id}/deliveries",
+        params={"skip": 0, "limit": 1},
+    )
+    if latest_delivery_response.status_code == 200:
+        latest_deliveries = _normalize_collection(
+            latest_delivery_response.json(), "deliveries", "items", "data"
+        )
+        if latest_deliveries:
+            latest = latest_deliveries[0]
+            click.echo(
+                "Latest delivery: "
+                f"{'success' if latest.get('success') else 'failed'}"
+                f" | status={latest.get('status_code') or 'n/a'}"
+                f" | attempts={latest.get('attempts', 0)}"
+                f" | created={latest.get('created_at')}"
+            )
+        else:
+            click.echo("Latest delivery: none")

--- a/components/dashboard/ApiKeysPageClient.tsx
+++ b/components/dashboard/ApiKeysPageClient.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import { Copy, KeyRound, RefreshCcw, Trash2 } from "lucide-react";
 
-import { ApiRequestError, normalizeCollection, readJson } from "@/components/app/http";
+import { ApiRequestError, readJson } from "@/components/app/http";
 import {
   LiveAuthRequired,
   LiveEmptyState,
@@ -17,6 +18,14 @@ import {
   formatRelativeTime,
 } from "@/components/dashboard/livePrimitives";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
+import {
+  apiKeyExpiryMeta,
+  apiKeyLastUsed,
+  apiKeyLifecycleMeta,
+  isApiKeyStale,
+  normalizeApiKeyCollection,
+  summarizeApiKeys,
+} from "@/lib/operatorLifecycle";
 
 import type { components } from "@/app/types/api";
 
@@ -48,51 +57,9 @@ function isApiKeyCreateResponse(value: unknown): value is ApiKeyCreateResponse {
   );
 }
 
-function keyLastUsed(key: ApiKeyRecord) {
-  return key.last_used_at ?? key.last_used ?? null;
-}
-
-function isKeyActive(key: ApiKeyRecord) {
-  if (typeof key.is_active === "boolean") {
-    return key.is_active;
-  }
-
-  const normalizedStatus = (key.status ?? "").toLowerCase();
-  if (normalizedStatus.includes("revoked") || normalizedStatus.includes("inactive")) {
-    return false;
-  }
-
-  if (key.expires_at) {
-    const expiresAt = new Date(key.expires_at).getTime();
-    if (!Number.isNaN(expiresAt) && expiresAt <= Date.now()) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 function maskKeyId(id: string) {
   if (id.length <= 10) return id;
   return `${id.slice(0, 6)}...${id.slice(-4)}`;
-}
-
-function getExpiryLabel(expiresAt?: string | null) {
-  if (!expiresAt) return null;
-
-  const millis = new Date(expiresAt).getTime();
-  if (Number.isNaN(millis)) return null;
-
-  if (millis <= Date.now()) {
-    return { label: "expired", status: "error" as const };
-  }
-
-  const daysUntilExpiry = Math.ceil((millis - Date.now()) / 86_400_000);
-  if (daysUntilExpiry <= 7) {
-    return { label: `expires in ${daysUntilExpiry}d`, status: "warning" as const };
-  }
-
-  return null;
 }
 
 function sortKeys(keys: ApiKeyRecord[]) {
@@ -116,9 +83,7 @@ export function ApiKeysPageClient() {
 
   async function fetchKeys() {
     const payload = await readJson<unknown>("/api/api-keys");
-    return sortKeys(
-      normalizeCollection<ApiKeyRecord>(payload, ["items", "keys", "api_keys", "data"]),
-    );
+    return sortKeys(normalizeApiKeyCollection(payload) as ApiKeyRecord[]);
   }
 
   useEffect(() => {
@@ -153,24 +118,7 @@ export function ApiKeysPageClient() {
     };
   }, []);
 
-  const activeKeys = useMemo(
-    () => keys.filter((key) => isKeyActive(key)),
-    [keys],
-  );
-  const recentlyUsedKeys = useMemo(
-    () =>
-      keys.filter((key) => {
-        const lastUsed = keyLastUsed(key);
-        if (!lastUsed) return false;
-        const millis = new Date(lastUsed).getTime();
-        return !Number.isNaN(millis) && millis >= Date.now() - 7 * 86_400_000;
-      }),
-    [keys],
-  );
-  const expiringSoon = useMemo(
-    () => activeKeys.filter((key) => getExpiryLabel(key.expires_at)?.status === "warning"),
-    [activeKeys],
-  );
+  const summary = useMemo(() => summarizeApiKeys(keys), [keys]);
 
   async function refreshKeys() {
     const nextKeys = await fetchKeys();
@@ -286,30 +234,26 @@ export function ApiKeysPageClient() {
       <LiveKpiGrid>
         <LiveStatCard
           label="Active keys"
-          value={String(activeKeys.length)}
+          value={String(summary.active)}
           detail={`${keys.length} total keys are visible in the operator ledger.`}
-          status={asDashboardStatus(activeKeys.length > 0 ? "healthy" : "idle")}
+          status={asDashboardStatus(summary.active > 0 ? "healthy" : "idle")}
         />
         <LiveStatCard
           label="Seen this week"
-          value={String(recentlyUsedKeys.length)}
+          value={String(summary.recentlyUsed)}
           detail="Keys with a recent `last used` signal in the last 7 days."
         />
         <LiveStatCard
           label="Expiring soon"
-          value={String(expiringSoon.length)}
+          value={String(summary.expiringSoon)}
           detail="Active keys expiring within the next 7 days."
-          status={asDashboardStatus(expiringSoon.length > 0 ? "warning" : "healthy")}
+          status={asDashboardStatus(summary.expiringSoon > 0 ? "warning" : "healthy")}
         />
         <LiveStatCard
-          label="One-time reveal"
-          value={revealedKey ? "ready" : "idle"}
-          detail={
-            revealedKey
-              ? "A newly created or rotated secret is available to copy once."
-              : "New secrets appear here immediately after create or rotate."
-          }
-          status={asDashboardStatus(revealedKey ? "running" : "idle")}
+          label="Stale keys"
+          value={String(summary.stale)}
+          detail="Active keys without a recent use signal in the last 30 days."
+          status={asDashboardStatus(summary.stale > 0 ? "warning" : "healthy")}
         />
       </LiveKpiGrid>
 
@@ -388,9 +332,10 @@ export function ApiKeysPageClient() {
             ) : (
               <div className="space-y-3">
                 {keys.map((key) => {
-                  const lastUsed = keyLastUsed(key);
-                  const active = isKeyActive(key);
-                  const expiry = getExpiryLabel(key.expires_at);
+                  const lastUsed = apiKeyLastUsed(key);
+                  const lifecycle = apiKeyLifecycleMeta(key);
+                  const expiry = apiKeyExpiryMeta(key);
+                  const stale = isApiKeyStale(key);
 
                   return (
                     <div key={key.id} className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
@@ -399,12 +344,13 @@ export function ApiKeysPageClient() {
                           <div className="flex flex-wrap items-center gap-2">
                             <p className="truncate text-sm font-medium text-white">{key.name}</p>
                             <StatusBadge
-                              status={active ? "success" : "idle"}
-                              label={active ? "active" : "inactive"}
+                              status={lifecycle.tone}
+                              label={lifecycle.label}
                             />
                             {expiry ? (
-                              <StatusBadge status={expiry.status} label={expiry.label} />
+                              <StatusBadge status={expiry.tone} label={expiry.label} />
                             ) : null}
+                            {stale ? <StatusBadge status="warning" label="stale" /> : null}
                           </div>
                           <p className="mt-2 font-mono text-xs text-slate-500">{maskKeyId(key.id)}</p>
                           <div className="mt-3 grid gap-2 text-xs text-slate-500 sm:grid-cols-2">
@@ -417,7 +363,7 @@ export function ApiKeysPageClient() {
                           </div>
                         </div>
 
-                        {active ? (
+                        {lifecycle.label === "active" ? (
                           <div className="flex flex-wrap items-center gap-2">
                             <button
                               type="button"
@@ -454,6 +400,20 @@ export function ApiKeysPageClient() {
               <p className="text-sm font-medium text-white">Creation and rotation are live</p>
               <p className="mt-2 text-sm leading-6 text-slate-400">
                 This route now owns create, rotate, and revoke actions directly instead of bouncing into the broader security page.
+              </p>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+              <p className="text-sm font-medium text-white">Dashboard and CLI use the same lifecycle story</p>
+              <p className="mt-2 text-sm leading-6 text-slate-400">
+                `active`, `revoked`, `expired`, and `expires soon` are derived from the same live API fields surfaced by
+                `mutx api-keys list`, `mutx api-keys rotate`, and the dashboard registry.
+              </p>
+              <p className="mt-3 text-sm leading-6 text-slate-400">
+                Pair this with the{" "}
+                <Link href="/dashboard/webhooks" className="text-cyan-300 underline decoration-cyan-400/40 underline-offset-4">
+                  webhook delivery surface
+                </Link>{" "}
+                when you need to compare credential readiness against outbound event health.
               </p>
             </div>
             <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">

--- a/components/webhooks/WebhooksPageClient.tsx
+++ b/components/webhooks/WebhooksPageClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Plus,
   Search,
@@ -21,88 +22,33 @@ import {
 } from "lucide-react";
 import { Card } from "@/components/ui/Card";
 import { readJson, writeJson } from "@/components/app/http";
-import { LiveAuthRequired } from "@/components/dashboard/livePrimitives";
+import {
+  LiveAuthRequired,
+  LiveKpiGrid,
+  LivePanel,
+  LiveStatCard,
+  formatDateTime,
+  formatRelativeTime,
+} from "@/components/dashboard/livePrimitives";
+import { StatusBadge } from "@/components/dashboard/StatusBadge";
+import {
+  describeWebhookHealth,
+  normalizeWebhookCollection,
+  normalizeWebhookDeliveryCollection,
+  summarizeWebhookFleet,
+  type WebhookDeliveryRecord,
+  type WebhookLifecycleRecord,
+} from "@/lib/operatorLifecycle";
 
-type WebhookDelivery = {
-  id: string;
-  event: string;
-  payload: string;
-  status_code: number | null;
-  success: boolean;
-  error_message: string | null;
-  attempts: number;
-  created_at: string;
-  delivered_at: string | null;
-};
-
-type Webhook = {
-  id: string;
-  url: string;
-  events: string[];
-  is_active: boolean;
-  created_at: string;
-};
-
-function normalizeStringList(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
-  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
-}
-
-function normalizeWebhooks(payload: unknown): Webhook[] {
-  const container = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : null;
-  const rawWebhooks = Array.isArray(payload) ? payload : container?.webhooks ?? container?.items ?? container?.data ?? [];
-
-  if (!Array.isArray(rawWebhooks)) return [];
-
-  return rawWebhooks
-    .map((entry) => {
-      if (!entry || typeof entry !== "object") return null;
-      const record = entry as Record<string, unknown>;
-      const id = typeof record.id === "string" ? record.id : "";
-      const url = typeof record.url === "string" ? record.url : "";
-      if (!id || !url) return null;
-      return {
-        id,
-        url,
-        events: normalizeStringList(record.events),
-        is_active: Boolean(record.is_active),
-        created_at: typeof record.created_at === "string" ? record.created_at : "",
-      } satisfies Webhook;
-    })
-    .filter((webhook): webhook is Webhook => Boolean(webhook));
-}
-
-function normalizeDeliveries(payload: unknown): WebhookDelivery[] {
-  const container = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : null;
-  const rawDeliveries = Array.isArray(payload) ? payload : container?.deliveries ?? container?.items ?? container?.data ?? [];
-
-  if (!Array.isArray(rawDeliveries)) return [];
-
-  return rawDeliveries
-    .map((entry) => {
-      if (!entry || typeof entry !== "object") return null;
-      const record = entry as Record<string, unknown>;
-      const id = typeof record.id === "string" ? record.id : "";
-      if (!id) return null;
-      return {
-        id,
-        event: typeof record.event === "string" ? record.event : "unknown",
-        payload: typeof record.payload === "string" ? record.payload : JSON.stringify(record.payload ?? {}, null, 2),
-        status_code: typeof record.status_code === "number" ? record.status_code : null,
-        success: Boolean(record.success),
-        error_message: typeof record.error_message === "string" ? record.error_message : null,
-        attempts: typeof record.attempts === "number" ? record.attempts : 0,
-        created_at: typeof record.created_at === "string" ? record.created_at : new Date(0).toISOString(),
-        delivered_at: typeof record.delivered_at === "string" ? record.delivered_at : null,
-      } satisfies WebhookDelivery;
-    })
-    .filter((delivery): delivery is WebhookDelivery => Boolean(delivery));
-}
+type Webhook = WebhookLifecycleRecord;
+type WebhookDelivery = WebhookDeliveryRecord;
 
 export default function WebhooksPageClient() {
   const [webhooks, setWebhooks] = useState<Webhook[]>([]);
+  const [deliverySnapshots, setDeliverySnapshots] = useState<Record<string, WebhookDelivery[]>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [deliverySummaryError, setDeliverySummaryError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [editingWebhook, setEditingWebhook] = useState<Webhook | null>(null);
   const [viewingDeliveries, setViewingDeliveries] = useState<Webhook | null>(null);
@@ -153,17 +99,50 @@ export default function WebhooksPageClient() {
         w.events.some(e => e.toLowerCase().includes(searchQuery.toLowerCase()))
       )
     : webhooks;
+  const fleetSummary = useMemo(
+    () => summarizeWebhookFleet(webhooks, deliverySnapshots),
+    [deliverySnapshots, webhooks],
+  );
 
   const hasAuthError = Boolean(error && /unauthorized|forbidden|auth|token|sign in|login/i.test(error));
+
+  async function loadDeliverySnapshots(nextWebhooks: Webhook[]) {
+    if (nextWebhooks.length === 0) {
+      setDeliverySnapshots({});
+      setDeliverySummaryError(null);
+      return;
+    }
+
+    let failed = 0;
+    const pairs = await Promise.all(
+      nextWebhooks.map(async (webhook) => {
+        try {
+          const payload = await readJson<unknown>(`/api/webhooks/${webhook.id}/deliveries?limit=3`);
+          return [webhook.id, normalizeWebhookDeliveryCollection(payload)] as const;
+        } catch {
+          failed += 1;
+          return [webhook.id, []] as const;
+        }
+      }),
+    );
+
+    setDeliverySnapshots(Object.fromEntries(pairs));
+    setDeliverySummaryError(
+      failed > 0 ? "Some delivery health snapshots could not be loaded from the live route." : null,
+    );
+  }
 
   async function fetchWebhooks() {
     try {
       setLoading(true);
       setError(null);
       const data = await readJson<unknown>("/api/webhooks");
-      setWebhooks(normalizeWebhooks(data));
+      const nextWebhooks = normalizeWebhookCollection(data);
+      setWebhooks(nextWebhooks);
+      await loadDeliverySnapshots(nextWebhooks);
     } catch (err) {
       setWebhooks([]);
+      setDeliverySnapshots({});
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
@@ -175,7 +154,7 @@ export default function WebhooksPageClient() {
       setLoadingDeliveries(true);
       setError(null);
       const data = await readJson<unknown>(`/api/webhooks/${webhookId}/deliveries`);
-      setDeliveries(normalizeDeliveries(data));
+      setDeliveries(normalizeWebhookDeliveryCollection(data));
     } catch (err) {
       setDeliveries([]);
       setError(err instanceof Error ? err.message : "Unknown error");
@@ -274,6 +253,85 @@ export default function WebhooksPageClient() {
 
   return (
     <div className="space-y-6">
+      {!viewingDeliveries && !hasAuthError && !error ? (
+        <>
+          <LiveKpiGrid>
+            <LiveStatCard
+              label="Active routes"
+              value={String(fleetSummary.active)}
+              detail={`${webhooks.length} total webhook endpoints are visible in the operator surface.`}
+              status={fleetSummary.active > 0 ? "success" : "idle"}
+            />
+            <LiveStatCard
+              label="Healthy latest delivery"
+              value={String(fleetSummary.healthy)}
+              detail="Active webhook routes whose latest recorded delivery completed successfully."
+              status={fleetSummary.healthy > 0 ? "success" : "idle"}
+            />
+            <LiveStatCard
+              label="Needs attention"
+              value={String(fleetSummary.attention)}
+              detail="Active routes whose latest recorded delivery failed and need operator follow-through."
+              status={fleetSummary.attention > 0 ? "error" : "success"}
+            />
+            <LiveStatCard
+              label="No deliveries yet"
+              value={String(fleetSummary.noDeliveries)}
+              detail="Active routes without a recorded delivery attempt in the current history lane."
+              status={fleetSummary.noDeliveries > 0 ? "warning" : "success"}
+            />
+          </LiveKpiGrid>
+
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1.08fr)_minmax(340px,0.92fr)]">
+            <LivePanel title="Delivery posture" meta="live health">
+              {deliverySummaryError ? (
+                <div className="rounded-xl border border-amber-400/20 bg-amber-400/10 px-3 py-3 text-sm text-amber-100">
+                  {deliverySummaryError}
+                </div>
+              ) : null}
+              <div className="space-y-3">
+                <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+                  <p className="text-sm font-medium text-white">Latest-delivery health only</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-400">
+                    This surface does not invent uptime scores. It classifies each route from the latest recorded delivery,
+                    plus the route&apos;s current active or inactive state.
+                  </p>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+                  <p className="text-sm font-medium text-white">Delivery history stays drill-down first</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-400">
+                    Summary badges stay compact here, while the full payload, error, and retry details remain inside each
+                    webhook&apos;s delivery history drawer.
+                  </p>
+                </div>
+              </div>
+            </LivePanel>
+
+            <LivePanel title="Lifecycle parity" meta="dashboard + CLI">
+              <div className="space-y-3">
+                <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+                  <p className="text-sm font-medium text-white">Same live routes, different operator shells</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-400">
+                    The dashboard health badges map to the same live delivery and route-state data you can inspect with
+                    `mutx webhooks get`, `mutx webhooks deliveries`, and `mutx webhooks list`.
+                  </p>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+                  <p className="text-sm font-medium text-white">Compare route health with key readiness</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-400">
+                    Use the{" "}
+                    <Link href="/dashboard/api-keys" className="text-cyan-300 underline decoration-cyan-400/40 underline-offset-4">
+                      API key registry
+                    </Link>{" "}
+                    to correlate expiring or stale credentials with outbound delivery behavior before rotating or revoking access.
+                  </p>
+                </div>
+              </div>
+            </LivePanel>
+          </div>
+        </>
+      ) : null}
+
       {error && (
         <div className="flex items-center gap-2 p-4 bg-destructive/10 text-destructive rounded-md">
           <AlertCircle className="h-4 w-4 flex-shrink-0" />
@@ -509,19 +567,22 @@ export default function WebhooksPageClient() {
       ) : (
         !viewingDeliveries && (
           <div className="space-y-4">
-            {filteredWebhooks.map((webhook) => (
-              <Card key={webhook.id} className="p-4">
+            {filteredWebhooks.map((webhook) => {
+              const health = describeWebhookHealth(webhook, deliverySnapshots[webhook.id] ?? [])
+
+              return (
+                <Card key={webhook.id} className="p-4">
                 <div className="flex items-start justify-between">
                   <div className="space-y-1">
                     <div className="flex items-center gap-2">
                       <code className="text-sm bg-muted px-2 py-1 rounded">
                         {webhook.url}
                       </code>
-                      {webhook.is_active ? (
-                        <CheckCircle2 className="h-4 w-4 text-green-500" />
-                      ) : (
-                        <AlertCircle className="h-4 w-4 text-amber-500" />
-                      )}
+                      <StatusBadge
+                        status={webhook.is_active ? "success" : "idle"}
+                        label={webhook.is_active ? "active" : "inactive"}
+                      />
+                      <StatusBadge status={health.tone} label={health.label} />
                       <button
                         onClick={() => handleCopyId(webhook.id)}
                         className="flex items-center gap-1 rounded p-1 text-slate-500 hover:text-cyan-400 transition-colors"
@@ -541,8 +602,22 @@ export default function WebhooksPageClient() {
                       ))}
                     </div>
                     <p className="text-xs text-muted-foreground">
-                      Created {new Date(webhook.created_at).toLocaleString()}
+                      Created {formatDateTime(webhook.created_at)}
                     </p>
+                    <p className="text-xs text-muted-foreground">
+                      Latest attempt {health.latestAttemptAt ? formatRelativeTime(health.latestAttemptAt) : "not recorded"}
+                    </p>
+                    {health.statusCode ? (
+                      <p className="text-xs text-muted-foreground">
+                        Last status {health.statusCode}
+                        {health.attempts && health.attempts > 1 ? ` · attempts ${health.attempts}` : ""}
+                      </p>
+                    ) : null}
+                    {health.errorMessage ? (
+                      <p className="text-xs text-red-400">
+                        {health.errorMessage}
+                      </p>
+                    ) : null}
                   </div>
                   <div className="flex gap-2">
                     <button
@@ -580,8 +655,9 @@ export default function WebhooksPageClient() {
                     </button>
                   </div>
                 </div>
-              </Card>
-            ))}
+                </Card>
+              )
+            })}
           </div>
         )
       )}

--- a/docs/architecture/webhook-api-key-product-depth-phase-1.md
+++ b/docs/architecture/webhook-api-key-product-depth-phase-1.md
@@ -16,6 +16,24 @@ Make the dashboard the shared operator summary layer for webhook and API-key dep
 
 That means phase 1 should add truthful summary and status structure in the dashboard, not a new backend abstraction. The goal is to make the current lifecycle data easier to understand and compare, then leave deeper unification for later phases.
 
+## Parity Contract
+
+- API keys:
+  - `active` means the key is still marked active and has not passed `expires_at`.
+  - `revoked` means `is_active` is false.
+  - `expired` means the key is still visible for audit, but `expires_at` is already in the past.
+  - `expires soon` is a warning layer on top of an otherwise active key, based on the live `expires_at` timestamp.
+  - `last used` comes from `last_used` or `last_used_at`; missing data stays `never` instead of being guessed.
+- Webhooks:
+  - Route state stays `active` or `inactive` from `is_active`.
+  - Delivery health comes from the latest recorded delivery attempt, not an invented aggregate score.
+  - `healthy` means the latest delivery succeeded.
+  - `failing` means the latest delivery failed and should surface its real status code and retry count.
+  - `no deliveries` means the route exists but the current history lane has no delivery attempts yet.
+- CLI and dashboard:
+  - The dashboard may summarize these states visually, but the CLI should expose the same underlying labels where possible.
+  - No new backend fields are introduced for phase 1; the parity story is built from current live endpoints only.
+
 ## File-Level Map
 
 - `components/dashboard/ApiKeysPageClient.tsx`

--- a/lib/operatorLifecycle.ts
+++ b/lib/operatorLifecycle.ts
@@ -1,0 +1,343 @@
+type RecordValue = Record<string, unknown>
+
+export type LifecycleTone = 'success' | 'warning' | 'error' | 'idle'
+
+export type ApiKeyLifecycleRecord = {
+  id: string
+  name?: string | null
+  created_at?: string | null
+  expires_at?: string | null
+  is_active?: boolean
+  last_used?: string | null
+  last_used_at?: string | null
+  status?: string | null
+  scopes?: string[]
+}
+
+export type WebhookLifecycleRecord = {
+  id: string
+  url: string
+  events: string[]
+  is_active: boolean
+  created_at: string
+}
+
+export type WebhookDeliveryRecord = {
+  id: string
+  event: string
+  payload: string
+  status_code: number | null
+  success: boolean
+  error_message: string | null
+  attempts: number
+  created_at: string
+  delivered_at: string | null
+}
+
+export type WebhookHealthSnapshot = {
+  label: string
+  tone: LifecycleTone
+  latestAttemptAt: string | null
+  latestSuccessAt: string | null
+  statusCode: number | null
+  attempts: number | null
+  errorMessage: string | null
+}
+
+function isRecord(value: unknown): value is RecordValue {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function readCollection<T>(payload: unknown, keys: string[]): T[] {
+  if (Array.isArray(payload)) return payload as T[]
+  if (!isRecord(payload)) return []
+
+  for (const key of keys) {
+    const value = payload[key]
+    if (Array.isArray(value)) {
+      return value as T[]
+    }
+  }
+
+  return []
+}
+
+function readString(record: RecordValue, key: string) {
+  const value = record[key]
+  return typeof value === 'string' ? value : null
+}
+
+function readBoolean(record: RecordValue, key: string, fallback = false) {
+  const value = record[key]
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function readNumber(record: RecordValue, key: string, fallback: number | null = null) {
+  const value = record[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+}
+
+function toTimestamp(value?: string | null) {
+  if (!value) return null
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+export function normalizeApiKeyCollection(payload: unknown): ApiKeyLifecycleRecord[] {
+  const records: Array<ApiKeyLifecycleRecord | null> = readCollection<RecordValue>(payload, [
+    'items',
+    'keys',
+    'api_keys',
+    'data',
+  ]).map((record) => {
+    const id = readString(record, 'id')
+    if (!id) return null
+
+    return {
+      id,
+      name: readString(record, 'name'),
+      created_at: readString(record, 'created_at'),
+      expires_at: readString(record, 'expires_at'),
+      is_active: typeof record.is_active === 'boolean' ? record.is_active : undefined,
+      last_used: readString(record, 'last_used'),
+      last_used_at: readString(record, 'last_used_at'),
+      status: readString(record, 'status'),
+      scopes: normalizeStringList(record.scopes),
+    }
+  })
+
+  return records.filter((record): record is ApiKeyLifecycleRecord => record !== null)
+}
+
+export function apiKeyLastUsed(key: ApiKeyLifecycleRecord) {
+  return key.last_used_at ?? key.last_used ?? null
+}
+
+export function isApiKeyRevoked(key: ApiKeyLifecycleRecord) {
+  if (typeof key.is_active === 'boolean') {
+    return !key.is_active
+  }
+
+  const normalizedStatus = (key.status ?? '').toLowerCase()
+  return normalizedStatus.includes('revoked') || normalizedStatus.includes('inactive')
+}
+
+export function isApiKeyExpired(key: ApiKeyLifecycleRecord, now = Date.now()) {
+  const expiresAt = toTimestamp(key.expires_at)
+  return expiresAt !== null && expiresAt <= now
+}
+
+export function isApiKeyUsable(key: ApiKeyLifecycleRecord, now = Date.now()) {
+  return !isApiKeyRevoked(key) && !isApiKeyExpired(key, now)
+}
+
+export function apiKeyExpiryMeta(key: ApiKeyLifecycleRecord, now = Date.now()) {
+  const expiresAt = toTimestamp(key.expires_at)
+  if (expiresAt === null) return null
+
+  if (expiresAt <= now) {
+    return { label: 'expired', tone: 'error' as const }
+  }
+
+  const daysUntilExpiry = Math.ceil((expiresAt - now) / 86_400_000)
+  if (daysUntilExpiry <= 7) {
+    return { label: `expires in ${daysUntilExpiry}d`, tone: 'warning' as const }
+  }
+
+  return null
+}
+
+export function apiKeyLifecycleMeta(key: ApiKeyLifecycleRecord, now = Date.now()) {
+  if (isApiKeyRevoked(key)) {
+    return { label: 'revoked', tone: 'idle' as const }
+  }
+
+  if (isApiKeyExpired(key, now)) {
+    return { label: 'expired', tone: 'error' as const }
+  }
+
+  return { label: 'active', tone: 'success' as const }
+}
+
+export function isApiKeyStale(
+  key: ApiKeyLifecycleRecord,
+  now = Date.now(),
+  staleAfterDays = 30,
+) {
+  if (!isApiKeyUsable(key, now)) return false
+
+  const freshnessSignal = toTimestamp(apiKeyLastUsed(key) ?? key.created_at ?? null)
+  if (freshnessSignal === null) return false
+
+  return freshnessSignal < now - staleAfterDays * 86_400_000
+}
+
+export function summarizeApiKeys(keys: ApiKeyLifecycleRecord[], now = Date.now()) {
+  return {
+    active: keys.filter((key) => isApiKeyUsable(key, now)).length,
+    recentlyUsed: keys.filter((key) => {
+      const lastUsed = toTimestamp(apiKeyLastUsed(key))
+      return lastUsed !== null && lastUsed >= now - 7 * 86_400_000
+    }).length,
+    expiringSoon: keys.filter((key) => apiKeyExpiryMeta(key, now)?.tone === 'warning').length,
+    stale: keys.filter((key) => isApiKeyStale(key, now)).length,
+  }
+}
+
+export function normalizeWebhookCollection(payload: unknown): WebhookLifecycleRecord[] {
+  const records: Array<WebhookLifecycleRecord | null> = readCollection<RecordValue>(payload, [
+    'webhooks',
+    'items',
+    'data',
+  ]).map((record) => {
+    const id = readString(record, 'id')
+    const url = readString(record, 'url')
+    if (!id || !url) return null
+
+    return {
+      id,
+      url,
+      events: normalizeStringList(record.events),
+      is_active: readBoolean(record, 'is_active'),
+      created_at: readString(record, 'created_at') ?? '',
+    }
+  })
+
+  return records.filter((record): record is WebhookLifecycleRecord => record !== null)
+}
+
+export function normalizeWebhookDeliveryCollection(payload: unknown): WebhookDeliveryRecord[] {
+  const records: Array<WebhookDeliveryRecord | null> = readCollection<RecordValue>(payload, [
+    'deliveries',
+    'items',
+    'data',
+  ]).map((record) => {
+    const id = readString(record, 'id')
+    if (!id) return null
+
+    const rawPayload = record.payload
+    const payloadText =
+      typeof rawPayload === 'string'
+        ? rawPayload
+        : JSON.stringify(rawPayload ?? {}, null, 2)
+
+    return {
+      id,
+      event: readString(record, 'event') ?? 'unknown',
+      payload: payloadText,
+      status_code: readNumber(record, 'status_code'),
+      success: readBoolean(record, 'success'),
+      error_message: readString(record, 'error_message'),
+      attempts: readNumber(record, 'attempts', 0) ?? 0,
+      created_at: readString(record, 'created_at') ?? new Date(0).toISOString(),
+      delivered_at: readString(record, 'delivered_at'),
+    }
+  })
+
+  return records.filter((record): record is WebhookDeliveryRecord => record !== null)
+}
+
+export function latestWebhookDelivery(deliveries: WebhookDeliveryRecord[]) {
+  return [...deliveries].sort((left, right) => {
+    const leftTime = toTimestamp(left.created_at) ?? 0
+    const rightTime = toTimestamp(right.created_at) ?? 0
+    return rightTime - leftTime
+  })[0] ?? null
+}
+
+export function describeWebhookHealth(
+  webhook: WebhookLifecycleRecord,
+  deliveries: WebhookDeliveryRecord[],
+): WebhookHealthSnapshot {
+  const latest = latestWebhookDelivery(deliveries)
+  const latestAttemptAt = latest?.delivered_at ?? latest?.created_at ?? null
+  const latestSuccessAt =
+    deliveries
+      .filter((delivery) => delivery.success)
+      .sort((left, right) => (toTimestamp(right.created_at) ?? 0) - (toTimestamp(left.created_at) ?? 0))[0]
+      ?.delivered_at ??
+    deliveries
+      .filter((delivery) => delivery.success)
+      .sort((left, right) => (toTimestamp(right.created_at) ?? 0) - (toTimestamp(left.created_at) ?? 0))[0]
+      ?.created_at ??
+    null
+
+  if (!webhook.is_active) {
+    return {
+      label: 'inactive',
+      tone: 'idle',
+      latestAttemptAt,
+      latestSuccessAt,
+      statusCode: latest?.status_code ?? null,
+      attempts: latest?.attempts ?? null,
+      errorMessage: latest?.error_message ?? null,
+    }
+  }
+
+  if (!latest) {
+    return {
+      label: 'no deliveries',
+      tone: 'idle',
+      latestAttemptAt: null,
+      latestSuccessAt: null,
+      statusCode: null,
+      attempts: null,
+      errorMessage: null,
+    }
+  }
+
+  if (latest.success) {
+    return {
+      label: 'healthy',
+      tone: 'success',
+      latestAttemptAt,
+      latestSuccessAt,
+      statusCode: latest.status_code,
+      attempts: latest.attempts,
+      errorMessage: null,
+    }
+  }
+
+  return {
+    label: 'failing',
+    tone: 'error',
+    latestAttemptAt,
+    latestSuccessAt,
+    statusCode: latest.status_code,
+    attempts: latest.attempts,
+    errorMessage: latest.error_message,
+  }
+}
+
+export function summarizeWebhookFleet(
+  webhooks: WebhookLifecycleRecord[],
+  deliveryMap: Record<string, WebhookDeliveryRecord[]>,
+) {
+  return webhooks.reduce(
+    (summary, webhook) => {
+      const health = describeWebhookHealth(webhook, deliveryMap[webhook.id] ?? [])
+      if (webhook.is_active) {
+        summary.active += 1
+      }
+      if (health.label === 'healthy') {
+        summary.healthy += 1
+      } else if (health.label === 'failing') {
+        summary.attention += 1
+      } else if (health.label === 'no deliveries') {
+        summary.noDeliveries += 1
+      }
+      return summary
+    },
+    {
+      active: 0,
+      healthy: 0,
+      attention: 0,
+      noDeliveries: 0,
+    },
+  )
+}

--- a/tests/test_cli_api_keys_contract.py
+++ b/tests/test_cli_api_keys_contract.py
@@ -32,20 +32,24 @@ def test_api_keys_list_hits_canonical_route_and_renders_keys(monkeypatch) -> Non
         captured["path"] = path
         return DummyResponse(
             200,
-            [
-                {
-                    "id": key_id,
-                    "name": "test-key-1",
-                    "is_active": True,
-                    "expires_at": "2026-04-14T10:00:00",
-                },
-                {
-                    "id": str(uuid.uuid4()),
-                    "name": "test-key-2",
-                    "is_active": False,
-                    "expires_at": None,
-                },
-            ],
+            {
+                "items": [
+                    {
+                        "id": key_id,
+                        "name": "test-key-1",
+                        "is_active": True,
+                        "expires_at": "2026-04-20T10:00:00",
+                        "last_used": "2026-04-14T09:30:00",
+                    },
+                    {
+                        "id": str(uuid.uuid4()),
+                        "name": "test-key-2",
+                        "is_active": False,
+                        "expires_at": None,
+                        "last_used": None,
+                    },
+                ]
+            },
         )
 
     monkeypatch.setattr("cli.commands.api_keys.current_config", lambda: DummyConfig())
@@ -61,13 +65,14 @@ def test_api_keys_list_hits_canonical_route_and_renders_keys(monkeypatch) -> Non
     assert key_id in result.output
     assert "test-key-1" in result.output
     assert "active" in result.output
+    assert "last used: 2026-04-14T09:30:00" in result.output
     assert "test-key-2" in result.output
     assert "revoked" in result.output
 
 
 def test_api_keys_list_empty(monkeypatch) -> None:
     def fake_get(path: str, params: dict[str, Any] | None = None) -> DummyResponse:
-        return DummyResponse(200, [])
+        return DummyResponse(200, {"items": []})
 
     monkeypatch.setattr("cli.commands.api_keys.current_config", lambda: DummyConfig())
     monkeypatch.setattr(

--- a/tests/test_cli_api_keys_contract.py
+++ b/tests/test_cli_api_keys_contract.py
@@ -38,7 +38,7 @@ def test_api_keys_list_hits_canonical_route_and_renders_keys(monkeypatch) -> Non
                         "id": key_id,
                         "name": "test-key-1",
                         "is_active": True,
-                        "expires_at": "2026-04-20T10:00:00",
+                        "expires_at": "2099-04-20T10:00:00Z",
                         "last_used": "2026-04-14T09:30:00",
                     },
                     {

--- a/tests/test_cli_webhooks_contract.py
+++ b/tests/test_cli_webhooks_contract.py
@@ -118,11 +118,25 @@ def test_webhooks_deliveries_hits_live_delivery_route_and_query_contract(monkeyp
 
 
 def test_webhooks_get_hits_contract_route_and_prints_created_timestamp(monkeypatch) -> None:
-    captured: dict[str, Any] = {}
+    captured: list[dict[str, Any]] = []
 
     def fake_get(path: str, params: dict[str, Any] | None = None) -> DummyResponse:
-        captured["path"] = path
-        captured["params"] = params
+        captured.append({"path": path, "params": params})
+        if path.endswith("/deliveries"):
+            return DummyResponse(
+                200,
+                [
+                    {
+                        "id": "delivery-1",
+                        "event": "deployment.failed",
+                        "success": False,
+                        "attempts": 2,
+                        "status_code": 502,
+                        "created_at": "2026-03-12T15:05:00",
+                    }
+                ],
+            )
+
         return DummyResponse(
             200,
             {
@@ -143,9 +157,16 @@ def test_webhooks_get_hits_contract_route_and_prints_created_timestamp(monkeypat
     result = runner.invoke(cli, ["webhooks", "get", "wh-456"])
 
     assert result.exit_code == 0
-    assert captured == {
-        "path": "/v1/webhooks/wh-456",
-        "params": None,
-    }
+    assert captured == [
+        {
+            "path": "/v1/webhooks/wh-456",
+            "params": None,
+        },
+        {
+            "path": "/v1/webhooks/wh-456/deliveries",
+            "params": {"skip": 0, "limit": 1},
+        },
+    ]
     assert "wh-456 | https://example.com/hook | inactive" in result.output
     assert "Created: 2026-03-12T15:00:00" in result.output
+    assert "Latest delivery: failed | status=502 | attempts=2 | created=2026-03-12T15:05:00" in result.output

--- a/tests/unit/apiKeyRoutes.test.ts
+++ b/tests/unit/apiKeyRoutes.test.ts
@@ -60,7 +60,7 @@ describe('API key route proxies', () => {
     await expect(response.json()).resolves.toEqual({ detail: 'Forbidden' })
   })
 
-  it('preserves successful list responses', async () => {
+  it('normalizes array list responses into the dashboard collection envelope', async () => {
     hasAuthSession.mockReturnValue(true)
     authenticatedFetch.mockResolvedValue({
       response: {
@@ -74,9 +74,39 @@ describe('API key route proxies', () => {
     const response = await GET(mockRequest())
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual([
-      { id: 'key_111', name: 'deploy-key', is_active: true },
-    ])
+    await expect(response.json()).resolves.toEqual({
+      items: [{ id: 'key_111', name: 'deploy-key', is_active: true }],
+      total: 1,
+      skip: 0,
+      limit: 1,
+    })
+  })
+
+  it('preserves paginated API key list responses', async () => {
+    hasAuthSession.mockReturnValue(true)
+    authenticatedFetch.mockResolvedValue({
+      response: {
+        status: 200,
+        json: async () => ({
+          items: [{ id: 'key_111', name: 'deploy-key', is_active: true }],
+          total: 3,
+          skip: 0,
+          limit: 50,
+        }),
+      },
+      tokenRefreshed: false,
+    })
+
+    const { GET } = await import('../../app/api/api-keys/route')
+    const response = await GET(mockRequest())
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      items: [{ id: 'key_111', name: 'deploy-key', is_active: true }],
+      total: 3,
+      skip: 0,
+      limit: 50,
+    })
   })
 
   it('preserves upstream create conflicts', async () => {

--- a/tests/unit/operatorLifecycle.test.ts
+++ b/tests/unit/operatorLifecycle.test.ts
@@ -1,0 +1,140 @@
+import {
+  apiKeyExpiryMeta,
+  apiKeyLifecycleMeta,
+  describeWebhookHealth,
+  normalizeApiKeyCollection,
+  normalizeWebhookDeliveryCollection,
+  summarizeApiKeys,
+  summarizeWebhookFleet,
+} from '../../lib/operatorLifecycle'
+
+describe('operatorLifecycle helpers', () => {
+  const now = Date.parse('2026-04-14T12:00:00Z')
+
+  it('normalizes API key collections from paginated payloads and summarizes lifecycle state', () => {
+    const keys = normalizeApiKeyCollection({
+      items: [
+        {
+          id: 'key_active',
+          name: 'active-key',
+          is_active: true,
+          created_at: '2026-04-01T12:00:00Z',
+          last_used: '2026-04-14T08:00:00Z',
+          expires_at: '2026-05-20T12:00:00Z',
+        },
+        {
+          id: 'key_expiring',
+          name: 'expiring-key',
+          is_active: true,
+          created_at: '2026-03-01T12:00:00Z',
+          last_used: '2026-03-01T12:00:00Z',
+          expires_at: '2026-04-16T12:00:00Z',
+        },
+        {
+          id: 'key_revoked',
+          name: 'revoked-key',
+          is_active: false,
+          created_at: '2026-03-10T12:00:00Z',
+          expires_at: null,
+        },
+      ],
+    })
+
+    expect(keys).toHaveLength(3)
+    expect(apiKeyLifecycleMeta(keys[0], now)).toEqual({ label: 'active', tone: 'success' })
+    expect(apiKeyExpiryMeta(keys[1], now)).toEqual({ label: 'expires in 2d', tone: 'warning' })
+    expect(apiKeyLifecycleMeta(keys[2], now)).toEqual({ label: 'revoked', tone: 'idle' })
+    expect(summarizeApiKeys(keys, now)).toEqual({
+      active: 2,
+      recentlyUsed: 1,
+      expiringSoon: 1,
+      stale: 1,
+    })
+  })
+
+  it('normalizes webhook delivery payloads and derives fleet health from the latest delivery', () => {
+    const webhooks = [
+      {
+        id: 'wh_healthy',
+        url: 'https://example.com/healthy',
+        events: ['agent.started'],
+        is_active: true,
+        created_at: '2026-04-10T12:00:00Z',
+      },
+      {
+        id: 'wh_failing',
+        url: 'https://example.com/failing',
+        events: ['run.failed'],
+        is_active: true,
+        created_at: '2026-04-10T12:00:00Z',
+      },
+      {
+        id: 'wh_idle',
+        url: 'https://example.com/idle',
+        events: ['deployment.completed'],
+        is_active: true,
+        created_at: '2026-04-10T12:00:00Z',
+      },
+    ]
+
+    const healthyDeliveries = normalizeWebhookDeliveryCollection({
+      deliveries: [
+        {
+          id: 'delivery_healthy',
+          event: 'agent.started',
+          success: true,
+          status_code: 200,
+          attempts: 1,
+          payload: '{"ok":true}',
+          created_at: '2026-04-14T11:55:00Z',
+          delivered_at: '2026-04-14T11:55:02Z',
+          error_message: null,
+        },
+      ],
+    })
+    const failingDeliveries = normalizeWebhookDeliveryCollection({
+      items: [
+        {
+          id: 'delivery_failed',
+          event: 'run.failed',
+          success: false,
+          status_code: 502,
+          attempts: 3,
+          payload: { ok: false },
+          created_at: '2026-04-14T11:50:00Z',
+          delivered_at: null,
+          error_message: 'Bad gateway',
+        },
+      ],
+    })
+
+    expect(describeWebhookHealth(webhooks[0], healthyDeliveries)).toMatchObject({
+      label: 'healthy',
+      tone: 'success',
+      statusCode: 200,
+    })
+    expect(describeWebhookHealth(webhooks[1], failingDeliveries)).toMatchObject({
+      label: 'failing',
+      tone: 'error',
+      statusCode: 502,
+      attempts: 3,
+      errorMessage: 'Bad gateway',
+    })
+    expect(describeWebhookHealth(webhooks[2], [])).toMatchObject({
+      label: 'no deliveries',
+      tone: 'idle',
+    })
+
+    expect(
+      summarizeWebhookFleet(webhooks, {
+        wh_healthy: healthyDeliveries,
+        wh_failing: failingDeliveries,
+      }),
+    ).toEqual({
+      active: 3,
+      healthy: 1,
+      attention: 1,
+      noDeliveries: 1,
+    })
+  })
+})

--- a/tests/unit/webhookDeliveryRoutes.test.ts
+++ b/tests/unit/webhookDeliveryRoutes.test.ts
@@ -1,0 +1,124 @@
+import type { NextRequest } from 'next/server'
+
+const applyAuthCookies = jest.fn()
+const authenticatedFetch = jest.fn()
+const hasAuthSession = jest.fn()
+
+jest.mock('../../app/api/_lib/controlPlane', () => ({
+  getApiBaseUrl: () => 'http://localhost:8000',
+  applyAuthCookies,
+  authenticatedFetch,
+  hasAuthSession,
+}))
+
+function mockRequest(url = 'http://localhost:3000/api/webhooks/wh_123/deliveries') {
+  return {
+    url,
+  } as NextRequest
+}
+
+describe('Webhook delivery route proxy', () => {
+  beforeEach(() => {
+    applyAuthCookies.mockReset()
+    authenticatedFetch.mockReset()
+    hasAuthSession.mockReset()
+  })
+
+  it('returns 401 when no auth session exists', async () => {
+    hasAuthSession.mockReturnValue(false)
+
+    const { GET } = await import('../../app/api/webhooks/[id]/deliveries/route')
+    const response = await GET(mockRequest(), {
+      params: Promise.resolve({ id: 'wh_123' }),
+    })
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      status: 'error',
+      error: { code: 'UNAUTHORIZED', message: 'Unauthorized' },
+    })
+  })
+
+  it('wraps array responses into a deliveries collection payload', async () => {
+    hasAuthSession.mockReturnValue(true)
+    authenticatedFetch.mockResolvedValue({
+      response: {
+        ok: true,
+        status: 200,
+        json: async () => [
+          {
+            id: 'delivery_1',
+            event: 'agent.started',
+            success: true,
+            status_code: 200,
+          },
+        ],
+      },
+      tokenRefreshed: false,
+    })
+
+    const request = mockRequest()
+    const { GET } = await import('../../app/api/webhooks/[id]/deliveries/route')
+    const response = await GET(request, {
+      params: Promise.resolve({ id: 'wh_123' }),
+    })
+
+    expect(authenticatedFetch).toHaveBeenCalledWith(
+      request,
+      'http://localhost:8000/v1/webhooks/wh_123/deliveries?limit=50',
+      {
+        headers: { 'Content-Type': 'application/json' },
+        cache: 'no-store',
+      },
+    )
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      deliveries: [
+        {
+          id: 'delivery_1',
+          event: 'agent.started',
+          success: true,
+          status_code: 200,
+        },
+      ],
+    })
+  })
+
+  it('normalizes wrapped delivery collections from alternate keys', async () => {
+    hasAuthSession.mockReturnValue(true)
+    authenticatedFetch.mockResolvedValue({
+      response: {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          items: [
+            {
+              id: 'delivery_2',
+              event: 'run.failed',
+              success: false,
+              status_code: 502,
+            },
+          ],
+        }),
+      },
+      tokenRefreshed: false,
+    })
+
+    const { GET } = await import('../../app/api/webhooks/[id]/deliveries/route')
+    const response = await GET(mockRequest(), {
+      params: Promise.resolve({ id: 'wh_123' }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      deliveries: [
+        {
+          id: 'delivery_2',
+          event: 'run.failed',
+          success: false,
+          status_code: 502,
+        },
+      ],
+    })
+  })
+})

--- a/tests/unit/webhooksRoutes.test.ts
+++ b/tests/unit/webhooksRoutes.test.ts
@@ -74,6 +74,32 @@ describe('Webhooks route proxies', () => {
       })
     })
 
+    it('normalizes wrapped webhook collections from alternate keys', async () => {
+      hasAuthSession.mockReturnValue(true)
+      authenticatedFetch.mockResolvedValue({
+        response: {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: [
+              { id: 'wh_789', url: 'https://example.com/alt', events: ['agent.started'], is_active: true },
+            ],
+          }),
+        },
+        tokenRefreshed: false,
+      })
+
+      const { GET } = await import('../../app/api/webhooks/route')
+      const response = await GET(mockRequest())
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({
+        webhooks: [
+          { id: 'wh_789', url: 'https://example.com/alt', events: ['agent.started'], is_active: true },
+        ],
+      })
+    })
+
     it('preserves backend error responses', async () => {
       hasAuthSession.mockReturnValue(true)
       authenticatedFetch.mockResolvedValue({


### PR DESCRIPTION
## Summary
- normalize API-key and webhook dashboard proxy envelopes around the current live backend fields
- deepen the dashboard lifecycle story with key expiry/staleness cues and webhook latest-delivery health
- align CLI output and tests with the same active/revoked/expired/delivery-health semantics

## Validation
- /Users/fortune/MUTX/node_modules/.bin/jest --runInBand tests/unit/apiKeyRoutes.test.ts tests/unit/webhooksRoutes.test.ts tests/unit/webhookDeliveryRoutes.test.ts tests/unit/operatorLifecycle.test.ts
- /Users/fortune/MUTX/.venv/bin/python -m pytest tests/test_cli_api_keys_contract.py tests/test_cli_webhooks_contract.py -q
- npm run typecheck
- python3 -m compileall cli

Closes #3592