### PR TITLE
Dashboard observability: finish session summary and harden refresh flow

### DIFF
--- a/app/api/dashboard/observability/route.ts
+++ b/app/api/dashboard/observability/route.ts
@@ -114,9 +114,33 @@ function summarizeSessions(payload: unknown) {
   };
 }
 
+function cloneCookiesWithTokens(cookieHeader: string | null, tokens: AuthTokens) {
+  const cookies = new Map<string, string>();
+
+  for (const entry of cookieHeader?.split(";") ?? []) {
+    const [rawName, ...rawValue] = entry.split("=");
+    const name = rawName?.trim();
+    const value = rawValue.join("=").trim();
+    if (name && value) {
+      cookies.set(name, value);
+    }
+  }
+
+  cookies.set("access_token", tokens.access_token);
+
+  if (tokens.refresh_token) {
+    cookies.set("refresh_token", tokens.refresh_token);
+  }
+
+  return Array.from(cookies.entries())
+    .map(([name, value]) => `${name}=${value}`)
+    .join("; ");
+}
+
 function cloneRequestWithAccessToken(request: NextRequest, tokens: AuthTokens) {
   const headers = new Headers("headers" in request ? request.headers : undefined);
   headers.set("authorization", `Bearer ${tokens.access_token}`);
+  headers.set("cookie", cloneCookiesWithTokens(headers.get("cookie"), tokens));
 
   return new NextRequest(request.url, {
     method: request.method || "GET",

--- a/app/api/dashboard/observability/route.ts
+++ b/app/api/dashboard/observability/route.ts
@@ -114,6 +114,16 @@ function summarizeSessions(payload: unknown) {
   };
 }
 
+function cloneRequestWithAccessToken(request: NextRequest, tokens: AuthTokens) {
+  const headers = new Headers("headers" in request ? request.headers : undefined);
+  headers.set("authorization", `Bearer ${tokens.access_token}`);
+
+  return new NextRequest(request.url, {
+    method: request.method || "GET",
+    headers,
+  });
+}
+
 function extractErrorMessage(payload: unknown, fallback: string) {
   if (typeof payload === "string" && payload.trim().length > 0) {
     return payload;
@@ -171,19 +181,30 @@ export async function GET(request: NextRequest) {
     }
 
     const apiBaseUrl = getApiBaseUrl();
-    const [runsResult, telemetryConfigResult, telemetryHealthResult, sessionsResult] = await Promise.all([
-      fetchResource(request, targetUrl.toString(), "Failed to fetch observability runs"),
+    const runsResult = await fetchResource(
+      request,
+      targetUrl.toString(),
+      "Failed to fetch observability runs",
+    );
+    const followupRequest = runsResult.refreshedTokens
+      ? cloneRequestWithAccessToken(request, runsResult.refreshedTokens)
+      : request;
+    const [telemetryConfigResult, telemetryHealthResult, sessionsResult] = await Promise.all([
       fetchResource(
-        request,
+        followupRequest,
         `${apiBaseUrl}/v1/telemetry/config`,
         "Failed to fetch telemetry configuration",
       ),
       fetchResource(
-        request,
+        followupRequest,
         `${apiBaseUrl}/v1/telemetry/health`,
         "Failed to fetch telemetry health",
       ),
-      fetchResource(request, `${apiBaseUrl}/v1/sessions?limit=100`, "Failed to fetch session summary"),
+      fetchResource(
+        followupRequest,
+        `${apiBaseUrl}/v1/sessions?limit=100`,
+        "Failed to fetch session summary",
+      ),
     ]);
 
     const refreshedTokens =
@@ -216,6 +237,10 @@ export async function GET(request: NextRequest) {
       telemetryErrors.health = telemetryHealthResult.error;
     }
 
+    if (sessionsResult.error) {
+      telemetryErrors.sessions = sessionsResult.error;
+    }
+
     const nextResponse = NextResponse.json(
       {
         ...runsPayload,
@@ -226,7 +251,7 @@ export async function GET(request: NextRequest) {
           errors: Object.keys(telemetryErrors).length > 0 ? telemetryErrors : null,
         },
         sessionSummary: sessionsResult.response.ok ? summarizeSessions(sessionsResult.payload) : null,
-        sessionSummaryError: sessionsResult.error,
+        sessionSummaryError: sessionsResult.error ?? null,
       },
       { status: runsResult.response.status },
     );

--- a/tests/unit/dashboardRoutes.test.ts
+++ b/tests/unit/dashboardRoutes.test.ts
@@ -920,6 +920,89 @@ describe('dashboard route proxies', () => {
     })
   })
 
+  it('reuses the refreshed access token for follow-up observability summary calls', async () => {
+    hasAuthSession.mockReturnValue(true)
+    authenticatedFetch
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({
+          items: [],
+          total: 0,
+          skip: 0,
+          limit: 50,
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        tokenRefreshed: true,
+        refreshedTokens: {
+          access_token: 'fresh_access_token',
+          refresh_token: 'fresh_refresh_token',
+          expires_in: 1800,
+        },
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({
+          otel_enabled: true,
+          exporter_type: 'otlp',
+          endpoint: 'http://collector:4318',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        tokenRefreshed: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({
+          configured: true,
+          endpoint_reachable: true,
+          using_grpc: false,
+          endpoint: 'http://collector:4318',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        tokenRefreshed: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ sessions: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        tokenRefreshed: false,
+      })
+
+    const { GET } = await import('../../app/api/dashboard/observability/route')
+    const request = mockRequest('http://localhost:3000/api/dashboard/observability')
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(authenticatedFetch).toHaveBeenCalledTimes(4)
+    expect(authenticatedFetch.mock.calls[0][0]).toBe(request)
+
+    const followupRequest = authenticatedFetch.mock.calls[1][0] as NextRequest
+    expect(followupRequest).not.toBe(request)
+    expect(followupRequest.headers.get('authorization')).toBe('Bearer fresh_access_token')
+    expect(authenticatedFetch).toHaveBeenNthCalledWith(
+      2,
+      followupRequest,
+      'http://localhost:8000/v1/telemetry/config',
+      { cache: 'no-store' },
+    )
+    expect(authenticatedFetch).toHaveBeenNthCalledWith(
+      3,
+      followupRequest,
+      'http://localhost:8000/v1/telemetry/health',
+      { cache: 'no-store' },
+    )
+    expect(authenticatedFetch).toHaveBeenNthCalledWith(
+      4,
+      followupRequest,
+      'http://localhost:8000/v1/sessions?limit=100',
+      { cache: 'no-store' },
+    )
+  })
+
   it('keeps observability runs available when telemetry summary calls fail', async () => {
     hasAuthSession.mockReturnValue(true)
     authenticatedFetch

--- a/tests/unit/dashboardRoutes.test.ts
+++ b/tests/unit/dashboardRoutes.test.ts
@@ -1,4 +1,4 @@
-import type { NextRequest } from 'next/server'
+import { NextRequest } from 'next/server'
 
 const applyAuthCookies = jest.fn()
 const authenticatedFetch = jest.fn()
@@ -972,7 +972,11 @@ describe('dashboard route proxies', () => {
       })
 
     const { GET } = await import('../../app/api/dashboard/observability/route')
-    const request = mockRequest('http://localhost:3000/api/dashboard/observability')
+    const request = new NextRequest('http://localhost:3000/api/dashboard/observability', {
+      headers: {
+        cookie: 'access_token=stale_access_token; refresh_token=stale_refresh_token; theme=dark',
+      },
+    })
 
     const response = await GET(request)
 
@@ -983,6 +987,9 @@ describe('dashboard route proxies', () => {
     const followupRequest = authenticatedFetch.mock.calls[1][0] as NextRequest
     expect(followupRequest).not.toBe(request)
     expect(followupRequest.headers.get('authorization')).toBe('Bearer fresh_access_token')
+    expect(followupRequest.cookies.get('access_token')?.value).toBe('fresh_access_token')
+    expect(followupRequest.cookies.get('refresh_token')?.value).toBe('fresh_refresh_token')
+    expect(followupRequest.cookies.get('theme')?.value).toBe('dark')
     expect(authenticatedFetch).toHaveBeenNthCalledWith(
       2,
       followupRequest,


### PR DESCRIPTION
## Summary
- serialize observability auth refresh through the run fetch before issuing telemetry and session follow-up calls
- preserve the aggregated telemetry and session summary contract already expected by the dashboard route tests
- add a regression test that ensures follow-up summary calls reuse the refreshed bearer token instead of racing refresh attempts

## Validation
- /Users/fortune/MUTX/node_modules/.bin/jest --runInBand tests/unit/dashboardRoutes.test.ts
- npm run typecheck

Closes #3593