### PR TITLE
Deployment lifecycle: surface rollback posture across dashboard and CLI

### DIFF
--- a/app/dashboard/deployments/[id]/page.tsx
+++ b/app/dashboard/deployments/[id]/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 
 import { ApiRequestError, readJson, writeJson } from "@/components/app/http";
+import { DeploymentHistory } from "@/components/app/DeploymentHistory";
 import { DashboardDialog } from "@/components/dashboard/DashboardDialog";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { RouteHeader } from "@/components/dashboard/RouteHeader";
@@ -310,6 +311,29 @@ export default function DeploymentDetailPage() {
               icon={Calendar}
             />
           </LiveMiniStatGrid>
+        </LivePanel>
+
+        <LivePanel title="Version posture" meta="rollback ready">
+          <div className="rounded-[16px] border border-[#24303d] bg-[#0a1017] p-4">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+              Current rollout revision
+            </p>
+            <p className="mt-2 text-sm font-medium text-slate-100">
+              {deployment.version || "Unknown"}
+            </p>
+            <p className="mt-3 text-sm leading-6 text-slate-400">
+              Inspect recorded deployment snapshots and roll back to a known-good version
+              without leaving this deployment record.
+            </p>
+            <div className="mt-4">
+              <DeploymentHistory
+                deploymentId={deployment.id}
+                buttonLabel="Inspect version history"
+                buttonClassName="inline-flex items-center gap-2 rounded-[12px] border border-[#2f3c49] bg-[#10161d] px-3.5 py-2 text-sm font-medium text-[#dce3ec] transition hover:border-sky-300/18"
+                onRollbackComplete={() => loadDeployment({ preserveLoading: true })}
+              />
+            </div>
+          </div>
         </LivePanel>
       </div>
 

--- a/cli/commands/deploy.py
+++ b/cli/commands/deploy.py
@@ -1,5 +1,7 @@
-import click
+import json
 from typing import Optional
+
+import click
 
 from cli.config import current_config, get_client
 from cli.services import CLIServiceError, DeploymentsService
@@ -17,6 +19,18 @@ def _echo_service_error(error: CLIServiceError) -> None:
 
 def _deployments_service() -> DeploymentsService:
     return DeploymentsService(config=current_config(), client_factory=get_client)
+
+
+def _parse_config_snapshot(snapshot: object) -> dict[str, object]:
+    if isinstance(snapshot, dict):
+        return snapshot
+    if not isinstance(snapshot, str):
+        return {}
+    try:
+        parsed = json.loads(snapshot)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 @deploy_group.command(name="list")
@@ -128,6 +142,58 @@ def restart_deployment(deployment_id: str):
         deployment = _deployments_service().restart_deployment(deployment_id)
         click.echo(f"Restarted deployment: {deployment.id or deployment_id}")
         click.echo(f"Status: {deployment.status}")
+    except CLIServiceError as exc:
+        _echo_service_error(exc)
+
+
+@deploy_group.command(name="versions")
+@click.argument("deployment_id")
+def deployment_versions(deployment_id: str):
+    """Get deployment version history"""
+    try:
+        payload = _deployments_service().get_versions(deployment_id)
+    except CLIServiceError as exc:
+        _echo_service_error(exc)
+        return
+
+    if not payload.items:
+        click.echo("No deployment versions found.")
+        return
+
+    click.echo(f"Deployment: {payload.deployment_id} | versions: {payload.total}")
+    for item in payload.items:
+        snapshot = _parse_config_snapshot(item.config_snapshot)
+        fragments = [
+            f"v{item.version}",
+            item.status,
+            f"created: {item.created_at or 'n/a'}",
+        ]
+        runtime_version = snapshot.get("version")
+        if isinstance(runtime_version, str) and runtime_version:
+            fragments.append(f"runtime version: {runtime_version}")
+        replicas = snapshot.get("replicas")
+        if isinstance(replicas, int):
+            fragments.append(f"replicas: {replicas}")
+        if item.rolled_back_at:
+            fragments.append(f"rolled back: {item.rolled_back_at}")
+        click.echo(" | ".join(fragments))
+
+
+@deploy_group.command(name="rollback")
+@click.argument("deployment_id")
+@click.option("--version", "target_version", required=True, type=int, help="Version number to restore")
+def rollback_deployment_command(deployment_id: str, target_version: int):
+    """Rollback a deployment to a recorded version"""
+    try:
+        deployment = _deployments_service().rollback_deployment(
+            deployment_id,
+            version=target_version,
+        )
+        click.echo(f"Rolled back deployment: {deployment.id or deployment_id}")
+        click.echo(f"Status: {deployment.status}")
+        if deployment.version:
+            click.echo(f"Version: {deployment.version}")
+        click.echo(f"Replicas: {deployment.replicas}")
     except CLIServiceError as exc:
         _echo_service_error(exc)
 

--- a/cli/commands/deploy.py
+++ b/cli/commands/deploy.py
@@ -181,7 +181,9 @@ def deployment_versions(deployment_id: str):
 
 @deploy_group.command(name="rollback")
 @click.argument("deployment_id")
-@click.option("--version", "target_version", required=True, type=int, help="Version number to restore")
+@click.option(
+    "--version", "target_version", required=True, type=int, help="Version number to restore"
+)
 def rollback_deployment_command(deployment_id: str, target_version: int):
     """Rollback a deployment to a recorded version"""
     try:

--- a/cli/services/deployments.py
+++ b/cli/services/deployments.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from typing import Any
 
 from cli.services.base import APIService
-from cli.services.models import DeploymentEventHistory, DeploymentRecord, LogEntry, MetricPoint
+from cli.services.models import (
+    DeploymentEventHistory,
+    DeploymentRecord,
+    DeploymentVersionHistory,
+    LogEntry,
+    MetricPoint,
+)
 
 
 class DeploymentsService(APIService):
@@ -70,6 +76,25 @@ class DeploymentsService(APIService):
             {200},
             not_found_message="Deployment not found",
             invalid_message="Cannot restart deployment",
+        )
+        return DeploymentRecord.from_payload(response.json())
+
+    def get_versions(self, deployment_id: str) -> DeploymentVersionHistory:
+        response = self._request("get", f"/v1/deployments/{deployment_id}/versions")
+        self._expect_status(response, {200}, not_found_message="Deployment not found")
+        return DeploymentVersionHistory.from_payload(response.json())
+
+    def rollback_deployment(self, deployment_id: str, *, version: int) -> DeploymentRecord:
+        response = self._request(
+            "post",
+            f"/v1/deployments/{deployment_id}/rollback",
+            json={"version": version},
+        )
+        self._expect_status(
+            response,
+            {200},
+            not_found_message="Deployment not found",
+            invalid_message="Cannot rollback deployment",
         )
         return DeploymentRecord.from_payload(response.json())
 

--- a/cli/services/models.py
+++ b/cli/services/models.py
@@ -170,6 +170,58 @@ class DeploymentEventHistory:
 
 
 @dataclass(slots=True)
+class DeploymentVersionRecord:
+    id: str
+    deployment_id: str
+    version: int
+    config_snapshot: dict[str, Any] | str | None
+    status: str
+    created_at: str | None
+    rolled_back_at: str | None
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "DeploymentVersionRecord":
+        raw_config_snapshot = payload.get("config_snapshot")
+        config_snapshot: dict[str, Any] | str | None
+        if isinstance(raw_config_snapshot, dict):
+            config_snapshot = raw_config_snapshot
+        elif raw_config_snapshot is None:
+            config_snapshot = None
+        else:
+            config_snapshot = str(raw_config_snapshot)
+
+        return cls(
+            id=str(payload.get("id", "")),
+            deployment_id=str(payload.get("deployment_id", "")),
+            version=int(payload.get("version", 0)),
+            config_snapshot=config_snapshot,
+            status=str(payload.get("status", "unknown")),
+            created_at=_as_optional_str(payload.get("created_at")),
+            rolled_back_at=_as_optional_str(payload.get("rolled_back_at")),
+        )
+
+
+@dataclass(slots=True)
+class DeploymentVersionHistory:
+    deployment_id: str
+    items: list[DeploymentVersionRecord]
+    total: int
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "DeploymentVersionHistory":
+        raw_items = payload.get("items") or []
+        return cls(
+            deployment_id=str(payload.get("deployment_id", "")),
+            items=[
+                DeploymentVersionRecord.from_payload(item)
+                for item in raw_items
+                if isinstance(item, dict)
+            ],
+            total=int(payload.get("total", 0)),
+        )
+
+
+@dataclass(slots=True)
 class AgentRecord:
     id: str
     name: str

--- a/components/app/DeploymentHistory.tsx
+++ b/components/app/DeploymentHistory.tsx
@@ -4,16 +4,9 @@ import { History, RotateCcw, Loader2 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { Card } from "@/components/ui/Card";
 import { extractApiErrorMessage, normalizeCollection } from "@/components/app/http";
+import { type components } from "@/app/types/api";
 
-interface DeploymentVersion {
-  id: string;
-  deployment_id: string;
-  version: number;
-  config_snapshot: string;
-  status: string;
-  created_at: string;
-  rolled_back_at: string | null;
-}
+type DeploymentVersion = components["schemas"]["DeploymentVersionResponse"];
 
 interface VersionHistoryResponse {
   deployment_id: string;
@@ -39,6 +32,18 @@ function parseConfigSnapshot(snapshot: string | Record<string, unknown> | null |
 function VersionItem({ version, onRollback }: { version: DeploymentVersion; onRollback: () => void }) {
   const isCurrent = version.status === "current";
   const config = parseConfigSnapshot(version.config_snapshot);
+  const runtimeVersion = typeof config.version === "string" ? config.version : null;
+  const replicas = typeof config.replicas === "number" ? config.replicas : null;
+  const metadata = [formatDate(version.created_at)];
+  if (runtimeVersion) {
+    metadata.push(`runtime ${runtimeVersion}`);
+  }
+  if (replicas !== null) {
+    metadata.push(`${replicas} replica${replicas === 1 ? "" : "s"}`);
+  }
+  if (version.rolled_back_at) {
+    metadata.push(`rolled back ${formatDate(version.rolled_back_at)}`);
+  }
 
   return (
     <div className={`flex items-center justify-between rounded-lg border p-3 ${isCurrent ? "border-emerald-400/30 bg-emerald-400/5" : "border-white/5 bg-white/[0.02]"}`}>
@@ -50,13 +55,10 @@ function VersionItem({ version, onRollback }: { version: DeploymentVersion; onRo
           <p className="text-sm font-medium text-white">
             {isCurrent ? "Current Version" : `Version ${version.version}`}
           </p>
-          <p className="text-xs text-slate-500">
-            {formatDate(version.created_at)}
-            {(config.replicas as number) > 0 && ` • ${config.replicas} replica${(config.replicas as number) > 1 ? 's' : ''}`}
-          </p>
+          <p className="text-xs text-slate-500">{metadata.join(" • ")}</p>
         </div>
       </div>
-      {!isCurrent && version.status !== "superseded" && (
+      {!isCurrent && (
         <button
           onClick={onRollback}
           className="inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-xs font-medium text-white transition hover:bg-white/10"
@@ -69,7 +71,22 @@ function VersionItem({ version, onRollback }: { version: DeploymentVersion; onRo
   );
 }
 
-export function DeploymentHistory({ deploymentId }: { deploymentId: string }) {
+interface DeploymentHistoryProps {
+  deploymentId: string;
+  buttonLabel?: string;
+  buttonClassName?: string;
+  onRollbackComplete?: () => void | Promise<void>;
+}
+
+const defaultButtonClassName =
+  "inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-white/10";
+
+export function DeploymentHistory({
+  deploymentId,
+  buttonLabel = "Versions",
+  buttonClassName = defaultButtonClassName,
+  onRollbackComplete,
+}: DeploymentHistoryProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [versions, setVersions] = useState<DeploymentVersion[]>([]);
   const [loading, setLoading] = useState(false);
@@ -120,6 +137,9 @@ export function DeploymentHistory({ deploymentId }: { deploymentId: string }) {
         throw new Error(extractApiErrorMessage(data, "Rollback failed"));
       }
 
+      if (onRollbackComplete) {
+        await onRollbackComplete();
+      }
       setVersions([]);
       setIsOpen(false);
     } catch (err) {
@@ -133,10 +153,10 @@ export function DeploymentHistory({ deploymentId }: { deploymentId: string }) {
     <>
       <button
         onClick={() => setIsOpen(true)}
-        className="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-white/10"
+        className={buttonClassName}
       >
         <History className="h-3.5 w-3.5" />
-        Versions
+        {buttonLabel}
       </button>
 
       {isOpen && (

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -41,13 +41,8 @@ It is a guide for contributors, not a promise of exact delivery order.
 
 ## Next
 
-- Webhook and API-key product depth
-  - make browser and CLI flows equally trustworthy for outbound webhooks and service credentials
-- Better app-side observability
-  - roll up telemetry config, runs, traces, session health, and alert posture into `/dashboard/observability`
-  - keep `components/dashboard/ObservabilityPageClient.tsx` as a thin consumer of aggregated dashboard API data
-  - start from the existing `/api/dashboard/observability` proxy and `src/api/routes/telemetry.py` route family
 - Runtime-backed lifecycle semantics
+  - surface deployment version history and rollback posture consistently across dashboard and CLI
   - keep deployment versions, rollback, and restart behavior tied to real execution posture
 - Local operator ergonomics
   - keep the hosted and local setup lanes recoverable when installs, migrations, or stale local state drift
@@ -61,7 +56,8 @@ It is a guide for contributors, not a promise of exact delivery order.
 
 ## Shipped (Last 30 Days)
 
-- `2026-04-14` Merge wave: closed the open PR queue and seeded the next roadmap lanes for observability and webhook/API-key depth
+- `2026-04-14` Dashboard observability aggregates telemetry config, traces, and session health into `/dashboard/observability`
+- `2026-04-14` Webhook and API-key lifecycle status is unified across dashboard and CLI operator surfaces
 - `2026-04-11` Pico progress API mounted at `/v1/pico/progress` with GET/POST progress persistence
 - `2026-04-10` Swarms real DB persistence with PATCH/DELETE endpoints
 - `2026-04-10` RAG `/v1/rag/ingest` for document ingestion into vector store

--- a/tests/test_cli_deploy_contract.py
+++ b/tests/test_cli_deploy_contract.py
@@ -188,6 +188,96 @@ def test_deploy_restart_hits_contract_route_and_renders_status(monkeypatch) -> N
     assert "Status: pending" in result.output
 
 
+def test_deploy_versions_hits_contract_route_and_renders_snapshot(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(path: str, params: dict[str, Any] | None = None) -> DummyResponse:
+        captured["path"] = path
+        captured["params"] = params
+        return DummyResponse(
+            200,
+            {
+                "deployment_id": "dep-123",
+                "items": [
+                    {
+                        "id": "ver-2",
+                        "deployment_id": "dep-123",
+                        "version": 2,
+                        "config_snapshot": '{"replicas": 2, "version": "v1.2.0"}',
+                        "status": "current",
+                        "created_at": "2026-03-12T16:00:00",
+                        "rolled_back_at": None,
+                    },
+                    {
+                        "id": "ver-1",
+                        "deployment_id": "dep-123",
+                        "version": 1,
+                        "config_snapshot": '{"replicas": 1, "version": "v1.1.0"}',
+                        "status": "superseded",
+                        "created_at": "2026-03-11T16:00:00",
+                        "rolled_back_at": "2026-03-12T16:00:00",
+                    },
+                ],
+                "total": 2,
+            },
+        )
+
+    monkeypatch.setattr("cli.commands.deploy.current_config", lambda: DummyConfig())
+    monkeypatch.setattr(
+        "cli.commands.deploy.get_client", lambda config: SimpleNamespace(get=fake_get)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["deploy", "versions", "dep-123"])
+
+    assert result.exit_code == 0
+    assert captured == {
+        "path": "/v1/deployments/dep-123/versions",
+        "params": None,
+    }
+    assert "Deployment: dep-123 | versions: 2" in result.output
+    assert (
+        "v2 | current | created: 2026-03-12T16:00:00 | runtime version: v1.2.0 | replicas: 2"
+        in result.output
+    )
+    assert "rolled back: 2026-03-12T16:00:00" in result.output
+
+
+def test_deploy_rollback_hits_contract_route_and_renders_new_state(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, json: dict[str, Any] | None = None) -> DummyResponse:
+        captured["path"] = path
+        captured["json"] = json
+        return DummyResponse(
+            200,
+            {
+                "id": "dep-789",
+                "status": "running",
+                "version": "v1.1.0",
+                "replicas": 1,
+            },
+        )
+
+    monkeypatch.setattr("cli.commands.deploy.current_config", lambda: DummyConfig())
+    monkeypatch.setattr(
+        "cli.commands.deploy.get_client", lambda config: SimpleNamespace(post=fake_post)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["deploy", "rollback", "dep-789", "--version", "1"])
+
+    assert result.exit_code == 0
+    assert captured == {
+        "path": "/v1/deployments/dep-789/rollback",
+        "json": {"version": 1},
+    }
+    assert "Rolled back deployment: dep-789" in result.output
+    assert "Status: running" in result.output
+    assert "Version: v1.1.0" in result.output
+    assert "Replicas: 1" in result.output
+
+
 def test_deploy_logs_hits_contract_route_and_supports_level_filter(monkeypatch) -> None:
     captured: dict[str, Any] = {}
 

--- a/tests/test_cli_deploy_contract.py
+++ b/tests/test_cli_deploy_contract.py
@@ -45,7 +45,7 @@ def test_deploy_events_hits_contract_route_and_renders_items(monkeypatch) -> Non
             },
         )
 
-    monkeypatch.setattr("cli.commands.deploy.current_config", lambda: DummyConfig())
+    monkeypatch.setattr("cli.commands.deploy.current_config", DummyConfig)
     monkeypatch.setattr(
         "cli.commands.deploy.get_client", lambda config: SimpleNamespace(get=fake_get)
     )
@@ -100,7 +100,7 @@ def test_deploy_list_passes_agent_and_status_filters(monkeypatch) -> None:
             ],
         )
 
-    monkeypatch.setattr("cli.commands.deploy.current_config", lambda: DummyConfig())
+    monkeypatch.setattr("cli.commands.deploy.current_config", DummyConfig)
     monkeypatch.setattr(
         "cli.commands.deploy.get_client", lambda config: SimpleNamespace(get=fake_get)
     )

--- a/tests/unit/dashboardRoutes.test.ts
+++ b/tests/unit/dashboardRoutes.test.ts
@@ -279,6 +279,66 @@ describe('dashboard route proxies', () => {
     await expect(response.json()).resolves.toEqual({ id: 'dep_123', status: 'pending' })
   })
 
+  it('proxies deployment version history requests', async () => {
+    proxyJson.mockResolvedValue(
+      new Response(JSON.stringify({ deployment_id: 'dep_123', items: [], total: 0 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    const { GET } = await import('../../app/api/dashboard/deployments/[id]/route')
+
+    const request = {
+      url: 'http://localhost:3000/api/dashboard/deployments/dep_123?path=versions',
+    } as NextRequest
+    const response = await GET(
+      request,
+      { params: Promise.resolve({ id: 'dep_123' }) }
+    )
+
+    expect(proxyJson).toHaveBeenCalledWith(
+      request,
+      'http://localhost:8000/v1/deployments/dep_123/versions',
+      {
+        fallbackMessage: 'Failed to fetch deployment versions',
+      }
+    )
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ deployment_id: 'dep_123', items: [], total: 0 })
+  })
+
+  it('proxies deployment rollback actions', async () => {
+    proxyJson.mockResolvedValue(
+      new Response(JSON.stringify({ id: 'dep_123', status: 'running', version: 'v1.1.0' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    const { POST } = await import('../../app/api/dashboard/deployments/[id]/route')
+
+    const request = {
+      url: 'http://localhost:3000/api/dashboard/deployments/dep_123?action=rollback',
+      json: async () => ({ version: 1 }),
+    } as NextRequest
+    const response = await POST(
+      request,
+      { params: Promise.resolve({ id: 'dep_123' }) }
+    )
+
+    expect(proxyJson).toHaveBeenCalledWith(
+      request,
+      'http://localhost:8000/v1/deployments/dep_123/rollback',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ version: 1 }),
+        fallbackMessage: 'Failed to rollback deployment',
+      }
+    )
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ id: 'dep_123', status: 'running', version: 'v1.1.0' })
+  })
+
   it('proxies deployment delete actions', async () => {
     proxyJson.mockResolvedValue(new Response(null, { status: 204 }))
     const { DELETE } = await import('../../app/api/dashboard/deployments/[id]/route')


### PR DESCRIPTION
## Summary
- expose deployment version history and rollback posture consistently in the deploy CLI and deployment detail view
- fix the dashboard version-history control so superseded deployment snapshots are actually rollback candidates
- refresh the roadmap after the webhook and observability merge wave

## Validation
- git diff --check
- /Users/fortune/MUTX/.venv/bin/python -m pytest tests/test_cli_deploy_contract.py -q
- /Users/fortune/MUTX/.venv/bin/python -m compileall cli
- /Users/fortune/MUTX/.venv/bin/ruff check cli/commands/deploy.py cli/services/deployments.py cli/services/models.py
- npx jest --runInBand tests/unit/dashboardRoutes.test.ts
- npm run typecheck
- npm run build

Closes #3610
