### PR TITLE
dashboard/cli: unify webhook and API-key readiness cues

### DIFF
--- a/cli/commands/api_keys.py
+++ b/cli/commands/api_keys.py
@@ -2,6 +2,11 @@ import click
 from typing import Optional
 
 from cli.config import current_config, get_client
+from cli.operator_readiness import (
+    api_key_last_used,
+    describe_api_key_lifecycle,
+    describe_api_key_readiness,
+)
 
 
 @click.group(name="api-keys")
@@ -29,15 +34,21 @@ def list_api_keys():
         click.echo(f"Error: {response.text}", err=True)
         return
 
-    keys = response.json()
+    payload = response.json()
+    keys = payload.get("items", payload) if isinstance(payload, dict) else payload
     if not keys:
         click.echo("No API keys found.")
         return
 
     for key in keys:
-        active = "active" if key.get("is_active") else "revoked"
+        lifecycle = describe_api_key_lifecycle(key)
+        readiness = describe_api_key_readiness(key) or lifecycle
         expires = key.get("expires_at") or "never"
-        click.echo(f"{key['id']} | {key['name']} | {active} | expires: {expires}")
+        last_used = api_key_last_used(key) or "never"
+        click.echo(
+            f"{key['id']} | {key['name']} | state={lifecycle} | health={readiness} | "
+            f"last used: {last_used} | expires: {expires}"
+        )
 
 
 @api_keys_group.command(name="create")

--- a/cli/commands/webhooks.py
+++ b/cli/commands/webhooks.py
@@ -2,6 +2,7 @@ import click
 from typing import Any, Optional
 
 from cli.config import current_config, get_client
+from cli.operator_readiness import describe_webhook_delivery_health, describe_webhook_lifecycle
 
 
 @click.group(name="webhooks")
@@ -31,15 +32,45 @@ def list_webhooks(limit: int, skip: int):
         click.echo(f"Error: {response.text}", err=True)
         return
 
-    webhooks = response.json()
+    payload = response.json()
+    webhooks = payload.get("items", payload) if isinstance(payload, dict) else payload
     if not webhooks:
         click.echo("No webhooks found.")
         return
 
     for webhook in webhooks:
-        active = "active" if webhook.get("is_active", False) else "inactive"
+        lifecycle = describe_webhook_lifecycle(webhook)
+        delivery = lifecycle
+        last_delivery = "never"
+
+        if lifecycle == "active":
+            delivery_response = client.get(
+                f"/v1/webhooks/{webhook['id']}/deliveries",
+                params={"limit": 5, "skip": 0},
+            )
+            if delivery_response.status_code == 200:
+                delivery_payload = delivery_response.json()
+                deliveries = (
+                    delivery_payload.get("deliveries", delivery_payload)
+                    if isinstance(delivery_payload, dict)
+                    else delivery_payload
+                )
+                delivery = describe_webhook_delivery_health(webhook, deliveries)
+                if deliveries:
+                    latest_delivery = deliveries[0]
+                    last_delivery = (
+                        latest_delivery.get("created_at")
+                        or latest_delivery.get("delivered_at")
+                        or "unknown"
+                    )
+            else:
+                delivery = "delivery-data-unavailable"
+
         events = ",".join(webhook.get("events", [])) or "*"
-        click.echo(f"{webhook['id']} | {webhook['url']} | {active} | events: {events}")
+        click.echo(
+            f"{webhook['id']} | {webhook['url']} | state={lifecycle} | delivery={delivery} | "
+            f"last delivery: {last_delivery} | events: {events}"
+        )
 
 
 @webhooks_group.command(name="deliveries")
@@ -78,7 +109,8 @@ def webhook_deliveries(
         click.echo(f"Error: {response.text}", err=True)
         return
 
-    deliveries = response.json()
+    payload = response.json()
+    deliveries = payload.get("deliveries", payload) if isinstance(payload, dict) else payload
     if not deliveries:
         click.echo("No webhook deliveries found.")
         return
@@ -114,7 +146,37 @@ def get_webhook(webhook_id: str):
         return
 
     webhook = response.json()
-    active = "active" if webhook.get("is_active", False) else "inactive"
-    click.echo(f"{webhook['id']} | {webhook['url']} | {active}")
+    lifecycle = describe_webhook_lifecycle(webhook)
+    click.echo(f"{webhook['id']} | {webhook['url']} | state={lifecycle}")
     click.echo(f"Events: {','.join(webhook.get('events', [])) or '*'}")
     click.echo(f"Created: {webhook.get('created_at')}")
+
+
+@webhooks_group.command(name="test")
+@click.argument("webhook_id")
+def test_webhook(webhook_id: str):
+    """Trigger a test delivery for a webhook"""
+    config = current_config()
+    if not config.is_authenticated():
+        click.echo("Error: Not authenticated. Run 'mutx login' first.", err=True)
+        return
+
+    client = get_client(config)
+    response = client.post(f"/v1/webhooks/{webhook_id}/test")
+
+    if response.status_code == 401:
+        click.echo("Error: Authentication expired. Run 'mutx login' again.", err=True)
+        return
+
+    if response.status_code == 404:
+        click.echo("Error: Webhook not found", err=True)
+        return
+
+    if response.status_code != 200:
+        click.echo(f"Error: {response.text}", err=True)
+        return
+
+    payload = response.json()
+    click.echo(f"Triggered webhook test: {webhook_id}")
+    if isinstance(payload, dict) and payload.get("message"):
+        click.echo(str(payload["message"]))

--- a/cli/operator_readiness.py
+++ b/cli/operator_readiness.py
@@ -100,9 +100,9 @@ def describe_webhook_delivery_health(
         return "not-exercised"
 
     def delivery_time(delivery: Mapping[str, Any]) -> datetime:
-        return parse_datetime(delivery.get("created_at") or delivery.get("delivered_at")) or datetime.min.replace(
-            tzinfo=timezone.utc
-        )
+        return parse_datetime(
+            delivery.get("created_at") or delivery.get("delivered_at")
+        ) or datetime.min.replace(tzinfo=timezone.utc)
 
     sorted_deliveries = sorted(deliveries, key=delivery_time, reverse=True)
     latest = sorted_deliveries[0]

--- a/cli/operator_readiness.py
+++ b/cli/operator_readiness.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+API_KEY_EXPIRING_SOON_DAYS = 7
+API_KEY_UNUSED_DAYS = 7
+API_KEY_STALE_DAYS = 30
+WEBHOOK_STALE_DAYS = 7
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+
+    return parsed.astimezone(timezone.utc)
+
+
+def api_key_last_used(key: Mapping[str, Any]) -> str | None:
+    last_used_at = key.get("last_used_at")
+    if isinstance(last_used_at, str) and last_used_at:
+        return last_used_at
+
+    last_used = key.get("last_used")
+    if isinstance(last_used, str) and last_used:
+        return last_used
+
+    return None
+
+
+def describe_api_key_lifecycle(key: Mapping[str, Any], now: datetime | None = None) -> str:
+    current_time = now or utc_now()
+
+    is_active = key.get("is_active")
+    if isinstance(is_active, bool) and not is_active:
+        return "revoked"
+
+    status = str(key.get("status") or "").lower()
+    if "revoked" in status or "inactive" in status:
+        return "revoked"
+
+    expires_at = parse_datetime(key.get("expires_at"))
+    if expires_at is not None and expires_at <= current_time:
+        return "expired"
+
+    return "active"
+
+
+def describe_api_key_readiness(key: Mapping[str, Any], now: datetime | None = None) -> str | None:
+    current_time = now or utc_now()
+
+    if describe_api_key_lifecycle(key, current_time) != "active":
+        return None
+
+    expires_at = parse_datetime(key.get("expires_at"))
+    if expires_at is not None:
+        days_until_expiry = (expires_at - current_time).days
+        if days_until_expiry <= API_KEY_EXPIRING_SOON_DAYS:
+            return "expires-soon"
+
+    last_used = parse_datetime(api_key_last_used(key))
+    created_at = parse_datetime(key.get("created_at"))
+    if last_used is None and created_at is not None:
+        if (current_time - created_at).days >= API_KEY_UNUSED_DAYS:
+            return "unused"
+
+    if last_used is not None and (current_time - last_used).days >= API_KEY_STALE_DAYS:
+        return "stale"
+
+    return "ready"
+
+
+def describe_webhook_lifecycle(webhook: Mapping[str, Any]) -> str:
+    return "active" if bool(webhook.get("is_active")) else "inactive"
+
+
+def describe_webhook_delivery_health(
+    webhook: Mapping[str, Any],
+    deliveries: Sequence[Mapping[str, Any]],
+    now: datetime | None = None,
+) -> str:
+    current_time = now or utc_now()
+
+    if describe_webhook_lifecycle(webhook) != "active":
+        return "inactive"
+
+    if not deliveries:
+        return "not-exercised"
+
+    def delivery_time(delivery: Mapping[str, Any]) -> datetime:
+        return parse_datetime(delivery.get("created_at") or delivery.get("delivered_at")) or datetime.min.replace(
+            tzinfo=timezone.utc
+        )
+
+    sorted_deliveries = sorted(deliveries, key=delivery_time, reverse=True)
+    latest = sorted_deliveries[0]
+    latest_time = delivery_time(latest)
+    recent_failures = sum(1 for delivery in sorted_deliveries if not bool(delivery.get("success")))
+
+    if not bool(latest.get("success")):
+        return "failing"
+
+    if (current_time - latest_time).days >= WEBHOOK_STALE_DAYS:
+        return "stale"
+
+    if recent_failures > 0:
+        return "recovering"
+
+    return "healthy"

--- a/components/app/operatorReadiness.ts
+++ b/components/app/operatorReadiness.ts
@@ -1,0 +1,256 @@
+import type { DashboardStatus } from '@/components/dashboard/types'
+
+const DAY_MS = 86_400_000
+const API_KEY_EXPIRING_SOON_DAYS = 7
+const API_KEY_UNUSED_DAYS = 7
+const API_KEY_STALE_DAYS = 30
+const WEBHOOK_STALE_DAYS = 7
+
+export type ApiKeyLifecycleInput = {
+  created_at?: string | null
+  expires_at?: string | null
+  is_active?: boolean | null
+  last_used?: string | null
+  last_used_at?: string | null
+  status?: string | null
+}
+
+export type WebhookLifecycleInput = {
+  created_at?: string | null
+  is_active?: boolean | null
+}
+
+export type WebhookDeliveryInput = {
+  attempts?: number | null
+  created_at?: string | null
+  delivered_at?: string | null
+  error_message?: string | null
+  status_code?: number | null
+  success?: boolean | null
+}
+
+export type ReadinessSignal = {
+  detail: string
+  label: string
+  status: DashboardStatus
+}
+
+export type WebhookDeliverySignal = ReadinessSignal & {
+  lastDeliveryAt: string | null
+  lastStatusCode: number | null
+  recentAttempts: number
+  recentFailures: number
+}
+
+function toTime(value?: string | null) {
+  if (!value) return null
+
+  const time = new Date(value).getTime()
+  return Number.isNaN(time) ? null : time
+}
+
+function daysUntil(targetTime: number, now: number) {
+  return Math.ceil((targetTime - now) / DAY_MS)
+}
+
+function daysSince(timestamp: number, now: number) {
+  return Math.floor((now - timestamp) / DAY_MS)
+}
+
+function isApiKeyRevoked(key: ApiKeyLifecycleInput) {
+  if (typeof key.is_active === 'boolean') {
+    return !key.is_active
+  }
+
+  const normalizedStatus = (key.status ?? '').toLowerCase()
+  return normalizedStatus.includes('revoked') || normalizedStatus.includes('inactive')
+}
+
+export function getApiKeyLastUsed(key: ApiKeyLifecycleInput) {
+  return key.last_used_at ?? key.last_used ?? null
+}
+
+export function getApiKeyLifecycleState(
+  key: ApiKeyLifecycleInput,
+  now: number = Date.now(),
+): ReadinessSignal {
+  if (isApiKeyRevoked(key)) {
+    return {
+      detail: 'This key has been revoked and is retained only for audit history.',
+      label: 'revoked',
+      status: 'idle',
+    }
+  }
+
+  const expiresAt = toTime(key.expires_at)
+  if (expiresAt !== null && expiresAt <= now) {
+    return {
+      detail: 'This key has passed its expiry and will no longer authenticate requests.',
+      label: 'expired',
+      status: 'error',
+    }
+  }
+
+  return {
+    detail: 'This key can still authenticate requests.',
+    label: 'active',
+    status: 'success',
+  }
+}
+
+export function isApiKeyUsable(key: ApiKeyLifecycleInput, now: number = Date.now()) {
+  return getApiKeyLifecycleState(key, now).label === 'active'
+}
+
+export function getApiKeyReadinessSignal(
+  key: ApiKeyLifecycleInput,
+  now: number = Date.now(),
+): ReadinessSignal | null {
+  if (!isApiKeyUsable(key, now)) {
+    return null
+  }
+
+  const expiresAt = toTime(key.expires_at)
+  if (expiresAt !== null) {
+    const days = daysUntil(expiresAt, now)
+    if (days <= API_KEY_EXPIRING_SOON_DAYS) {
+      return {
+        detail: `Rotation window is open because the key expires in ${days}d.`,
+        label: 'expires soon',
+        status: 'warning',
+      }
+    }
+  }
+
+  const lastUsed = toTime(getApiKeyLastUsed(key))
+  const createdAt = toTime(key.created_at)
+
+  if (lastUsed === null && createdAt !== null && daysSince(createdAt, now) >= API_KEY_UNUSED_DAYS) {
+    return {
+      detail: 'No usage has been recorded since the key was created.',
+      label: 'unused',
+      status: 'warning',
+    }
+  }
+
+  if (lastUsed !== null && daysSince(lastUsed, now) >= API_KEY_STALE_DAYS) {
+    return {
+      detail: 'No usage has been recorded in the last 30 days.',
+      label: 'stale',
+      status: 'warning',
+    }
+  }
+
+  return {
+    detail: 'Recent usage and expiry posture look healthy.',
+    label: 'ready',
+    status: 'success',
+  }
+}
+
+function sortDeliveriesByNewest(deliveries: WebhookDeliveryInput[]) {
+  return [...deliveries].sort((left, right) => {
+    const leftTime = toTime(left.created_at ?? left.delivered_at) ?? 0
+    const rightTime = toTime(right.created_at ?? right.delivered_at) ?? 0
+    return rightTime - leftTime
+  })
+}
+
+export function getWebhookLifecycleState(webhook: WebhookLifecycleInput): ReadinessSignal {
+  if (!webhook.is_active) {
+    return {
+      detail: 'This route is paused and will not receive delivery attempts.',
+      label: 'inactive',
+      status: 'idle',
+    }
+  }
+
+  return {
+    detail: 'This route can receive live test and event deliveries.',
+    label: 'active',
+    status: 'success',
+  }
+}
+
+export function getWebhookDeliverySignal(
+  webhook: WebhookLifecycleInput,
+  deliveries: WebhookDeliveryInput[],
+  now: number = Date.now(),
+): WebhookDeliverySignal {
+  if (!webhook.is_active) {
+    return {
+      ...getWebhookLifecycleState(webhook),
+      lastDeliveryAt: null,
+      lastStatusCode: null,
+      recentAttempts: 0,
+      recentFailures: 0,
+    }
+  }
+
+  const sortedDeliveries = sortDeliveriesByNewest(deliveries)
+  const latestDelivery = sortedDeliveries[0]
+
+  if (!latestDelivery) {
+    return {
+      detail: 'No deliveries are recorded yet for this route.',
+      label: 'not exercised',
+      lastDeliveryAt: null,
+      lastStatusCode: null,
+      recentAttempts: 0,
+      recentFailures: 0,
+      status: 'idle',
+    }
+  }
+
+  const lastDeliveryAt = latestDelivery.created_at ?? latestDelivery.delivered_at ?? null
+  const lastDeliveryTime = toTime(lastDeliveryAt)
+  const recentFailures = sortedDeliveries.filter((delivery) => !delivery.success).length
+  const lastStatusCode =
+    typeof latestDelivery.status_code === 'number' ? latestDelivery.status_code : null
+
+  if (!latestDelivery.success) {
+    return {
+      detail: `Latest delivery failed${lastStatusCode ? ` with ${lastStatusCode}` : ''}.`,
+      label: 'failing',
+      lastDeliveryAt,
+      lastStatusCode,
+      recentAttempts: sortedDeliveries.length,
+      recentFailures,
+      status: 'error',
+    }
+  }
+
+  if (lastDeliveryTime !== null && daysSince(lastDeliveryTime, now) >= WEBHOOK_STALE_DAYS) {
+    return {
+      detail: 'No delivery has been recorded in the last 7 days.',
+      label: 'stale',
+      lastDeliveryAt,
+      lastStatusCode,
+      recentAttempts: sortedDeliveries.length,
+      recentFailures,
+      status: 'warning',
+    }
+  }
+
+  if (recentFailures > 0) {
+    return {
+      detail: `Latest delivery recovered after ${recentFailures} recent failure${recentFailures === 1 ? '' : 's'}.`,
+      label: 'recovering',
+      lastDeliveryAt,
+      lastStatusCode,
+      recentAttempts: sortedDeliveries.length,
+      recentFailures,
+      status: 'warning',
+    }
+  }
+
+  return {
+    detail: 'Recent delivery sample is succeeding.',
+    label: 'healthy',
+    lastDeliveryAt,
+    lastStatusCode,
+    recentAttempts: sortedDeliveries.length,
+    recentFailures: 0,
+    status: 'success',
+  }
+}

--- a/components/dashboard/ApiKeysPageClient.tsx
+++ b/components/dashboard/ApiKeysPageClient.tsx
@@ -5,6 +5,12 @@ import { Copy, KeyRound, RefreshCcw, Trash2 } from "lucide-react";
 
 import { ApiRequestError, normalizeCollection, readJson } from "@/components/app/http";
 import {
+  getApiKeyLastUsed,
+  getApiKeyLifecycleState,
+  getApiKeyReadinessSignal,
+  isApiKeyUsable,
+} from "@/components/app/operatorReadiness";
+import {
   LiveAuthRequired,
   LiveEmptyState,
   LiveErrorState,
@@ -48,51 +54,9 @@ function isApiKeyCreateResponse(value: unknown): value is ApiKeyCreateResponse {
   );
 }
 
-function keyLastUsed(key: ApiKeyRecord) {
-  return key.last_used_at ?? key.last_used ?? null;
-}
-
-function isKeyActive(key: ApiKeyRecord) {
-  if (typeof key.is_active === "boolean") {
-    return key.is_active;
-  }
-
-  const normalizedStatus = (key.status ?? "").toLowerCase();
-  if (normalizedStatus.includes("revoked") || normalizedStatus.includes("inactive")) {
-    return false;
-  }
-
-  if (key.expires_at) {
-    const expiresAt = new Date(key.expires_at).getTime();
-    if (!Number.isNaN(expiresAt) && expiresAt <= Date.now()) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 function maskKeyId(id: string) {
   if (id.length <= 10) return id;
   return `${id.slice(0, 6)}...${id.slice(-4)}`;
-}
-
-function getExpiryLabel(expiresAt?: string | null) {
-  if (!expiresAt) return null;
-
-  const millis = new Date(expiresAt).getTime();
-  if (Number.isNaN(millis)) return null;
-
-  if (millis <= Date.now()) {
-    return { label: "expired", status: "error" as const };
-  }
-
-  const daysUntilExpiry = Math.ceil((millis - Date.now()) / 86_400_000);
-  if (daysUntilExpiry <= 7) {
-    return { label: `expires in ${daysUntilExpiry}d`, status: "warning" as const };
-  }
-
-  return null;
 }
 
 function sortKeys(keys: ApiKeyRecord[]) {
@@ -153,14 +117,11 @@ export function ApiKeysPageClient() {
     };
   }, []);
 
-  const activeKeys = useMemo(
-    () => keys.filter((key) => isKeyActive(key)),
-    [keys],
-  );
+  const activeKeys = useMemo(() => keys.filter((key) => isApiKeyUsable(key)), [keys]);
   const recentlyUsedKeys = useMemo(
     () =>
       keys.filter((key) => {
-        const lastUsed = keyLastUsed(key);
+        const lastUsed = getApiKeyLastUsed(key);
         if (!lastUsed) return false;
         const millis = new Date(lastUsed).getTime();
         return !Number.isNaN(millis) && millis >= Date.now() - 7 * 86_400_000;
@@ -168,7 +129,15 @@ export function ApiKeysPageClient() {
     [keys],
   );
   const expiringSoon = useMemo(
-    () => activeKeys.filter((key) => getExpiryLabel(key.expires_at)?.status === "warning"),
+    () => activeKeys.filter((key) => getApiKeyReadinessSignal(key)?.label === "expires soon"),
+    [activeKeys],
+  );
+  const attentionKeys = useMemo(
+    () =>
+      activeKeys.filter((key) => {
+        const readiness = getApiKeyReadinessSignal(key);
+        return Boolean(readiness && readiness.status !== "success");
+      }),
     [activeKeys],
   );
 
@@ -296,10 +265,10 @@ export function ApiKeysPageClient() {
           detail="Keys with a recent `last used` signal in the last 7 days."
         />
         <LiveStatCard
-          label="Expiring soon"
-          value={String(expiringSoon.length)}
-          detail="Active keys expiring within the next 7 days."
-          status={asDashboardStatus(expiringSoon.length > 0 ? "warning" : "healthy")}
+          label="Attention needed"
+          value={String(attentionKeys.length)}
+          detail={`Includes ${expiringSoon.length} key${expiringSoon.length === 1 ? "" : "s"} in the 7-day rotation window.`}
+          status={asDashboardStatus(attentionKeys.length > 0 ? "warning" : "healthy")}
         />
         <LiveStatCard
           label="One-time reveal"
@@ -379,7 +348,7 @@ export function ApiKeysPageClient() {
             ) : null}
           </LivePanel>
 
-          <LivePanel title="Key registry" meta={`${keys.length} records`}>
+          <LivePanel title="Key registry" meta={`${keys.length} records · ${attentionKeys.length} attention`}>
             {keys.length === 0 ? (
               <LiveEmptyState
                 title="No API keys provisioned yet"
@@ -388,9 +357,10 @@ export function ApiKeysPageClient() {
             ) : (
               <div className="space-y-3">
                 {keys.map((key) => {
-                  const lastUsed = keyLastUsed(key);
-                  const active = isKeyActive(key);
-                  const expiry = getExpiryLabel(key.expires_at);
+                  const lastUsed = getApiKeyLastUsed(key);
+                  const lifecycle = getApiKeyLifecycleState(key);
+                  const readiness = getApiKeyReadinessSignal(key);
+                  const active = lifecycle.label === "active";
 
                   return (
                     <div key={key.id} className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
@@ -398,13 +368,8 @@ export function ApiKeysPageClient() {
                         <div className="min-w-0">
                           <div className="flex flex-wrap items-center gap-2">
                             <p className="truncate text-sm font-medium text-white">{key.name}</p>
-                            <StatusBadge
-                              status={active ? "success" : "idle"}
-                              label={active ? "active" : "inactive"}
-                            />
-                            {expiry ? (
-                              <StatusBadge status={expiry.status} label={expiry.label} />
-                            ) : null}
+                            <StatusBadge status={lifecycle.status} label={lifecycle.label} />
+                            {readiness ? <StatusBadge status={readiness.status} label={readiness.label} /> : null}
                           </div>
                           <p className="mt-2 font-mono text-xs text-slate-500">{maskKeyId(key.id)}</p>
                           <div className="mt-3 grid gap-2 text-xs text-slate-500 sm:grid-cols-2">
@@ -413,7 +378,7 @@ export function ApiKeysPageClient() {
                               last used {lastUsed ? formatRelativeTime(lastUsed) : "never"}
                             </div>
                             <div>expires {key.expires_at ? formatDateTime(key.expires_at) : "no expiry"}</div>
-                            <div>scopes {(key.scopes ?? []).join(", ") || "default"}</div>
+                            <div>operator health {readiness?.detail ?? lifecycle.detail}</div>
                           </div>
                         </div>
 

--- a/components/webhooks/WebhooksPageClient.tsx
+++ b/components/webhooks/WebhooksPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Plus,
   Search,
@@ -21,7 +21,16 @@ import {
 } from "lucide-react";
 import { Card } from "@/components/ui/Card";
 import { readJson, writeJson } from "@/components/app/http";
-import { LiveAuthRequired } from "@/components/dashboard/livePrimitives";
+import {
+  getWebhookDeliverySignal,
+  getWebhookLifecycleState,
+  type WebhookDeliverySignal,
+} from "@/components/app/operatorReadiness";
+import {
+  LiveAuthRequired,
+  formatRelativeTime,
+} from "@/components/dashboard/livePrimitives";
+import { StatusBadge } from "@/components/dashboard/StatusBadge";
 
 type WebhookDelivery = {
   id: string;
@@ -101,6 +110,7 @@ function normalizeDeliveries(payload: unknown): WebhookDelivery[] {
 
 export default function WebhooksPageClient() {
   const [webhooks, setWebhooks] = useState<Webhook[]>([]);
+  const [deliverySignals, setDeliverySignals] = useState<Record<string, WebhookDeliverySignal>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
@@ -115,6 +125,7 @@ export default function WebhooksPageClient() {
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const deliverySignalRequestRef = useRef(0);
   const [isMac, setIsMac] = useState(false);
 
   useEffect(() => {
@@ -154,6 +165,35 @@ export default function WebhooksPageClient() {
       )
     : webhooks;
 
+  const readinessSummary = useMemo(() => {
+    const summary = {
+      active: 0,
+      attention: 0,
+      healthy: 0,
+      notExercised: 0,
+    };
+
+    for (const webhook of webhooks) {
+      if (!webhook.is_active) continue;
+      summary.active += 1;
+
+      const signal = deliverySignals[webhook.id];
+      if (!signal) continue;
+
+      if (signal.status === "success") {
+        summary.healthy += 1;
+      }
+      if (signal.status === "warning" || signal.status === "error") {
+        summary.attention += 1;
+      }
+      if (signal.label === "not exercised") {
+        summary.notExercised += 1;
+      }
+    }
+
+    return summary;
+  }, [deliverySignals, webhooks]);
+
   const hasAuthError = Boolean(error && /unauthorized|forbidden|auth|token|sign in|login/i.test(error));
 
   async function fetchWebhooks() {
@@ -161,13 +201,52 @@ export default function WebhooksPageClient() {
       setLoading(true);
       setError(null);
       const data = await readJson<unknown>("/api/webhooks");
-      setWebhooks(normalizeWebhooks(data));
+      const nextWebhooks = normalizeWebhooks(data);
+      setWebhooks(nextWebhooks);
+      void hydrateDeliverySignals(nextWebhooks);
     } catch (err) {
       setWebhooks([]);
+      setDeliverySignals({});
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
     }
+  }
+
+  async function hydrateDeliverySignals(nextWebhooks: Webhook[]) {
+    const requestId = ++deliverySignalRequestRef.current;
+
+    const nextSignals = await Promise.all(
+      nextWebhooks.map(async (webhook) => {
+        if (!webhook.is_active) {
+          return [webhook.id, getWebhookDeliverySignal(webhook, [])] as const;
+        }
+
+        try {
+          const payload = await readJson<unknown>(`/api/webhooks/${webhook.id}/deliveries?limit=5`);
+          return [webhook.id, getWebhookDeliverySignal(webhook, normalizeDeliveries(payload))] as const;
+        } catch (deliveryError) {
+          return [
+            webhook.id,
+            {
+              detail:
+                deliveryError instanceof Error
+                  ? deliveryError.message
+                  : "Failed to load recent delivery history.",
+              label: "delivery data unavailable",
+              lastDeliveryAt: null,
+              lastStatusCode: null,
+              recentAttempts: 0,
+              recentFailures: 0,
+              status: "warning",
+            } satisfies WebhookDeliverySignal,
+          ] as const;
+        }
+      }),
+    );
+
+    if (requestId !== deliverySignalRequestRef.current) return;
+    setDeliverySignals(Object.fromEntries(nextSignals));
   }
 
   async function fetchDeliveries(webhookId: string) {
@@ -285,6 +364,31 @@ export default function WebhooksPageClient() {
           >
             <X className="h-4 w-4" />
           </button>
+        </div>
+      )}
+
+      {!showForm && !viewingDeliveries && webhooks.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <Card className="p-4">
+            <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Active routes</p>
+            <p className="mt-2 text-2xl font-semibold">{readinessSummary.active}</p>
+            <p className="mt-2 text-xs text-muted-foreground">Webhooks that can accept test or live deliveries.</p>
+          </Card>
+          <Card className="p-4">
+            <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Healthy sample</p>
+            <p className="mt-2 text-2xl font-semibold">{readinessSummary.healthy}</p>
+            <p className="mt-2 text-xs text-muted-foreground">Active routes whose recent delivery sample is succeeding.</p>
+          </Card>
+          <Card className="p-4">
+            <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Attention needed</p>
+            <p className="mt-2 text-2xl font-semibold">{readinessSummary.attention}</p>
+            <p className="mt-2 text-xs text-muted-foreground">Routes currently failing, recovering, stale, or missing delivery data.</p>
+          </Card>
+          <Card className="p-4">
+            <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Not exercised</p>
+            <p className="mt-2 text-2xl font-semibold">{readinessSummary.notExercised}</p>
+            <p className="mt-2 text-xs text-muted-foreground">Active routes with no recorded delivery attempts yet.</p>
+          </Card>
         </div>
       )}
 
@@ -509,19 +613,30 @@ export default function WebhooksPageClient() {
       ) : (
         !viewingDeliveries && (
           <div className="space-y-4">
-            {filteredWebhooks.map((webhook) => (
-              <Card key={webhook.id} className="p-4">
-                <div className="flex items-start justify-between">
-                  <div className="space-y-1">
+            {filteredWebhooks.map((webhook) => {
+              const lifecycle = getWebhookLifecycleState(webhook);
+              const deliverySignal =
+                deliverySignals[webhook.id] ??
+                ({
+                  detail: "Loading recent delivery sample.",
+                  label: "probing",
+                  lastDeliveryAt: null,
+                  lastStatusCode: null,
+                  recentAttempts: 0,
+                  recentFailures: 0,
+                  status: "idle",
+                } satisfies WebhookDeliverySignal);
+
+              return (
+                <Card key={webhook.id} className="p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-2">
                     <div className="flex items-center gap-2">
                       <code className="text-sm bg-muted px-2 py-1 rounded">
                         {webhook.url}
                       </code>
-                      {webhook.is_active ? (
-                        <CheckCircle2 className="h-4 w-4 text-green-500" />
-                      ) : (
-                        <AlertCircle className="h-4 w-4 text-amber-500" />
-                      )}
+                      <StatusBadge status={lifecycle.status} label={lifecycle.label} />
+                      <StatusBadge status={deliverySignal.status} label={deliverySignal.label} />
                       <button
                         onClick={() => handleCopyId(webhook.id)}
                         className="flex items-center gap-1 rounded p-1 text-slate-500 hover:text-cyan-400 transition-colors"
@@ -542,46 +657,57 @@ export default function WebhooksPageClient() {
                     </div>
                     <p className="text-xs text-muted-foreground">
                       Created {new Date(webhook.created_at).toLocaleString()}
+                      {deliverySignal.lastDeliveryAt
+                        ? ` · last delivery ${formatRelativeTime(deliverySignal.lastDeliveryAt)}`
+                        : ""}
                     </p>
+                    <p className="text-xs text-muted-foreground">{deliverySignal.detail}</p>
+                    {deliverySignal.lastStatusCode ? (
+                      <p className="text-xs text-muted-foreground">
+                        Latest HTTP status {deliverySignal.lastStatusCode} across {deliverySignal.recentAttempts} sampled attempt
+                        {deliverySignal.recentAttempts === 1 ? "" : "s"}.
+                      </p>
+                    ) : null}
                   </div>
-                  <div className="flex gap-2">
-                    <button
-                      onClick={() => setViewingDeliveries(webhook)}
-                      className="p-2 hover:bg-accent rounded-md"
-                      title="View delivery history"
-                    >
-                      <Eye className="h-4 w-4" />
-                    </button>
-                    <button
-                      onClick={() => handleTest(webhook.id)}
-                      disabled={testingId === webhook.id}
-                      className="p-2 hover:bg-accent rounded-md disabled:opacity-50"
-                      title="Test webhook"
-                    >
-                      {testingId === webhook.id ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <Play className="h-4 w-4" />
-                      )}
-                    </button>
-                    <button
-                      onClick={() => startEdit(webhook)}
-                      className="p-2 hover:bg-accent rounded-md"
-                      title="Edit webhook"
-                    >
-                      <Edit2 className="h-4 w-4" />
-                    </button>
-                    <button
-                      onClick={() => handleDelete(webhook.id)}
-                      className="p-2 hover:bg-accent rounded-md text-destructive"
-                      title="Delete webhook"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => setViewingDeliveries(webhook)}
+                        className="p-2 hover:bg-accent rounded-md"
+                        title="View delivery history"
+                      >
+                        <Eye className="h-4 w-4" />
+                      </button>
+                      <button
+                        onClick={() => handleTest(webhook.id)}
+                        disabled={testingId === webhook.id}
+                        className="p-2 hover:bg-accent rounded-md disabled:opacity-50"
+                        title="Test webhook"
+                      >
+                        {testingId === webhook.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Play className="h-4 w-4" />
+                        )}
+                      </button>
+                      <button
+                        onClick={() => startEdit(webhook)}
+                        className="p-2 hover:bg-accent rounded-md"
+                        title="Edit webhook"
+                      >
+                        <Edit2 className="h-4 w-4" />
+                      </button>
+                      <button
+                        onClick={() => handleDelete(webhook.id)}
+                        className="p-2 hover:bg-accent rounded-md text-destructive"
+                        title="Delete webhook"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
                   </div>
-                </div>
-              </Card>
-            ))}
+                </Card>
+              );
+            })}
           </div>
         )
       )}

--- a/docs/architecture/webhook-api-key-product-depth-phase-1.md
+++ b/docs/architecture/webhook-api-key-product-depth-phase-1.md
@@ -14,29 +14,41 @@ Issue: `#3592`
 
 Make the dashboard the shared operator summary layer for webhook and API-key depth, while keeping the API and CLI as thin contract clients underneath it.
 
-That means phase 1 should add truthful summary and status structure in the dashboard, not a new backend abstraction. The goal is to make the current lifecycle data easier to understand and compare, then leave deeper unification for later phases.
+That means phase 1 should add truthful summary and status structure in the dashboard and CLI, not a new backend abstraction. The goal is to make the current lifecycle data easier to understand and compare, then leave deeper unification for later phases.
+
+## Shared Status Vocabulary
+
+- API keys keep a lifecycle state of `active`, `expired`, or `revoked`.
+- Active API keys also expose a readiness cue of `ready`, `expires soon`, `unused`, or `stale`.
+- Webhooks keep a lifecycle state of `active` or `inactive`.
+- Active webhooks also expose a delivery cue of `healthy`, `recovering`, `failing`, `stale`, or `not exercised`.
+- Dashboard and CLI compute those cues from existing list and delivery-history payloads only. No backend contract expansion is required for this phase.
 
 ## File-Level Map
 
 - `components/dashboard/ApiKeysPageClient.tsx`
   - keep the existing lifecycle actions
   - surface compact key-risk summary signals that operators can scan quickly
+  - use the shared lifecycle and readiness labels above
 - `components/webhooks/WebhooksPageClient.tsx`
   - keep CRUD and delivery history
   - add a matching summary treatment so webhook state reads like an operator surface, not just a form
+  - use recent delivery-history samples to compute truthful health cues
 - `src/api/routes/api_keys.py`
   - remain the source of truth for API-key lifecycle and one-time secret issuance
 - `src/api/routes/webhooks.py`
   - remain the source of truth for webhook lifecycle, delivery inspection, and test dispatch
 - `cli/commands/api_keys.py`
   - keep command names and response handling aligned with the backend contract
+  - render the same lifecycle/readiness labels as the dashboard
 - `cli/commands/webhooks.py`
   - keep list/get/deliveries commands aligned with the backend contract
+  - render the same lifecycle/delivery labels as the dashboard and expose the test action
 
 ## Phased Build Sequence
 
-1. Phase 1: add the smallest truthful dashboard summary layer for keys and webhooks, using existing API payloads only.
-2. Phase 2: tighten naming, status labels, and empty states so the two surfaces read consistently across dashboard and CLI.
+1. Phase 1: add the smallest truthful dashboard and CLI summary layer for keys and webhooks, using existing API payloads only.
+2. Phase 2: decide whether create, update, delete, and test actions need more CLI parity or whether the current dashboard-first split is enough.
 3. Phase 3: decide whether any backend aggregation endpoint is justified, but only after the UI proves a shared summary actually helps.
 
 ## Risks
@@ -56,4 +68,6 @@ That means phase 1 should add truthful summary and status structure in the dashb
   - `cli/commands/webhooks.py`
 - Keep future validation lightweight for phase 1:
   - `sed` or `rg` for contract drift
-  - local frontend build or targeted tests only if code changes land later
+  - targeted Jest tests for the shared readiness helpers
+  - targeted CLI contract tests for status output and webhook test dispatch
+  - local frontend build after dashboard changes land

--- a/tests/test_cli_api_keys_contract.py
+++ b/tests/test_cli_api_keys_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import uuid
 from types import SimpleNamespace
 from typing import Any
@@ -36,18 +37,23 @@ def test_api_keys_list_hits_canonical_route_and_renders_keys(monkeypatch) -> Non
                 {
                     "id": key_id,
                     "name": "test-key-1",
+                    "created_at": "2026-03-14T10:00:00",
                     "is_active": True,
                     "expires_at": "2026-04-14T10:00:00",
                 },
                 {
                     "id": str(uuid.uuid4()),
                     "name": "test-key-2",
+                    "created_at": "2026-03-14T10:00:00",
                     "is_active": False,
                     "expires_at": None,
                 },
             ],
         )
 
+    monkeypatch.setattr(
+        "cli.operator_readiness.utc_now", lambda: datetime(2026, 4, 10, 10, 0, tzinfo=timezone.utc)
+    )
     monkeypatch.setattr("cli.commands.api_keys.current_config", lambda: DummyConfig())
     monkeypatch.setattr(
         "cli.commands.api_keys.get_client", lambda config: SimpleNamespace(get=fake_get)
@@ -60,9 +66,10 @@ def test_api_keys_list_hits_canonical_route_and_renders_keys(monkeypatch) -> Non
     assert captured["path"] == "/v1/api-keys"
     assert key_id in result.output
     assert "test-key-1" in result.output
-    assert "active" in result.output
+    assert "state=active" in result.output
+    assert "health=expires-soon" in result.output
     assert "test-key-2" in result.output
-    assert "revoked" in result.output
+    assert "state=revoked" in result.output
 
 
 def test_api_keys_list_empty(monkeypatch) -> None:

--- a/tests/test_cli_webhooks_contract.py
+++ b/tests/test_cli_webhooks_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
 
@@ -24,24 +25,42 @@ class DummyResponse:
 
 
 def test_webhooks_list_hits_contract_route_and_forwards_filters(monkeypatch) -> None:
-    captured: dict[str, Any] = {}
+    captured: list[tuple[str, dict[str, Any] | None]] = []
 
     def fake_get(path: str, params: dict[str, Any] | None = None) -> DummyResponse:
-        captured["path"] = path
-        captured["params"] = params
+        captured.append((path, params))
+        if path == "/v1/webhooks":
+            return DummyResponse(
+                200,
+                [
+                    {
+                        "id": "wh-123",
+                        "url": "https://example.com/hook",
+                        "is_active": True,
+                        "events": ["agent.status"],
+                    }
+                ],
+            )
+
         return DummyResponse(
             200,
             [
                 {
-                    "id": "wh-123",
-                    "url": "https://example.com/hook",
-                    "is_active": True,
-                    "events": ["agent.status"],
+                    "id": "delivery-1",
+                    "event": "agent.status",
+                    "success": True,
+                    "attempts": 1,
+                    "status_code": 204,
+                    "created_at": "2026-03-14T16:00:00",
+                    "delivered_at": "2026-03-14T16:00:01",
                 }
             ],
         )
 
     monkeypatch.setattr("cli.commands.webhooks.current_config", lambda: DummyConfig())
+    monkeypatch.setattr(
+        "cli.operator_readiness.utc_now", lambda: datetime(2026, 3, 15, 16, 0, tzinfo=timezone.utc)
+    )
     monkeypatch.setattr(
         "cli.commands.webhooks.get_client", lambda config: SimpleNamespace(get=fake_get)
     )
@@ -50,11 +69,12 @@ def test_webhooks_list_hits_contract_route_and_forwards_filters(monkeypatch) -> 
     result = runner.invoke(cli, ["webhooks", "list", "--limit", "25", "--skip", "5"])
 
     assert result.exit_code == 0
-    assert captured == {
-        "path": "/v1/webhooks",
-        "params": {"limit": 25, "skip": 5},
-    }
-    assert "wh-123 | https://example.com/hook | active | events: agent.status" in result.output
+    assert captured == [
+        ("/v1/webhooks", {"limit": 25, "skip": 5}),
+        ("/v1/webhooks/wh-123/deliveries", {"limit": 5, "skip": 0}),
+    ]
+    assert "wh-123 | https://example.com/hook | state=active | delivery=healthy" in result.output
+    assert "events: agent.status" in result.output
 
 
 def test_webhooks_deliveries_hits_live_delivery_route_and_query_contract(monkeypatch) -> None:
@@ -147,5 +167,36 @@ def test_webhooks_get_hits_contract_route_and_prints_created_timestamp(monkeypat
         "path": "/v1/webhooks/wh-456",
         "params": None,
     }
-    assert "wh-456 | https://example.com/hook | inactive" in result.output
+    assert "wh-456 | https://example.com/hook | state=inactive" in result.output
     assert "Created: 2026-03-12T15:00:00" in result.output
+
+
+def test_webhooks_test_hits_live_contract_route(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, json: dict[str, Any] | None = None) -> DummyResponse:
+        captured["path"] = path
+        captured["json"] = json
+        return DummyResponse(
+            200,
+            {
+                "status": "test_delivered",
+                "message": "Test event delivered successfully",
+            },
+        )
+
+    monkeypatch.setattr("cli.commands.webhooks.current_config", lambda: DummyConfig())
+    monkeypatch.setattr(
+        "cli.commands.webhooks.get_client", lambda config: SimpleNamespace(post=fake_post)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["webhooks", "test", "wh-789"])
+
+    assert result.exit_code == 0
+    assert captured == {
+        "path": "/v1/webhooks/wh-789/test",
+        "json": None,
+    }
+    assert "Triggered webhook test: wh-789" in result.output
+    assert "Test event delivered successfully" in result.output

--- a/tests/unit/operatorReadiness.test.ts
+++ b/tests/unit/operatorReadiness.test.ts
@@ -1,0 +1,135 @@
+import {
+  getApiKeyLifecycleState,
+  getApiKeyReadinessSignal,
+  getWebhookDeliverySignal,
+} from '../../components/app/operatorReadiness'
+
+const now = new Date('2026-04-14T10:00:00.000Z').getTime()
+
+describe('operator readiness helpers', () => {
+  it('marks a live API key as active and ready when usage and expiry are healthy', () => {
+    const key = {
+      created_at: '2026-04-10T10:00:00.000Z',
+      expires_at: '2026-05-10T10:00:00.000Z',
+      is_active: true,
+      last_used: '2026-04-13T10:00:00.000Z',
+    }
+
+    expect(getApiKeyLifecycleState(key, now)).toMatchObject({
+      label: 'active',
+      status: 'success',
+    })
+    expect(getApiKeyReadinessSignal(key, now)).toMatchObject({
+      label: 'ready',
+      status: 'success',
+    })
+  })
+
+  it('marks a live API key as unused when no use is recorded after seven days', () => {
+    const key = {
+      created_at: '2026-04-01T10:00:00.000Z',
+      expires_at: '2026-05-10T10:00:00.000Z',
+      is_active: true,
+      last_used: null,
+    }
+
+    expect(getApiKeyReadinessSignal(key, now)).toMatchObject({
+      label: 'unused',
+      status: 'warning',
+    })
+  })
+
+  it('marks a live API key as expired when its expiry is in the past', () => {
+    const key = {
+      created_at: '2026-04-01T10:00:00.000Z',
+      expires_at: '2026-04-10T10:00:00.000Z',
+      is_active: true,
+      last_used: '2026-04-09T10:00:00.000Z',
+    }
+
+    expect(getApiKeyLifecycleState(key, now)).toMatchObject({
+      label: 'expired',
+      status: 'error',
+    })
+    expect(getApiKeyReadinessSignal(key, now)).toBeNull()
+  })
+
+  it('marks a webhook as failing when the latest sampled delivery fails', () => {
+    const webhook = {
+      created_at: '2026-04-01T10:00:00.000Z',
+      is_active: true,
+    }
+
+    const signal = getWebhookDeliverySignal(
+      webhook,
+      [
+        {
+          created_at: '2026-04-14T09:00:00.000Z',
+          status_code: 502,
+          success: false,
+        },
+      ],
+      now,
+    )
+
+    expect(signal).toMatchObject({
+      label: 'failing',
+      lastStatusCode: 502,
+      status: 'error',
+    })
+  })
+
+  it('marks a webhook as recovering when the latest delivery succeeds after recent failures', () => {
+    const webhook = {
+      created_at: '2026-04-01T10:00:00.000Z',
+      is_active: true,
+    }
+
+    const signal = getWebhookDeliverySignal(
+      webhook,
+      [
+        {
+          created_at: '2026-04-14T09:00:00.000Z',
+          status_code: 204,
+          success: true,
+        },
+        {
+          created_at: '2026-04-14T08:00:00.000Z',
+          status_code: 502,
+          success: false,
+        },
+      ],
+      now,
+    )
+
+    expect(signal).toMatchObject({
+      label: 'recovering',
+      recentFailures: 1,
+      status: 'warning',
+    })
+  })
+
+  it('marks a webhook as stale when no deliveries have landed in seven days', () => {
+    const webhook = {
+      created_at: '2026-04-01T10:00:00.000Z',
+      is_active: true,
+    }
+
+    const signal = getWebhookDeliverySignal(
+      webhook,
+      [
+        {
+          created_at: '2026-04-01T09:00:00.000Z',
+          status_code: 204,
+          success: true,
+        },
+      ],
+      now,
+    )
+
+    expect(signal).toMatchObject({
+      label: 'stale',
+      status: 'warning',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- unify operator lifecycle labels for API keys and webhooks without expanding the backend contract
- add webhook delivery health summaries to the dashboard from existing delivery-history endpoints
- make the CLI render matching readiness cues and add webhook test dispatch parity
- document the shared status vocabulary for the phase-1 lane

## Why
The dashboard and CLI exposed the same resources with different operator stories. Keys already showed some expiry and usage posture, while webhooks mostly read as raw CRUD records. This slice makes both surfaces speak the same lifecycle language using the payloads that already exist.

## Impact
- dashboard operators can now scan `active/expired/revoked` plus `ready/expires soon/unused/stale` for API keys
- dashboard operators can now scan `active/inactive` plus `healthy/recovering/failing/stale/not exercised` for webhooks
- CLI output now carries the same lifecycle vocabulary, and `mutx webhooks test <id>` matches the dashboard's live test action

## Validation
- `git diff --check`
- `/Users/fortune/MUTX/.venv/bin/python -m pytest tests/test_cli_api_keys_contract.py tests/test_cli_webhooks_contract.py -q`
- `npx jest --runInBand tests/unit/operatorReadiness.test.ts`
- `/Users/fortune/MUTX/.venv/bin/python -m compileall cli`
- `npm run build`

Closes #3592
