### PR TITLE
Redesign Pico as a premium studio experience

### DIFF
--- a/app/pico/pico.css
+++ b/app/pico/pico.css
@@ -1,20 +1,25 @@
 .pico-root {
-  --pico-bg: #050904;
-  --pico-bg-raised: #0b1209;
-  --pico-bg-surface: rgba(159, 255, 78, 0.045);
-  --pico-bg-surface-hover: rgba(159, 255, 78, 0.085);
-  --pico-text: #f3faee;
-  --pico-text-secondary: rgba(221, 234, 214, 0.76);
-  --pico-text-muted: rgba(166, 186, 156, 0.5);
-  --pico-border: rgba(159, 255, 78, 0.14);
-  --pico-border-hover: rgba(159, 255, 78, 0.28);
-  --pico-accent-rgb: 159, 255, 78;
-  --pico-accent: #9fff4e;
-  --pico-accent-bright: #dfff9a;
-  --pico-accent-deep: #52c51c;
-  --pico-accent-contrast: #071404;
-  --pico-accent-soft: rgba(159, 255, 78, 0.12);
-  --pico-accent-glow: rgba(159, 255, 78, 0.1);
+  --pico-bg: #030804;
+  --pico-bg-raised: #071108;
+  --pico-bg-surface: rgba(164, 255, 92, 0.05);
+  --pico-bg-surface-hover: rgba(164, 255, 92, 0.1);
+  --pico-bg-panel: rgba(6, 13, 8, 0.86);
+  --pico-bg-panel-strong: rgba(8, 15, 10, 0.94);
+  --pico-bg-input: rgba(8, 14, 9, 0.96);
+  --pico-text: #f5ffe9;
+  --pico-text-secondary: rgba(221, 239, 211, 0.8);
+  --pico-text-muted: rgba(157, 188, 145, 0.62);
+  --pico-border: rgba(164, 255, 92, 0.14);
+  --pico-border-hover: rgba(164, 255, 92, 0.32);
+  --pico-border-strong: rgba(206, 255, 170, 0.22);
+  --pico-accent-rgb: 164, 255, 92;
+  --pico-accent: #a4ff5c;
+  --pico-accent-bright: #ebffbf;
+  --pico-accent-deep: #60ca32;
+  --pico-accent-contrast: #051103;
+  --pico-accent-soft: rgba(164, 255, 92, 0.12);
+  --pico-accent-glow: rgba(164, 255, 92, 0.14);
+  --pico-accent-fog: rgba(164, 255, 92, 0.07);
   --pico-blue: #73efbe;
   --pico-blue-soft: rgba(115, 239, 190, 0.12);
   --pico-blue-glow: rgba(115, 239, 190, 0.08);
@@ -29,19 +34,64 @@
   --pico-radius: 1.2rem;
   --pico-radius-lg: 1.6rem;
   --pico-radius-full: 999px;
-  --pico-shell: min(100% - 2.5rem, 72rem);
+  --pico-shell: min(100% - 2.5rem, 80rem);
+  --pico-shadow-panel:
+    0 28px 90px rgba(0, 0, 0, 0.34),
+    0 0 0 1px rgba(255, 255, 255, 0.02),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  --pico-shadow-frame:
+    0 36px 120px rgba(0, 0, 0, 0.42),
+    0 0 0 1px rgba(255, 255, 255, 0.02),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
   min-height: 100vh;
+  position: relative;
+  isolation: isolate;
   color: var(--pico-text);
+  background:
+    radial-gradient(circle at 16% -6%, rgba(var(--pico-accent-rgb), 0.16), transparent 26%),
+    radial-gradient(circle at 84% 2%, rgba(115, 239, 190, 0.1), transparent 22%),
+    linear-gradient(180deg, #071008 0%, #040905 38%, #020603 100%);
+  color-scheme: dark;
 }
 
 body:has(.pico-root) {
-  background: #050904;
+  background:
+    radial-gradient(circle at 16% -10%, rgba(var(--pico-accent-rgb), 0.14), transparent 24%),
+    radial-gradient(circle at 86% 6%, rgba(115, 239, 190, 0.08), transparent 20%),
+    linear-gradient(180deg, #071008 0%, #030804 100%);
   color: var(--pico-text);
+}
+
+.pico-root::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: 64px 64px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.5), transparent 88%);
+  opacity: 0.28;
+  z-index: -2;
+}
+
+.pico-root::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(var(--pico-accent-rgb), 0.12), transparent 38%),
+    radial-gradient(circle at 50% 100%, rgba(var(--pico-accent-rgb), 0.06), transparent 28%);
+  mix-blend-mode: screen;
+  opacity: 0.8;
+  z-index: -1;
 }
 
 .pico-root ::selection {
   background: rgba(var(--pico-accent-rgb), 0.28);
-  color: #071404;
+  color: var(--pico-accent-contrast);
 }
 
 .pico-root a:focus-visible,

--- a/components/pico/PicoAcademyDashboard.tsx
+++ b/components/pico/PicoAcademyDashboard.tsx
@@ -70,9 +70,9 @@ function LessonStateStamp({ state }: { state: LessonState }) {
       className={cn(
         picoCodex.stamp,
         state === 'done' && 'border-emerald-500/35 bg-emerald-500/10 text-emerald-100',
-        state === 'current' && 'border-[#e2904f] bg-[rgba(226,144,79,0.16)] text-[#fff1df]',
+        state === 'current' && 'border-[color:var(--pico-accent)] bg-[rgba(var(--pico-accent-rgb),0.16)] text-[color:var(--pico-text)]',
         state === 'ready' && 'border-cyan-500/30 bg-cyan-500/10 text-cyan-100',
-        state === 'locked' && 'border-[#5a3d28] bg-transparent text-[#9f8063]',
+        state === 'locked' && 'border-[color:var(--pico-border)] bg-transparent text-[color:var(--pico-text-muted)]',
       )}
     >
       {copy}
@@ -276,7 +276,42 @@ export function PicoAcademyDashboard() {
     },
   ]
 
-  const visibleTracks = progress.platform.railCollapsed ? [activeTrack] : PICO_TRACKS
+  const studioMethod = [
+    {
+      label: '01 • Brief',
+      title: 'Read the mission like a client brief',
+      body: currentMissionSummary,
+    },
+    {
+      label: '02 • Deliverable',
+      title: 'Make one artifact worth keeping',
+      body: activationLesson?.expectedResult ?? currentMissionValidation,
+    },
+    {
+      label: '03 • Critique',
+      title: 'Use the validation like studio review',
+      body: currentMissionValidation,
+    },
+  ]
+
+  const academyStandards = [
+    {
+      label: 'Track outcome',
+      value: activeTrack.outcome,
+    },
+    {
+      label: 'Level reward',
+      value: currentLevel?.projectOutcome ?? 'Ship one real operator outcome.',
+    },
+    {
+      label: 'Next standard',
+      value: currentLevel?.recommendedNextStep ?? 'Keep the chapter narrow and honest.',
+    },
+  ]
+
+  const chapterPreviewTracks = progress.platform.railCollapsed
+    ? []
+    : PICO_TRACKS.filter((track) => track.slug !== activeTrack.slug)
 
   useEffect(() => {
     if (progress.platform.activeSurface !== 'academy') {
@@ -305,20 +340,20 @@ export function PicoAcademyDashboard() {
           data-testid="pico-academy-mission-billboard"
         >
           <div className="grid gap-8 lg:grid-cols-[8rem,minmax(0,1fr)]">
-            <div className="grid content-between gap-6 border-b border-[#5d412d] pb-6 lg:border-b-0 lg:border-r lg:pb-0 lg:pr-8">
+            <div className="grid content-between gap-6 border-b border-[color:var(--pico-border)] pb-6 lg:border-b-0 lg:border-r lg:pb-0 lg:pr-8">
               <div className="grid gap-2">
                 <p className={picoClasses.label}>Codex chapter</p>
-                <p className="font-[family:var(--font-site-display)] text-7xl leading-none tracking-[-0.08em] text-[#f0bb83] sm:text-8xl">
+                <p className="font-[family:var(--font-site-display)] text-7xl leading-none tracking-[-0.08em] text-[color:var(--pico-accent)] sm:text-8xl">
                   {activeTrackChapter}
                 </p>
               </div>
 
               <div className="grid gap-2">
                 <p className={picoClasses.label}>Track</p>
-                <p className="font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+                <p className="font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                   {activeTrack.title}
                 </p>
-                <p className="text-sm leading-6 text-[#d8c0a4]">
+                <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   Stop {String(missionIndex).padStart(2, '0')} of {activeTrackLessons.length}
                 </p>
               </div>
@@ -337,18 +372,18 @@ export function PicoAcademyDashboard() {
               </div>
 
               <div className="grid gap-4">
-                <h1 className="max-w-4xl font-[family:var(--font-site-display)] text-5xl leading-[0.92] tracking-[-0.08em] text-[#fff4e6] sm:text-7xl">
+                <h1 className="max-w-4xl font-[family:var(--font-site-display)] text-5xl leading-[0.92] tracking-[-0.08em] text-[color:var(--pico-text)] sm:text-7xl">
                   {currentMissionTitle}
                 </h1>
-                <p className="max-w-3xl text-lg leading-8 text-[#e2ccb3]">
+                <p className="max-w-3xl text-lg leading-8 text-[color:var(--pico-text-secondary)]">
                   {currentMissionSummary}
                 </p>
-                <p className="max-w-3xl text-sm leading-6 text-[#b99879]">
+                <p className="max-w-3xl text-sm leading-6 text-[color:var(--pico-text-muted)]">
                   Validation: {currentMissionValidation}
                 </p>
               </div>
 
-              <div className="flex flex-wrap gap-3">
+              <div className="grid gap-3 sm:flex sm:flex-wrap">
                 <Link href={currentMissionPrimaryHref} className={picoClasses.primaryButton}>
                   {currentMissionPrimaryLabel}
                 </Link>
@@ -358,16 +393,16 @@ export function PicoAcademyDashboard() {
               </div>
 
               <div
-                className="grid gap-3 border-t border-[#5d412d] pt-5 sm:grid-cols-2 xl:grid-cols-4"
+                className="grid gap-3 border-t border-[color:var(--pico-border)] pt-5 sm:grid-cols-2 xl:grid-cols-4"
                 data-testid="pico-academy-progress-strip"
               >
                 {missionStrip.map((item) => (
                   <div key={item.label} className="grid gap-1">
                     <p className={picoClasses.label}>{item.label}</p>
-                    <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
+                    <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                       {item.value}
                     </p>
-                    <p className="text-sm leading-6 text-[#bfa78c]">{item.detail}</p>
+                    <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">{item.detail}</p>
                   </div>
                 ))}
               </div>
@@ -388,7 +423,7 @@ export function PicoAcademyDashboard() {
                 <div className="flex flex-wrap items-start justify-between gap-4">
                   <div>
                     <p className={picoClasses.label}>Active proof lane</p>
-                    <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[#fff4e6]">
+                    <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)]">
                       {focusedActivationStep?.title ?? activationLesson.title}
                     </h2>
                   </div>
@@ -399,18 +434,18 @@ export function PicoAcademyDashboard() {
 
                 <div className={picoCodexSheet('p-5')}>
                   <p className={picoClasses.label}>Resume from here</p>
-                  <p className="mt-4 text-base leading-8 text-[#f0deca]">
+                  <p className="mt-4 text-base leading-8 text-[color:var(--pico-text-secondary)]">
                     {focusedActivationStep?.body ??
                       'Open the lesson route and keep the proof lane short.'}
                   </p>
                   {focusedActivationStep?.command ? (
-                    <pre className="mt-5 overflow-x-auto rounded-[22px] border border-[#6a452a] bg-[#16100d] p-4 text-sm text-[#ffc88f]">
+                    <pre className="mt-5 overflow-x-auto rounded-[22px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-input)] p-4 text-sm text-[color:var(--pico-accent-bright)]">
                       <code>{focusedActivationStep.command}</code>
                     </pre>
                   ) : null}
-                  <div className="mt-5 overflow-hidden rounded-full bg-[#1b120d]">
+                  <div className="mt-5 overflow-hidden rounded-full bg-[color:var(--pico-bg-input)]">
                     <div
-                      className="h-2 rounded-full bg-[linear-gradient(90deg,#e2904f,#ffd0a4)]"
+                      className="h-2 rounded-full bg-[linear-gradient(90deg,var(--pico-accent),var(--pico-accent-bright))]"
                       style={{ width: `${activationLessonWorkspace.progressPercent}%` }}
                     />
                   </div>
@@ -428,17 +463,17 @@ export function PicoAcademyDashboard() {
               <div className="grid gap-4">
                 <div className={picoCodexInset('p-5')}>
                   <p className={picoClasses.label}>Proof state</p>
-                  <p className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+                  <p className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                     {workspaceCaptured ? 'captured' : 'missing'}
                   </p>
-                  <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
+                  <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                     Updated {workspaceUpdatedAt}
                   </p>
                 </div>
 
                 <div className={picoCodexNote('p-5')}>
                   <p className={picoClasses.label}>Captured proof</p>
-                  <p className="mt-3 text-sm leading-6 text-[#f0deca]">
+                  <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                     {workspaceCaptured
                       ? activationLessonWorkspace.workspace.evidence
                       : 'No proof has been logged yet. Save the single artifact that proves the mission actually worked.'}
@@ -447,7 +482,7 @@ export function PicoAcademyDashboard() {
 
                 <div className={picoCodexInset('p-5')}>
                   <p className={picoClasses.label}>Hosted note</p>
-                  <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                  <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                     {hostedDetail}
                   </p>
                 </div>
@@ -457,180 +492,309 @@ export function PicoAcademyDashboard() {
         </FadeIn>
       ) : null}
 
-      <FadeIn delay={0.12} reduceMotion={reduceMotion}>
+      <FadeIn delay={0.1} reduceMotion={reduceMotion}>
         <section
-          className={picoCodexFrame('overflow-hidden')}
-          data-testid="pico-academy-campaign-map"
+          className={picoCodexFrame('px-6 py-6 sm:px-8 sm:py-8')}
+          data-testid="pico-academy-studio-method"
         >
-          <div className="border-b border-[#5d412d] px-6 py-6 sm:px-8 lg:px-10">
-            <div className="flex flex-wrap items-start justify-between gap-4">
-              <div>
-                <p className={picoClasses.label}>Chapter ledger</p>
-                <h2 className="mt-3 max-w-4xl font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[#fff4e6] sm:text-5xl">
-                  Follow the route in order. Let the appendix stay quiet.
-                </h2>
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1.08fr),20rem]">
+            <div>
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                  <p className={picoClasses.label}>Studio method</p>
+                  <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)]">
+                    Learn like a boutique studio ships
+                  </h2>
+                </div>
+                <span className={picoCodex.stamp}>brief • deliverable • critique</span>
               </div>
-              <span className={picoCodex.stamp}>
-                {progress.platform.railCollapsed ? 'focus mode' : 'all chapters'}
-              </span>
+
+              <div className="mt-6 grid gap-4 xl:grid-cols-3">
+                {studioMethod.map((item) => (
+                  <article key={item.label} className={picoCodexInset('flex h-full flex-col p-5')}>
+                    <p className={picoClasses.label}>{item.label}</p>
+                    <h3 className="mt-5 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                      {item.title}
+                    </h3>
+                    <p className="mt-4 text-sm leading-7 text-[color:var(--pico-text-secondary)]">
+                      {item.body}
+                    </p>
+                  </article>
+                ))}
+              </div>
             </div>
-            <p className="mt-3 max-w-3xl text-sm leading-6 text-[#c8b296]">
-              {progress.platform.railCollapsed
-                ? 'Map is narrowed to the current track. Open Map to see every chapter.'
-                : 'The ledger should explain sequence without feeling like a dashboard of equal choices.'}
-            </p>
-          </div>
 
-          <div className="px-6 py-6 sm:px-8 lg:px-10 lg:py-8">
-            <div className="grid gap-10">
-              {visibleTracks.map((track, trackIndex) => {
-                const trackLessons = track.lessons
-                  .map((slug) => getLessonBySlug(slug))
-                  .filter((lesson): lesson is PicoLesson => Boolean(lesson))
-                const completedCount = trackLessons.filter((lesson) =>
-                  progress.completedLessons.includes(lesson.slug),
-                ).length
-                const unlocked = derived.unlockedTrackSlugs.includes(track.slug)
-                const active = track.slug === activeTrack.slug
-                const chapterIndex = Math.max(
-                  PICO_TRACKS.findIndex((entry) => entry.slug === track.slug),
-                  trackIndex,
-                )
+            <div className="grid gap-4">
+              <div className={picoCodexNote('p-5')}>
+                <p className={picoClasses.label}>Track standards</p>
+                <div className="mt-4 grid gap-4">
+                  {academyStandards.map((item) => (
+                    <div
+                      key={item.label}
+                      className="grid gap-2 border-t border-[color:var(--pico-border)] pt-4 first:border-t-0 first:pt-0"
+                    >
+                      <p className={picoClasses.label}>{item.label}</p>
+                      <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                        {item.value}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
 
-                return (
-                  <motion.article
-                    key={track.slug}
-                    initial={reduceMotion ? false : { opacity: 0, y: 14 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={reduceMotion ? { duration: 0 } : { duration: 0.45, delay: trackIndex * 0.05 }}
-                    className="grid gap-5 lg:grid-cols-[15rem,minmax(0,1fr)]"
-                  >
-                    <div className="grid gap-3">
-                      <span className={picoCodex.stamp}>
-                        Track {String(chapterIndex + 1).padStart(2, '0')}
+              <div className={picoCodexInset('p-5')}>
+                <p className={picoClasses.label}>Chapter checklist</p>
+                <div className="mt-4 grid gap-3">
+                  {activeTrack.checklist.map((item) => (
+                    <div key={item} className="flex items-start gap-3">
+                      <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full border border-[color:var(--pico-border)] bg-[rgba(var(--pico-accent-rgb),0.12)] text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--pico-accent)]">
+                        ok
                       </span>
-                      <h3 className="font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[#fff4e6]">
-                        {track.title}
-                      </h3>
-                      <p className="text-sm leading-6 text-[#e0c9b0]">{track.outcome}</p>
-                      <p className="text-sm leading-6 text-[#b99879]">{track.intro}</p>
-                      <div className="flex flex-wrap items-center gap-3 text-sm text-[#c7af93]">
-                        <span>{completedCount}/{trackLessons.length} cleared</span>
-                        <span>•</span>
-                        <span>{unlocked ? 'route open' : 'route locked'}</span>
-                        {active ? <span>•</span> : null}
-                        {active ? <span>current track</span> : null}
-                      </div>
+                      <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">{item}</p>
                     </div>
-
-                    <div className="relative pl-6">
-                      <div className="absolute left-2 top-1 bottom-1 w-px bg-[#5d412d]" />
-
-                      <div className={cn('grid gap-5', !unlocked && 'opacity-55')}>
-                        {trackLessons.map((lesson, lessonIndex) => {
-                          const state = getLessonState(
-                            lesson,
-                            progress.completedLessons,
-                            derived.unlockedLessonSlugs,
-                            activationLessonSlug,
-                          )
-                          const dominant =
-                            active &&
-                            (lesson.slug === activationLessonSlug ||
-                              state === 'current' ||
-                              (state === 'ready' && lessonIndex === 0))
-
-                          return (
-                            <Link
-                              key={lesson.slug}
-                              href={toHref(`/academy/${lesson.slug}`)}
-                              className={cn(
-                                'relative block border-l pl-5 pr-2 py-1 transition',
-                                state === 'locked'
-                                  ? 'border-[#4c3424] text-[#8f7157]'
-                                  : dominant
-                                    ? 'border-[#e2904f] text-[#fff4e6]'
-                                    : state === 'done'
-                                      ? 'border-[#5f7457] text-[#d8c3a8]'
-                                      : 'border-[#6a4a33] text-[#d5c0a8] hover:border-[#a1714b] hover:text-[#fff4e6]',
-                              )}
-                            >
-                              <span
-                                className={cn(
-                                  'absolute -left-[0.42rem] top-4 h-3.5 w-3.5 rounded-full border bg-[#120a07]',
-                                  state === 'done' && 'border-emerald-400 bg-emerald-500/20',
-                                  state === 'current' && 'border-[#e2904f] bg-[#e2904f]/20',
-                                  state === 'ready' && 'border-cyan-400 bg-cyan-400/15',
-                                  state === 'locked' && 'border-[#4a3423]',
-                                )}
-                              />
-
-                              <div className="flex flex-wrap items-start justify-between gap-3">
-                                <div className="min-w-0">
-                                  <p className="font-[family:var(--font-mono)] text-[11px] uppercase tracking-[0.22em] text-[#b58d65]">
-                                    Stop {String(lessonIndex + 1).padStart(2, '0')} • level {lesson.level}
-                                  </p>
-                                  <p className="mt-1 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-inherit">
-                                    {lesson.title}
-                                  </p>
-                                </div>
-                                <LessonStateStamp state={state} />
-                              </div>
-
-                              {dominant ? (
-                                <div className={picoCodexNote('mt-3 p-4')}>
-                                  <p className={picoClasses.label}>Dominant stop</p>
-                                  <p className="mt-3 text-sm leading-6 text-[#f0deca]">
-                                    {lesson.expectedResult}
-                                  </p>
-                                </div>
-                              ) : (
-                                <p className="mt-2 text-sm leading-6 text-[#bfa78c]">{lesson.summary}</p>
-                              )}
-                            </Link>
-                          )
-                        })}
-                      </div>
-                    </div>
-                  </motion.article>
-                )
-              })}
+                  ))}
+                </div>
+              </div>
             </div>
           </div>
         </section>
       </FadeIn>
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.04fr),minmax(0,0.96fr)]">
-        <FadeIn delay={0.18} reduceMotion={reduceMotion}>
-          <section className={picoCodexFrame('px-6 py-6 sm:px-8')}>
-            <div className="flex flex-wrap items-center justify-between gap-4">
+      <FadeIn delay={0.12} reduceMotion={reduceMotion}>
+        <section
+          className={picoCodexFrame('overflow-hidden')}
+          data-testid="pico-academy-campaign-map"
+        >
+          <div className="border-b border-[color:var(--pico-border)] px-6 py-6 sm:px-8 lg:px-10">
+            <div className="flex flex-wrap items-start justify-between gap-4">
               <div>
-                <p className={picoClasses.label}>Codex appendix</p>
-                <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
-                  The capabilities and patterns that matter after the mission is real
+                <p className={picoClasses.label}>Chapter ledger</p>
+                <h2 className="mt-3 max-w-4xl font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)] sm:text-5xl">
+                  One dominant chapter, with the rest of the map kept quiet.
                 </h2>
               </div>
               <span className={picoCodex.stamp}>
-                {currentLevel ? currentLevel.title : 'Setup'}
+                {progress.platform.railCollapsed ? 'focus mode' : 'guided atlas'}
               </span>
             </div>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+              The current track gets the full editorial treatment. The rest of the atlas stays visible, but compressed, so the route still feels authored instead of equally loud everywhere.
+            </p>
+          </div>
 
-            <div className="mt-6 grid gap-5">
+          <div className="grid gap-0 xl:grid-cols-[minmax(0,1.08fr),22rem]">
+            <div className="px-6 py-6 sm:px-8 lg:px-10 lg:py-8">
+              <motion.article
+                initial={reduceMotion ? false : { opacity: 0, y: 14 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={reduceMotion ? { duration: 0 } : { duration: 0.45, delay: 0.04 }}
+                className="grid gap-6"
+              >
+                <div className="grid gap-5 lg:grid-cols-[16rem,minmax(0,1fr)]">
+                  <div className="grid gap-3">
+                    <span className={picoCodex.stamp}>
+                      Track {String(activeTrackIndex + 1).padStart(2, '0')}
+                    </span>
+                    <h3 className="font-[family:var(--font-site-display)] text-5xl tracking-[-0.06em] text-[color:var(--pico-text)]">
+                      {activeTrack.title}
+                    </h3>
+                    <p className="text-sm leading-6 text-[#e0c9b0]">{activeTrack.outcome}</p>
+                    <p className="text-sm leading-6 text-[color:var(--pico-text-muted)]">{activeTrack.intro}</p>
+                    <div className="grid gap-3 pt-2">
+                      <div className={picoCodexInset('p-4')}>
+                        <p className={picoClasses.label}>Route state</p>
+                        <p className="mt-2 text-lg font-medium text-[color:var(--pico-text)]">
+                          {activeTrackCompletedCount}/{activeTrackLessons.length} cleared
+                        </p>
+                      </div>
+                      <div className={picoCodexInset('p-4')}>
+                        <p className={picoClasses.label}>Next dominant stop</p>
+                        <p className="mt-2 text-lg font-medium text-[color:var(--pico-text)]">
+                          {activationLesson?.title ?? 'Open Autopilot'}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="relative pl-6">
+                    <div className="absolute left-2 top-1 bottom-1 w-px bg-[color:var(--pico-border)]" />
+
+                    <div className="grid gap-5">
+                      {activeTrackLessons.map((lesson, lessonIndex) => {
+                        const state = getLessonState(
+                          lesson,
+                          progress.completedLessons,
+                          derived.unlockedLessonSlugs,
+                          activationLessonSlug,
+                        )
+                        const dominant =
+                          lesson.slug === activationLessonSlug ||
+                          state === 'current' ||
+                          (state === 'ready' && lessonIndex === 0)
+
+                        return (
+                          <Link
+                            key={lesson.slug}
+                            href={toHref(`/academy/${lesson.slug}`)}
+                            className={cn(
+                              'relative block border-l pl-5 pr-2 py-1 transition',
+                              state === 'locked'
+                                ? 'border-[color:var(--pico-border)] text-[color:var(--pico-text-muted)]'
+                                : dominant
+                                  ? 'border-[color:var(--pico-accent)] text-[color:var(--pico-text)]'
+                                  : state === 'done'
+                                    ? 'border-[color:var(--pico-border-hover)] text-[color:var(--pico-text-secondary)]'
+                                    : 'border-[color:var(--pico-border)] text-[color:var(--pico-text-secondary)] hover:border-[color:var(--pico-border-hover)] hover:text-[color:var(--pico-text)]',
+                            )}
+                          >
+                            <span
+                              className={cn(
+                                'absolute -left-[0.42rem] top-4 h-3.5 w-3.5 rounded-full border bg-[color:var(--pico-bg)]',
+                                state === 'done' && 'border-emerald-400 bg-emerald-500/20',
+                                state === 'current' &&
+                                  'border-[color:var(--pico-accent)] bg-[rgba(var(--pico-accent-rgb),0.2)]',
+                                state === 'ready' && 'border-cyan-400 bg-cyan-400/15',
+                                state === 'locked' && 'border-[color:var(--pico-border)]',
+                              )}
+                            />
+
+                            <div className="flex flex-wrap items-start justify-between gap-3">
+                              <div className="min-w-0">
+                                <p className="font-[family:var(--font-mono)] text-[11px] uppercase tracking-[0.22em] text-[color:var(--pico-text-muted)]">
+                                  Stop {String(lessonIndex + 1).padStart(2, '0')} • level {lesson.level}
+                                </p>
+                                <p className="mt-1 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-inherit">
+                                  {lesson.title}
+                                </p>
+                              </div>
+                              <LessonStateStamp state={state} />
+                            </div>
+
+                            {dominant ? (
+                              <div className={picoCodexNote('mt-3 p-4')}>
+                                <p className={picoClasses.label}>Dominant stop</p>
+                                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                                  {lesson.expectedResult}
+                                </p>
+                              </div>
+                            ) : (
+                              <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                                {lesson.summary}
+                              </p>
+                            )}
+                          </Link>
+                        )
+                      })}
+                    </div>
+                  </div>
+                </div>
+              </motion.article>
+            </div>
+
+            <aside className="border-t border-[color:var(--pico-border)] bg-[rgba(5,14,8,0.62)] px-6 py-6 sm:px-8 xl:border-l xl:border-t-0">
+              <div className="grid gap-4">
+                <div className={picoCodexInset('p-5')}>
+                  <p className={picoClasses.label}>Mission correction</p>
+                  <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                    The atlas stays useful only if it keeps pushing you back into the current mission.
+                  </p>
+                  <div className="mt-4 grid gap-3">
+                    <Link href={currentMissionPrimaryHref} className={picoClasses.primaryButton}>
+                      {currentMissionPrimaryLabel}
+                    </Link>
+                    <Link href={currentMissionSecondaryHref} className={picoClasses.tertiaryButton}>
+                      {currentMissionSecondaryLabel}
+                    </Link>
+                  </div>
+                </div>
+
+                {!progress.platform.railCollapsed && chapterPreviewTracks.length > 0 ? (
+                  <div className={picoCodexNote('p-5')}>
+                    <p className={picoClasses.label}>Other chapters</p>
+                    <div className="mt-4 grid gap-3">
+                      {chapterPreviewTracks.map((track, trackIndex) => {
+                        const trackLessons = track.lessons
+                          .map((slug) => getLessonBySlug(slug))
+                          .filter((lesson): lesson is PicoLesson => Boolean(lesson))
+                        const completedCount = trackLessons.filter((lesson) =>
+                          progress.completedLessons.includes(lesson.slug),
+                        ).length
+                        const unlocked = derived.unlockedTrackSlugs.includes(track.slug)
+
+                        return (
+                          <article key={track.slug} className={picoCodexInset('grid gap-3 p-4')}>
+                            <div className="flex items-start justify-between gap-3">
+                              <div>
+                                <p className={picoClasses.label}>
+                                  Track {String(trackIndex + 2).padStart(2, '0')}
+                                </p>
+                                <h3 className="mt-2 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                                  {track.title}
+                                </h3>
+                              </div>
+                              <span className={picoCodex.stamp}>{unlocked ? 'open' : 'locked'}</span>
+                            </div>
+                            <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                              {track.outcome}
+                            </p>
+                            <p className="text-xs uppercase tracking-[0.18em] text-[color:var(--pico-text-muted)]">
+                              {completedCount}/{trackLessons.length} cleared
+                            </p>
+                          </article>
+                        )
+                      })}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </aside>
+          </div>
+        </section>
+      </FadeIn>
+
+      <FadeIn delay={0.18} reduceMotion={reduceMotion}>
+        <section className={picoCodexFrame('px-6 py-6 sm:px-8')}>
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <p className={picoClasses.label}>Reference annex</p>
+              <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                Capability, archive, and platform memory stay below the route on purpose
+              </h2>
+            </div>
+            <span className={picoCodex.stamp}>
+              {currentLevel ? currentLevel.title : 'Setup'} • {lockedLessonCount} locked
+            </span>
+          </div>
+
+          <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.04fr),minmax(0,0.96fr)]">
+            <div className="grid gap-5">
               <div className={picoCodexInset('p-5')}>
-                <p className={picoClasses.label}>Unlocked capabilities</p>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className={picoClasses.label}>Unlocked capabilities</p>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      The pieces that matter after the mission is already real.
+                    </p>
+                  </div>
+                  <span className={picoCodex.stamp}>
+                    {derived.unlockedCapabilities.length} live
+                  </span>
+                </div>
                 <div className="mt-4 grid gap-4">
-                  {derived.unlockedCapabilities.slice(0, 3).map((capability) => (
+                  {derived.unlockedCapabilities.slice(0, 2).map((capability) => (
                     <div
                       key={capability.id}
-                      className="grid gap-2 border-t border-[#5d412d] pt-4 first:border-t-0 first:pt-0"
+                      className="grid gap-2 border-t border-[color:var(--pico-border)] pt-4 first:border-t-0 first:pt-0"
                     >
                       <div className="flex flex-wrap items-center justify-between gap-3">
-                        <h3 className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
+                        <h3 className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                           {capability.title}
                         </h3>
                         <span className={picoCodex.stamp}>live</span>
                       </div>
-                      <p className="text-sm leading-6 text-[#d5c0a8]">{capability.description}</p>
+                      <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                        {capability.description}
+                      </p>
                       <Link href={toHref(capability.href)} className={picoClasses.secondaryButton}>
                         {capability.actionLabel}
                       </Link>
@@ -638,32 +802,78 @@ export function PicoAcademyDashboard() {
                   ))}
 
                   {derived.unlockedCapabilities.length === 0 ? (
-                    <p className="text-sm leading-6 text-[#d5c0a8]">
+                    <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                       The first capability unlock lands only after the first lessons are cleared for real.
                     </p>
                   ) : null}
                 </div>
               </div>
 
-              {derived.nextCapability ? (
-                <div className={picoCodexNote('p-5')}>
-                  <p className={picoClasses.label}>Next unlock</p>
-                  <h3 className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                    {derived.nextCapability.title}
-                  </h3>
-                  <p className="mt-3 text-sm leading-6 text-[#f0deca]">
-                    {derived.nextCapability.description}
-                  </p>
-                  <Link href={toHref(derived.nextCapability.href)} className={cn(picoClasses.primaryButton, 'mt-4')}>
-                    {derived.nextCapability.actionLabel}
-                  </Link>
+              <div className="grid gap-5 lg:grid-cols-2">
+                {derived.nextCapability ? (
+                  <div className={picoCodexNote('p-5')}>
+                    <p className={picoClasses.label}>Next unlock</p>
+                    <h3 className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                      {derived.nextCapability.title}
+                    </h3>
+                    <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      {derived.nextCapability.description}
+                    </p>
+                    <Link href={toHref(derived.nextCapability.href)} className={cn(picoClasses.primaryButton, 'mt-4')}>
+                      {derived.nextCapability.actionLabel}
+                    </Link>
+                  </div>
+                ) : null}
+
+                <div className={picoCodexInset('p-5')}>
+                  <p className={picoClasses.label}>Pattern archive</p>
+                  <div className="mt-4 grid gap-4">
+                    {PICO_SHOWCASE_PATTERNS.slice(0, 2).map((pattern) => (
+                      <div
+                        key={pattern.lessonSlug}
+                        className="grid gap-2 border-t border-[color:var(--pico-border)] pt-4 first:border-t-0 first:pt-0"
+                      >
+                        <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                          {pattern.title}
+                        </p>
+                        <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                          {pattern.summary}
+                        </p>
+                        <Link href={toHref(`/academy/${pattern.lessonSlug}`)} className={picoClasses.tertiaryButton}>
+                          Open pattern lesson
+                        </Link>
+                      </div>
+                    ))}
+                  </div>
                 </div>
-              ) : null}
+              </div>
+            </div>
+
+            <div className="grid gap-5">
+              <div className={picoCodexInset('p-5')}>
+                <p className={picoClasses.label}>Field notes</p>
+                <div className="mt-4 grid gap-4">
+                  {PICO_RELEASE_NOTES.slice(0, 2).map((note) => (
+                    <div
+                      key={`${note.date}-${note.title}`}
+                      className="grid gap-2 border-t border-[color:var(--pico-border)] pt-4 first:border-t-0 first:pt-0"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                          {note.title}
+                        </p>
+                        <span className={picoCodex.stamp}>{note.date}</span>
+                      </div>
+                      <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">{note.body}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
 
               <div className={picoCodexSheet('p-5')}>
                 <p className={picoClasses.label}>Control annex</p>
-                <p className="mt-3 text-sm leading-6 text-[#dbc6ae]">
-                  Platform memory stays available, but it sits below the codex on purpose. The Academy should lead with route and proof, not settings.
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                  Platform memory stays available, but it sits under the codex on purpose. The Academy leads with route and proof, then exposes configuration only when you need it.
                 </p>
                 <div className="mt-5">
                   <PicoPlatformSurface
@@ -686,69 +896,9 @@ export function PicoAcademyDashboard() {
                 </div>
               </div>
             </div>
-          </section>
-        </FadeIn>
-
-        <FadeIn delay={0.22} reduceMotion={reduceMotion}>
-          <section className={picoCodexFrame('px-6 py-6 sm:px-8')}>
-            <div className="flex flex-wrap items-center justify-between gap-4">
-              <div>
-                <p className={picoClasses.label}>Field archive</p>
-                <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
-                  Patterns, release notes, and the material that should never outrun the mission
-                </h2>
-              </div>
-              <span className={picoCodex.stamp}>{lockedLessonCount} locked</span>
-            </div>
-
-            <div className="mt-6 grid gap-5">
-              <div className={picoCodexInset('p-5')}>
-                <p className={picoClasses.label}>Pattern archive</p>
-                <div className="mt-4 grid gap-4">
-                  {PICO_SHOWCASE_PATTERNS.slice(0, 3).map((pattern) => (
-                    <div
-                      key={pattern.lessonSlug}
-                      className="grid gap-2 border-t border-[#5d412d] pt-4 first:border-t-0 first:pt-0"
-                    >
-                      <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                        {pattern.title}
-                      </p>
-                      <p className="text-sm leading-6 text-[#d5c0a8]">{pattern.summary}</p>
-                      <Link href={toHref(`/academy/${pattern.lessonSlug}`)} className={picoClasses.tertiaryButton}>
-                        Open pattern lesson
-                      </Link>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              <div className={picoCodexInset('p-5')}>
-                <p className={picoClasses.label}>Recent field notes</p>
-                <div className="mt-4 grid gap-4">
-                  {PICO_RELEASE_NOTES.slice(0, 3).map((note) => (
-                    <div
-                      key={`${note.date}-${note.title}`}
-                      className="grid gap-2 border-t border-[#5d412d] pt-4 first:border-t-0 first:pt-0"
-                    >
-                      <div className="flex flex-wrap items-center justify-between gap-3">
-                        <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                          {note.title}
-                        </p>
-                        <span className={picoCodex.stamp}>{note.date}</span>
-                      </div>
-                      <p className="text-sm leading-6 text-[#d5c0a8]">{note.body}</p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              <div className={picoCodexSheet('p-5 text-sm leading-6 text-[#d5c0a8]')}>
-                Locked lessons: <span className="text-[#fff4e6]">{lockedLessonCount}</span>. The Academy should stay narrower than the work it protects.
-              </div>
-            </div>
-          </section>
-        </FadeIn>
-      </div>
+          </div>
+        </section>
+      </FadeIn>
     </PicoShell>
   )
 }

--- a/components/pico/PicoAutopilotPageClient.tsx
+++ b/components/pico/PicoAutopilotPageClient.tsx
@@ -40,6 +40,30 @@ import {
 
 type LoadState = 'loading' | 'ready' | 'partial' | 'offline'
 
+const controlProtocol = [
+  {
+    id: '01',
+    title: 'Start with the last run',
+    body: 'If the latest execution does not make sense, the rest of this surface is just decoration.',
+    href: '#recent-runs',
+    action: 'Open recent runs',
+  },
+  {
+    id: '02',
+    title: 'Budget tells you when to stop',
+    body: 'Thresholds are useful only when they are anchored to live spend rather than gut feel.',
+    href: '#budget-section',
+    action: 'Tune spend guardrail',
+  },
+  {
+    id: '03',
+    title: 'Risky actions stay visible',
+    body: 'Approvals should survive restarts, stay reviewable, and read like real decisions.',
+    href: '#approvals-section',
+    action: 'Open approval queue',
+  },
+] as const
+
 function extractErrorMessage(payload: unknown, fallbackMessage: string) {
   if (!payload || typeof payload !== 'object') {
     return fallbackMessage
@@ -102,9 +126,9 @@ function severityClasses(severity: AutopilotTimelineItem['severity']) {
     case 'warn':
       return 'border-amber-400/20 bg-amber-400/10 text-amber-50'
     case 'good':
-      return 'border-[#7d5232] bg-[linear-gradient(180deg,rgba(103,57,29,0.22),rgba(45,27,16,0.18))] text-[#f7e2c8]'
+      return 'border-[color:var(--pico-border-hover)] bg-[linear-gradient(180deg,rgba(var(--pico-accent-rgb),0.16),rgba(8,15,9,0.2))] text-[color:var(--pico-text)]'
     default:
-      return 'border-[#4a3423] bg-[rgba(255,247,235,0.04)] text-[#efe1cf]'
+      return 'border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] text-[color:var(--pico-text-secondary)]'
   }
 }
 
@@ -117,7 +141,7 @@ function StatCard({ label, value, hint }: { label: string; value: string; hint: 
     <div className={picoClasses.metric}>
       <p className={picoClasses.label}>{label}</p>
       <p className={picoClasses.metricValue}>{value}</p>
-      <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">{hint}</p>
+      <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">{hint}</p>
     </div>
   )
 }
@@ -129,9 +153,9 @@ function TimelineItemCard({ item }: { item: AutopilotTimelineItem }) {
         <span>{item.sourceLabel}</span>
         <span>{formatTimestamp(item.occurredAt)} • {formatRelativeTime(item.occurredAt)}</span>
       </div>
-      <h3 className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">{item.title}</h3>
+      <h3 className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">{item.title}</h3>
       <p className="mt-2 text-sm leading-6">{item.detail}</p>
-      <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">Why it matters: {item.impact}</p>
+      <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">Why it matters: {item.impact}</p>
       <Link href={item.href} className={cn(picoClasses.link, 'mt-4 inline-flex')}>
         Jump to detail section
       </Link>
@@ -142,7 +166,7 @@ function TimelineItemCard({ item }: { item: AutopilotTimelineItem }) {
 function EmptyStatePanel({ state }: { state: AutopilotEmptyState }) {
   return (
     <div className={picoSoft('p-5')}>
-      <p className="font-medium text-[#fff4e6]">{state.title}</p>
+      <p className="font-medium text-[color:var(--pico-text)]">{state.title}</p>
       <p className="mt-2">{state.body}</p>
       <Link
         href={state.nextStep.href}
@@ -177,6 +201,8 @@ export function PicoAutopilotPageClient() {
     actionType: 'OUTBOUND_SEND',
     summary: 'Outbound send requires a human decision before the runtime crosses the line.',
   })
+  const storyRailClass =
+    'mt-6 grid grid-flow-col auto-cols-[minmax(16rem,82vw)] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory md:grid-flow-row md:auto-cols-auto md:overflow-visible xl:grid-cols-3'
 
   const pendingApprovals = useMemo(
     () => approvals.filter((approval) => approval.status === 'PENDING'),
@@ -343,6 +369,11 @@ export function PicoAutopilotPageClient() {
       }).slice(0, 10),
     [alerts, approvals, budget, progress.autopilot.costThresholdPercent, runs, tracesByRunId],
   )
+  const visibleTimeline = timeline.slice(0, 4)
+  const visibleRuns = runs.slice(0, 3)
+  const visibleAlerts = alerts.slice(0, 4)
+  const visiblePendingApprovals = pendingApprovals.slice(0, 3)
+  const visibleResolvedApprovals = resolvedApprovals.slice(0, 3)
 
   const integrationStatus = useMemo(
     () =>
@@ -531,6 +562,36 @@ export function PicoAutopilotPageClient() {
     : `Inspect run ${latestRun.id.slice(0, 8)}`
   const latestRunTimestamp = latestRun?.completed_at ?? latestRun?.started_at ?? latestRun?.created_at ?? null
   const latestRunTraces = latestRun ? tracesByRunId[latestRun.id] ?? [] : []
+  const operatorDoctrine = [
+    {
+      label: '01 • Read',
+      title: 'Start with the strongest live signal',
+      body: authRequired
+        ? 'Without a hosted session this room should refuse to improvise. Attach the live feed first.'
+        : latestRun
+          ? `Run ${latestRun.id.slice(0, 8)} is the first thing to read. ${describeRunDetail(latestRun, latestRunTraces)}`
+          : 'No live run exists yet. The honest move is to trigger one real task before tuning anything else.',
+    },
+    {
+      label: '02 • Judge',
+      title: 'Make the decision line explicit',
+      body: authRequired
+        ? 'Budget review is unavailable until the live account is attached.'
+        : budget
+          ? `${formatPercent(budget.usage_percentage)} usage against a ${formatPercent(progress.autopilot.costThresholdPercent)} threshold. That line should tell you when a human steps in.`
+          : 'No live budget snapshot yet. Do not pretend a threshold matters until it meets real spend.',
+    },
+    {
+      label: '03 • Intervene',
+      title: 'Keep risky actions reviewable',
+      body:
+        pendingApprovals.length > 0
+          ? `${pendingApprovals.length} approval item${pendingApprovals.length === 1 ? '' : 's'} is waiting. Good. The dangerous work is still visible.`
+          : progress.autopilot.approvalGateEnabled
+            ? 'The gate is configured, but nothing is waiting right now. Keep it reviewable and boring.'
+            : 'The gate is still off. Turn it on before a risky action becomes an invisible side effect.',
+    },
+  ]
   const recoveryWorkspace = usePicoLessonWorkspace(derived.nextLesson?.slug ?? 'autopilot', derived.nextLesson?.steps.length ?? 0, {
     progress,
     persistRemote: derived.nextLesson
@@ -558,7 +619,7 @@ export function PicoAutopilotPageClient() {
       actions={
         <Link
           href={primaryAutopilotHref}
-          className="inline-flex items-center justify-center gap-2 rounded-full bg-[#e2904f] px-5 py-3 text-sm font-semibold text-[#21130c] transition hover:bg-[#eca265]"
+          className={picoClasses.primaryButton}
         >
           {primaryAutopilotLabel}
         </Link>
@@ -618,15 +679,61 @@ export function PicoAutopilotPageClient() {
         </div>
       ) : null}
 
+      <section className={picoPanel('mb-6 p-6 sm:p-7')} data-testid="pico-autopilot-operator-doctrine">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.08fr),20rem]">
+          <div>
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className={picoClasses.label}>Operator doctrine</p>
+                <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)]">
+                  Read, judge, then intervene
+                </h2>
+              </div>
+              <span className={picoClasses.chip}>signal • line • gate</span>
+            </div>
+
+            <div className={storyRailClass}>
+              {operatorDoctrine.map((item) => (
+                <article key={item.label} className={picoInset('snap-start flex h-full flex-col p-5')}>
+                  <p className={picoClasses.label}>{item.label}</p>
+                  <h3 className="mt-5 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                    {item.title}
+                  </h3>
+                  <p className="mt-4 text-sm leading-7 text-[color:var(--pico-text-secondary)]">
+                    {item.body}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-4">
+            <div className={picoEmber('p-5')}>
+              <p className={picoClasses.label}>Control room posture</p>
+              <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                This surface should feel like an operator review room, not a dashboard that celebrates motion for its own sake.
+              </p>
+            </div>
+
+            <div className={picoInset('p-5')}>
+              <p className={picoClasses.label}>Decision line</p>
+              <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                Start with the last run, compare it against the budget line, then decide whether the gate needs a human call. That order matters.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr),22rem]">
         <div className={picoPanel('overflow-hidden p-0')}>
-          <div className="grid gap-0 border-b border-[#3a291d] lg:grid-cols-[minmax(0,1fr),18rem]">
+          <div className="grid gap-0 border-b border-[color:var(--pico-border)] lg:grid-cols-[minmax(0,1fr),18rem]">
             <div className="p-6 sm:p-7">
-              <p className={picoClasses.label}>Command brief</p>
-              <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[#fff4e6] sm:text-5xl">
+              <p className={picoClasses.label}>Control brief</p>
+              <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)] sm:text-5xl">
                 Read the runtime before you trust the automation
               </h2>
-              <p className="mt-4 max-w-3xl text-sm leading-7 text-[#d5c0a8] sm:text-base">
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-[color:var(--pico-text-secondary)] sm:text-base">
                 Autopilot only earns trust when the last run, the live spend, and the risky actions are visible in one surface. This page should feel like a control room, not a dashboard collage.
               </p>
 
@@ -640,7 +747,7 @@ export function PicoAutopilotPageClient() {
                     {progress.autopilot.approvalGateEnabled ? 'Gate configured in Pico' : 'Gate still off in Pico'}
                   </span>
                 </div>
-                <p className="mt-4 text-sm leading-7 text-[#f0deca]">
+                <p className="mt-4 text-sm leading-7 text-[color:var(--pico-text-secondary)]">
                   {authRequired
                     ? 'Until a MUTX session is attached, this surface should refuse to invent truth. Use the academy to finish the setup path, then come back to read the real runtime.'
                     : latestRun
@@ -649,88 +756,42 @@ export function PicoAutopilotPageClient() {
                 </p>
               </div>
 
-              <div className="mt-6 grid gap-4 lg:grid-cols-3">
-                <div className={picoInset('p-5')}>
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#a8896e]">
-                    01 Inspect first
-                  </p>
-                  <p className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
-                    Start with the last run
-                  </p>
-                  <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
-                    If the latest execution does not make sense, the rest of this surface is just decoration.
-                  </p>
-                  <Link href="#recent-runs" className={cn(picoClasses.link, 'mt-4 inline-flex')}>
-                    Open recent runs
-                  </Link>
-                </div>
-
-                <div className={picoInset('p-5')}>
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#a8896e]">
-                    02 Hold the line
-                  </p>
-                  <p className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
-                    Budget tells you when to stop
-                  </p>
-                  <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
-                    Thresholds are useful only when they are anchored to live spend rather than gut feel.
-                  </p>
-                  <Link href="#budget-section" className={cn(picoClasses.link, 'mt-4 inline-flex')}>
-                    Tune spend guardrail
-                  </Link>
-                </div>
-
-                <div className={picoInset('p-5')}>
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#a8896e]">
-                    03 Gate risk
-                  </p>
-                  <p className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
-                    Risky actions stay visible
-                  </p>
-                  <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
-                    Approvals should survive restarts, stay reviewable, and read like real decisions.
-                  </p>
-                  <Link href="#approvals-section" className={cn(picoClasses.link, 'mt-4 inline-flex')}>
-                    Open approval queue
-                  </Link>
-                </div>
-              </div>
             </div>
 
-            <div className="border-t border-[#3a291d] bg-[rgba(255,247,235,0.03)] p-6 lg:border-l lg:border-t-0">
+            <div className="border-t border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] p-6 lg:border-l lg:border-t-0">
               <p className={picoClasses.label}>Operator rail</p>
               <div className="mt-4 grid gap-3">
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Session status</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Session status</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {authRequired ? 'auth required' : 'attached'}
                   </p>
                 </div>
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Progress sync</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">{syncState}</p>
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Progress sync</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">{syncState}</p>
                 </div>
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Budget line</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Budget line</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {formatPercent(progress.autopilot.costThresholdPercent)}
                   </p>
                 </div>
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Gate state</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Gate state</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {progress.autopilot.approvalGateEnabled ? 'enabled' : 'off'}
                   </p>
                 </div>
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Active surface</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Active surface</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {progress.platform.activeSurface ?? 'none'}
                   </p>
                 </div>
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Help lane</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Help lane</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {progress.platform.helpLaneOpen ? 'open' : 'closed'}
                   </p>
                 </div>
@@ -756,7 +817,7 @@ export function PicoAutopilotPageClient() {
 
               <div className={picoInset('mt-4 p-4')}>
                 <p className={picoClasses.label}>If the feed is empty</p>
-                <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   Do not dress up missing runtime data. Finish the academy path, trigger one real action, and come back only when MUTX has something to report.
                 </p>
                 <Link
@@ -769,7 +830,7 @@ export function PicoAutopilotPageClient() {
             </div>
           </div>
 
-          <div className="grid gap-4 border-t border-[#3a291d] p-6 md:grid-cols-2 xl:grid-cols-5">
+          <div className="grid gap-4 border-t border-[color:var(--pico-border)] p-6 md:grid-cols-2 xl:grid-cols-5">
             <StatCard
               label="Runs"
               value={liveValue(String(runs.length))}
@@ -833,35 +894,11 @@ export function PicoAutopilotPageClient() {
 
         <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start">
           <section className={picoPanel('p-5')}>
-            <p className={picoClasses.label}>Control rules</p>
-            <div className="mt-4 grid gap-3">
-              <div className={picoInset('p-4')}>
-                <p className="font-medium text-[#fff4e6]">Runs before rules</p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                  Do not configure alerts and approvals around a workflow you have not inspected live.
-                </p>
-              </div>
-              <div className={picoInset('p-4')}>
-                <p className="font-medium text-[#fff4e6]">Thresholds before panic</p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                  Budget lines should explain what cost you are willing to tolerate before a human gets involved.
-                </p>
-              </div>
-              <div className={picoInset('p-4')}>
-                <p className="font-medium text-[#fff4e6]">Gates before damage</p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                  The approval queue exists so risky actions stay reversible and reviewable.
-                </p>
-              </div>
-            </div>
-          </section>
-
-          <section className={picoPanel('p-5')}>
-            <p className={picoClasses.label}>Current posture</p>
+            <p className={picoClasses.label}>Control brief</p>
             <div className="mt-4 grid gap-3">
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Latest run</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Latest run</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {authRequired
                     ? 'unavailable'
                     : latestRun
@@ -870,55 +907,29 @@ export function PicoAutopilotPageClient() {
                 </p>
               </div>
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Threshold breach</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Threshold line</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {thresholdBreached ? 'breached' : 'clear'}
                 </p>
               </div>
-              <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Last breach marker</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                  {progress.autopilot.lastThresholdBreachAt
-                    ? formatTimestamp(progress.autopilot.lastThresholdBreachAt)
-                    : 'not recorded'}
-                </p>
-              </div>
+              {derived.nextLesson ? (
+                <>
+                  <div className={picoInset('p-4')} data-testid="pico-autopilot-academy-context">
+                    <p className="text-sm text-[color:var(--pico-text-muted)]">Recovery lesson</p>
+                    <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">{derived.nextLesson.title}</p>
+                  </div>
+                  <div className={picoInset('p-4')}>
+                    <p className="text-sm text-[color:var(--pico-text-muted)]">Workspace proof</p>
+                    <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                      {recoveryWorkspace.workspace.evidence.trim() ? 'captured' : 'missing'}
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      {recoveryWorkspace.completedStepCount}/{derived.nextLesson.steps.length} steps • {recoveryFocusedStep}
+                    </p>
+                  </div>
+                </>
+              ) : null}
             </div>
-          </section>
-
-          {derived.nextLesson ? (
-            <section className={picoPanel('p-5')} data-testid="pico-autopilot-academy-context">
-              <p className={picoClasses.label}>Academy context</p>
-              <div className="mt-4 grid gap-3">
-                <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Recovery lesson</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">{derived.nextLesson.title}</p>
-                </div>
-                <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Workspace progress</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                    {recoveryWorkspace.completedStepCount}/{derived.nextLesson.steps.length}
-                  </p>
-                </div>
-                <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Focused step</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">{recoveryFocusedStep}</p>
-                </div>
-                <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Proof state</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                    {recoveryWorkspace.workspace.evidence.trim() ? 'captured' : 'missing'}
-                  </p>
-                </div>
-              </div>
-              <p className="mt-4 text-sm leading-6 text-[#d5c0a8]">
-                If this academy context is still incomplete, the lesson lane probably remains the real source of truth. Stay in Autopilot only when the live runtime is what actually broke next.
-              </p>
-            </section>
-          ) : null}
-
-          <section className={picoPanel('p-5')}>
-            <p className={picoClasses.label}>Route correction</p>
             <div className="mt-4 grid gap-3">
               <Link
                 href={derived.nextLesson ? toHref(`/academy/${derived.nextLesson.slug}`) : toHref('/academy')}
@@ -938,11 +949,46 @@ export function PicoAutopilotPageClient() {
             </div>
             <div className={picoSoft('mt-4 p-4')}>
               <p className={picoClasses.body}>
-                Stay here when the runtime is the source of truth. Go back to the academy when setup or the lesson workspace is still incomplete, use tutor when the next action is still probably documented, and escalate only when the live state stops being operable.
+                Stay here when the runtime is the source of truth. If the lesson workspace is still incomplete, the academy remains the cleaner route back to a real answer.
               </p>
             </div>
           </section>
         </aside>
+      </section>
+
+      <section className={picoPanel('mt-6 p-6 sm:p-7')} data-testid="pico-autopilot-control-protocol">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <p className={picoClasses.label}>Control protocol</p>
+            <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)] sm:text-4xl">
+              Three operator checks before automation earns trust
+            </h2>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+              The control room should stage the first decisions in plain sight. Read the last run, read the spend line, and keep risky actions exposed before you touch anything more abstract.
+            </p>
+          </div>
+          <span className={picoClasses.chip}>live operator checklist</span>
+        </div>
+
+        <div className={storyRailClass}>
+          {controlProtocol.map((item) => (
+            <article key={item.id} className={picoInset('snap-start flex h-full flex-col p-5 sm:p-6')}>
+              <div className="flex items-center justify-between gap-3">
+                <span className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-[color:var(--pico-border)] bg-[rgba(var(--pico-accent-rgb),0.12)] text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-accent)]">
+                  {item.id}
+                </span>
+                <span className={picoClasses.label}>Operator check</span>
+              </div>
+              <h3 className="mt-6 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                {item.title}
+              </h3>
+              <p className="mt-4 flex-1 text-sm leading-7 text-[color:var(--pico-text-secondary)]">{item.body}</p>
+              <Link href={item.href} className={cn(picoClasses.link, 'mt-6 inline-flex')}>
+                {item.action}
+              </Link>
+            </article>
+          ))}
+        </div>
       </section>
 
       <section className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.08fr),22rem]">
@@ -950,11 +996,11 @@ export function PicoAutopilotPageClient() {
           <div id="timeline-section" className={sectionClasses()}>
             <div className="flex items-center justify-between gap-4">
               <div>
-                <p className={picoClasses.label}>Activity timeline</p>
-                <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.05em] text-[#fff4e6]">
-                  What happened, when, and why it matters
+                <p className={picoClasses.label}>Signal narrative</p>
+                <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                  Read the live story before you touch settings
                 </h2>
-                <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   This is the operator narrative. If the timeline is empty, the correct answer is that nothing meaningful has happened yet.
                 </p>
               </div>
@@ -962,13 +1008,22 @@ export function PicoAutopilotPageClient() {
             </div>
             <div className="mt-5 space-y-4">
               {authRequired ? (
-                <div className="rounded-[24px] border border-[#4a3423] bg-[rgba(255,247,235,0.04)] p-5 text-sm leading-6 text-[#d5c0a8]">
+                <div className="rounded-[24px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] p-5 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   No timeline without live control-plane access. That is the honest answer.
                 </div>
               ) : timeline.length === 0 ? (
                 <EmptyStatePanel state={runEmptyState} />
               ) : (
-                timeline.map((item) => <TimelineItemCard key={item.id} item={item} />)
+                <>
+                  {visibleTimeline.map((item) => <TimelineItemCard key={item.id} item={item} />)}
+                  {timeline.length > visibleTimeline.length ? (
+                    <div className={picoSoft('p-4')}>
+                      <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                        {timeline.length - visibleTimeline.length} older signal{timeline.length - visibleTimeline.length === 1 ? '' : 's'} stayed out of view on purpose. Start with the strongest four.
+                      </p>
+                    </div>
+                  ) : null}
+                </>
               )}
             </div>
           </div>
@@ -976,11 +1031,11 @@ export function PicoAutopilotPageClient() {
           <div id="recent-runs" className={sectionClasses()}>
             <div className="flex items-center justify-between gap-4">
               <div>
-                <p className={picoClasses.label}>Runs</p>
-                <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.05em] text-[#fff4e6]">
-                  Recent execution history
+                <p className={picoClasses.label}>Run review</p>
+                <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                  Recent execution review
                 </h2>
-                <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   Start here. Read the latest run before you touch thresholds or approvals.
                 </p>
               </div>
@@ -994,13 +1049,14 @@ export function PicoAutopilotPageClient() {
             </div>
             <div className="mt-5 space-y-4">
               {authRequired ? (
-                <div className="rounded-[24px] border border-[#4a3423] bg-[rgba(255,247,235,0.04)] p-5 text-sm leading-6 text-[#d5c0a8]">
+                <div className="rounded-[24px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] p-5 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   Sign in, then come back here to inspect the first real run.
                 </div>
               ) : runs.length === 0 ? (
                 <EmptyStatePanel state={runEmptyState} />
               ) : (
-                runs.map((run) => {
+                <>
+                  {visibleRuns.map((run) => {
                   const severity = getRunSeverity(run.status)
                   const traces = tracesByRunId[run.id] ?? []
                   const runTimestamp = run.completed_at ?? run.started_at ?? run.created_at
@@ -1010,11 +1066,11 @@ export function PicoAutopilotPageClient() {
                       <div className="flex flex-wrap items-start justify-between gap-4">
                         <div>
                           <p className="text-xs uppercase tracking-[0.18em]">{humanizeRunStatus(run.status)}</p>
-                          <h3 className="mt-2 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+                          <h3 className="mt-2 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                             Run {run.id.slice(0, 8)}
                           </h3>
                         </div>
-                        <div className="text-right text-xs uppercase tracking-[0.18em] text-[#d5c0a8]">
+                        <div className="text-right text-xs uppercase tracking-[0.18em] text-[color:var(--pico-text-secondary)]">
                           <p>{formatTimestamp(runTimestamp)}</p>
                           <p className="mt-1">{formatRelativeTime(runTimestamp)}</p>
                         </div>
@@ -1025,7 +1081,7 @@ export function PicoAutopilotPageClient() {
                       <div className="mt-5 grid gap-3 lg:grid-cols-[minmax(0,1fr),18rem]">
                         <div className={picoInset('p-4')}>
                           <p className={picoClasses.label}>Operator read</p>
-                          <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                          <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                             {['FAILED', 'ERROR', 'CANCELLED'].includes(run.status.toUpperCase())
                               ? 'This job failed. If the agent is still trusted, it should be because you understand this failure.'
                               : ['RUNNING', 'QUEUED', 'PENDING'].includes(run.status.toUpperCase())
@@ -1036,7 +1092,7 @@ export function PicoAutopilotPageClient() {
 
                         <div className={picoInset('p-4')}>
                           <p className={picoClasses.label}>Run facts</p>
-                          <div className="mt-3 grid gap-2 text-sm text-[#d5c0a8]">
+                          <div className="mt-3 grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
                             <p>Agent: {run.agent_id ?? 'unknown'}</p>
                             <p>Trace count: {run.trace_count ?? traces.length}</p>
                             <p>
@@ -1051,7 +1107,7 @@ export function PicoAutopilotPageClient() {
                       <div className={picoInset('mt-4 p-4')}>
                         <p className={picoClasses.label}>Trace signals</p>
                         {traces.length === 0 ? (
-                          <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                          <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                             No run traces were returned for this run.
                           </p>
                         ) : (
@@ -1064,7 +1120,7 @@ export function PicoAutopilotPageClient() {
                                 <p className="text-xs uppercase tracking-[0.16em] text-[#b09376]">
                                   {trace.event_type}
                                 </p>
-                                <p className="mt-1 text-sm leading-6 text-[#d5c0a8]">{trace.message}</p>
+                                <p className="mt-1 text-sm leading-6 text-[color:var(--pico-text-secondary)]">{trace.message}</p>
                               </div>
                             ))}
                           </div>
@@ -1072,7 +1128,15 @@ export function PicoAutopilotPageClient() {
                       </div>
                     </article>
                   )
-                })
+                  })}
+                  {runs.length > visibleRuns.length ? (
+                    <div className={picoSoft('p-4')}>
+                      <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                        {runs.length - visibleRuns.length} older run{runs.length - visibleRuns.length === 1 ? '' : 's'} are hidden so the review stays on the latest decisions first.
+                      </p>
+                    </div>
+                  ) : null}
+                </>
               )}
             </div>
           </div>
@@ -1080,8 +1144,8 @@ export function PicoAutopilotPageClient() {
 
         <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start">
           <div id="budget-section" className={sectionClasses()}>
-            <p className={picoClasses.label}>Budget</p>
-            <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.05em] text-[#fff4e6]">
+            <p className={picoClasses.label}>Spend review</p>
+            <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.05em] text-[color:var(--pico-text)]">
               Live spend and your line in the sand
             </h2>
 
@@ -1090,7 +1154,7 @@ export function PicoAutopilotPageClient() {
                 <div className="flex items-start justify-between gap-4">
                   <div>
                     <p className={picoClasses.label}>Usage</p>
-                    <p className="mt-3 font-[family:var(--font-site-display)] text-5xl tracking-[-0.06em] text-[#fff4e6]">
+                    <p className="mt-3 font-[family:var(--font-site-display)] text-5xl tracking-[-0.06em] text-[color:var(--pico-text)]">
                       {authRequired ? '--' : budget ? formatPercent(budget.usage_percentage) : '--'}
                     </p>
                   </div>
@@ -1098,7 +1162,7 @@ export function PicoAutopilotPageClient() {
                     {thresholdBreached ? 'above threshold' : 'within threshold'}
                   </span>
                 </div>
-                <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   {authRequired
                     ? 'Live budget requires authentication.'
                     : budget
@@ -1109,12 +1173,12 @@ export function PicoAutopilotPageClient() {
 
               <div className={picoSoft('p-5')}>
                 <p className={picoClasses.label}>Threshold</p>
-                <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   Pico stores the local budget line here. Real alert delivery still follows the live MUTX monitoring setup, so this surface refuses to pretend email or webhook routing is active when it is not.
                 </p>
 
-                <label className="mt-4 block text-sm text-[#d5c0a8]">
-                  <span className="block text-xs uppercase tracking-[0.24em] text-[#a8896e]">
+                <label className="mt-4 block text-sm text-[color:var(--pico-text-secondary)]">
+                  <span className="block text-xs uppercase tracking-[0.24em] text-[color:var(--pico-text-muted)]">
                     Cost threshold percent
                   </span>
                   <input
@@ -1126,7 +1190,7 @@ export function PicoAutopilotPageClient() {
                       setError(null)
                       setThresholdDraft(Number(event.target.value))
                     }}
-                    className="mt-3 w-full rounded-2xl border border-[#4a3423] bg-[rgba(255,247,235,0.04)] px-4 py-3 text-sm text-[#fff4e6] outline-none"
+                    className="mt-3 w-full rounded-2xl border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-sm text-[color:var(--pico-text)] outline-none"
                   />
                 </label>
 
@@ -1135,7 +1199,7 @@ export function PicoAutopilotPageClient() {
                     type="button"
                     onClick={saveThreshold}
                     disabled={Boolean(thresholdValidationError)}
-                    className="inline-flex items-center justify-center gap-2 rounded-full bg-[#e2904f] px-4 py-2 text-sm font-semibold text-[#21130c] disabled:cursor-not-allowed disabled:opacity-60"
+                    className="inline-flex items-center justify-center gap-2 rounded-full bg-[color:var(--pico-accent)] px-4 py-2 text-sm font-semibold text-[color:var(--pico-accent-contrast)] disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     Save threshold
                   </button>
@@ -1159,12 +1223,12 @@ export function PicoAutopilotPageClient() {
                   <p className={picoClasses.label}>Top spenders</p>
                   <div className="mt-3 grid gap-2">
                     {authRequired ? (
-                      <p className="text-sm leading-6 text-[#d5c0a8]">Sign in to read the usage breakdown.</p>
+                      <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">Sign in to read the usage breakdown.</p>
                     ) : usage?.usage_by_agent.length ? (
                       usage.usage_by_agent.slice(0, 3).map((item) => (
                         <div key={`${item.agent_id}-${item.agent_name}`} className={picoSoft('px-4 py-3')}>
-                          <p className="font-medium text-[#fff4e6]">{item.agent_name}</p>
-                          <p className="mt-1 text-sm leading-6 text-[#d5c0a8]">
+                          <p className="font-medium text-[color:var(--pico-text)]">{item.agent_name}</p>
+                          <p className="mt-1 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                             {item.credits_used} credits across {item.event_count} events
                           </p>
                         </div>
@@ -1179,12 +1243,12 @@ export function PicoAutopilotPageClient() {
                   <p className={picoClasses.label}>Usage drivers</p>
                   <div className="mt-3 grid gap-2">
                     {authRequired ? (
-                      <p className="text-sm leading-6 text-[#d5c0a8]">Sign in to read the usage breakdown.</p>
+                      <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">Sign in to read the usage breakdown.</p>
                     ) : usage?.usage_by_type.length ? (
                       usage.usage_by_type.slice(0, 3).map((item) => (
                         <div key={item.event_type} className={picoSoft('px-4 py-3')}>
-                          <p className="font-medium text-[#fff4e6]">{item.event_type}</p>
-                          <p className="mt-1 text-sm leading-6 text-[#d5c0a8]">
+                          <p className="font-medium text-[color:var(--pico-text)]">{item.event_type}</p>
+                          <p className="mt-1 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                             {item.credits_used} credits across {item.event_count} events
                           </p>
                         </div>
@@ -1200,48 +1264,57 @@ export function PicoAutopilotPageClient() {
 
           <div id="alerts-section" className={sectionClasses()}>
             <p className={picoClasses.label}>Alerts</p>
-            <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.05em] text-[#fff4e6]">
+            <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.05em] text-[color:var(--pico-text)]">
               Meaningful monitoring events
             </h2>
-            <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+            <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
               This is the live alert feed. No fake warning badges, no synthetic incidents.
             </p>
 
             <div className="mt-5 space-y-4">
               {authRequired ? (
-                <div className="rounded-[24px] border border-[#4a3423] bg-[rgba(255,247,235,0.04)] p-5 text-sm leading-6 text-[#d5c0a8]">
+                <div className="rounded-[24px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] p-5 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   Sign in to load live alerts.
                 </div>
               ) : alerts.length === 0 ? (
                 <EmptyStatePanel state={alertsEmptyState} />
               ) : (
-                alerts.map((alert) => (
-                  <article
-                    key={alert.id}
-                    className={`rounded-[24px] border p-5 ${severityClasses(alert.resolved ? 'good' : 'critical')}`}
-                  >
-                    <div className="flex flex-wrap items-center justify-between gap-3">
-                      <div>
-                        <p className="text-xs uppercase tracking-[0.18em]">{alert.type}</p>
-                        <h3 className="mt-2 text-lg font-semibold text-[#fff4e6]">
-                          {alert.resolved ? 'Resolved alert' : 'Active alert'}
-                        </h3>
+                <>
+                  {visibleAlerts.map((alert) => (
+                    <article
+                      key={alert.id}
+                      className={`rounded-[24px] border p-5 ${severityClasses(alert.resolved ? 'good' : 'critical')}`}
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                          <p className="text-xs uppercase tracking-[0.18em]">{alert.type}</p>
+                          <h3 className="mt-2 text-lg font-semibold text-[color:var(--pico-text)]">
+                            {alert.resolved ? 'Resolved alert' : 'Active alert'}
+                          </h3>
+                        </div>
+                        <div className="text-right text-xs uppercase tracking-[0.18em] text-[color:var(--pico-text-secondary)]">
+                          <p>{formatTimestamp(alert.resolved_at ?? alert.created_at)}</p>
+                          <p className="mt-1">{formatRelativeTime(alert.resolved_at ?? alert.created_at)}</p>
+                        </div>
                       </div>
-                      <div className="text-right text-xs uppercase tracking-[0.18em] text-[#d5c0a8]">
-                        <p>{formatTimestamp(alert.resolved_at ?? alert.created_at)}</p>
-                        <p className="mt-1">{formatRelativeTime(alert.resolved_at ?? alert.created_at)}</p>
+                      <p className="mt-4 text-sm leading-6">{alert.message}</p>
+                      <div className="mt-3 flex flex-wrap gap-4 text-sm text-[color:var(--pico-text-secondary)]">
+                        <span>Agent: {alert.agent_id}</span>
+                        <span>{alert.resolved ? 'Resolved' : 'Still active'}</span>
                       </div>
+                      <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                        Why it matters: {explainAlertImpact(alert)}
+                      </p>
+                    </article>
+                  ))}
+                  {alerts.length > visibleAlerts.length ? (
+                    <div className={picoSoft('p-4')}>
+                      <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                        {alerts.length - visibleAlerts.length} additional alert{alerts.length - visibleAlerts.length === 1 ? '' : 's'} are suppressed so the feed stays editorial instead of turning into a wall of badges.
+                      </p>
                     </div>
-                    <p className="mt-4 text-sm leading-6">{alert.message}</p>
-                    <div className="mt-3 flex flex-wrap gap-4 text-sm text-[#d5c0a8]">
-                      <span>Agent: {alert.agent_id}</span>
-                      <span>{alert.resolved ? 'Resolved' : 'Still active'}</span>
-                    </div>
-                    <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
-                      Why it matters: {explainAlertImpact(alert)}
-                    </p>
-                  </article>
-                ))
+                  ) : null}
+                </>
               )}
             </div>
           </div>
@@ -1251,109 +1324,20 @@ export function PicoAutopilotPageClient() {
       <section id="approvals-section" className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.08fr),22rem]">
         <div className={sectionClasses()}>
           <p className={picoClasses.label}>Approvals</p>
-          <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.05em] text-[#fff4e6]">
+          <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.05em] text-[color:var(--pico-text)]">
             Risky actions and their decisions
           </h2>
-          <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+          <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
             This queue is now the approval source of truth for Pico. It should not disappear because a process restarted.
           </p>
 
           <div className="mt-5 space-y-4">
             {authRequired ? (
-              <div className="rounded-[24px] border border-[#4a3423] bg-[rgba(255,247,235,0.04)] p-5 text-sm leading-6 text-[#d5c0a8]">
+              <div className="rounded-[24px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] p-5 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                 Sign in to load live approval requests.
               </div>
             ) : (
               <>
-                <div className={picoInset('grid gap-4 p-5')}>
-                  <div className="flex items-start justify-between gap-4">
-                    <div>
-                      <p className={picoClasses.label}>Create a gated action</p>
-                      <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                        Use this to exercise the live approval queue from Pico instead of waiting for another surface to create the request first.
-                      </p>
-                    </div>
-                    <span className={picoClasses.chip}>live queue write</span>
-                  </div>
-
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <label className="grid gap-2 text-sm text-[#d5c0a8]">
-                      <span className={picoClasses.label}>Agent ID</span>
-                      <input
-                        value={approvalDraft.agentId}
-                        onChange={(event) =>
-                          setApprovalDraft((current) => ({ ...current, agentId: event.target.value }))
-                        }
-                        className="rounded-[20px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-3 text-[#fff4e6] outline-none placeholder:text-[#8f7157]"
-                        placeholder="agent-founder-lab"
-                      />
-                    </label>
-
-                    <label className="grid gap-2 text-sm text-[#d5c0a8]">
-                      <span className={picoClasses.label}>Session or run ID</span>
-                      <input
-                        value={approvalDraft.sessionId}
-                        onChange={(event) =>
-                          setApprovalDraft((current) => ({ ...current, sessionId: event.target.value }))
-                        }
-                        className="rounded-[20px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-3 text-[#fff4e6] outline-none placeholder:text-[#8f7157]"
-                        placeholder="ses-pico-approval"
-                      />
-                    </label>
-                  </div>
-
-                  <label className="grid gap-2 text-sm text-[#d5c0a8]">
-                    <span className={picoClasses.label}>Action type</span>
-                    <input
-                      value={approvalDraft.actionType}
-                      onChange={(event) =>
-                        setApprovalDraft((current) => ({ ...current, actionType: event.target.value }))
-                      }
-                      className="rounded-[20px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-3 text-[#fff4e6] outline-none placeholder:text-[#8f7157]"
-                      placeholder="OUTBOUND_SEND"
-                    />
-                  </label>
-
-                  <label className="grid gap-2 text-sm text-[#d5c0a8]">
-                    <span className={picoClasses.label}>Why this action needs a gate</span>
-                    <textarea
-                      value={approvalDraft.summary}
-                      onChange={(event) =>
-                        setApprovalDraft((current) => ({ ...current, summary: event.target.value }))
-                      }
-                      rows={4}
-                      className="rounded-[20px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-3 text-[#fff4e6] outline-none placeholder:text-[#8f7157]"
-                      placeholder="Describe the risky action clearly."
-                    />
-                  </label>
-
-                  <div className="flex flex-wrap gap-3">
-                    <button
-                      type="button"
-                      onClick={() => void createApprovalRequest()}
-                      disabled={creatingApproval}
-                      className={picoClasses.primaryButton}
-                    >
-                      {creatingApproval ? 'Creating request...' : 'Create approval request'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setApprovalDraft({
-                          agentId: latestRun?.agent_id || 'agent-founder-lab',
-                          sessionId: latestRun?.id || 'ses-pico-approval',
-                          actionType: 'OUTBOUND_SEND',
-                          summary:
-                            'Outbound send requires a human decision before the runtime crosses the line.',
-                        })
-                      }
-                      className={picoClasses.secondaryButton}
-                    >
-                      Reset draft
-                    </button>
-                  </div>
-                </div>
-
                 {pendingApprovals.length === 0 && resolvedApprovals.length === 0 ? (
                   <EmptyStatePanel state={approvalsEmptyState} />
                 ) : null}
@@ -1364,14 +1348,14 @@ export function PicoAutopilotPageClient() {
                   </div>
                 ) : null}
 
-                {pendingApprovals.map((approval) => (
+                {visiblePendingApprovals.map((approval) => (
                   <article key={approval.id} className={`rounded-[24px] border p-5 ${severityClasses('warn')}`}>
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <div>
                         <p className="text-xs uppercase tracking-[0.18em]">Pending</p>
-                        <h3 className="mt-2 text-lg font-semibold text-[#fff4e6]">{approval.action_type}</h3>
+                        <h3 className="mt-2 text-lg font-semibold text-[color:var(--pico-text)]">{approval.action_type}</h3>
                       </div>
-                      <div className="text-right text-xs uppercase tracking-[0.18em] text-[#d5c0a8]">
+                      <div className="text-right text-xs uppercase tracking-[0.18em] text-[color:var(--pico-text-secondary)]">
                         <p>{formatTimestamp(approval.created_at)}</p>
                         <p className="mt-1">{formatRelativeTime(approval.created_at)}</p>
                       </div>
@@ -1381,7 +1365,7 @@ export function PicoAutopilotPageClient() {
                         ? approval.payload.summary
                         : `${approval.requester} requested this action for agent ${approval.agent_id}.`}
                     </p>
-                    <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                    <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                       Why it matters: {explainApprovalImpact(approval)}
                     </p>
                     <div className="mt-4 flex flex-wrap gap-3">
@@ -1389,7 +1373,7 @@ export function PicoAutopilotPageClient() {
                         type="button"
                         onClick={() => void resolveApproval(approval.id, 'approve')}
                         disabled={resolvingApprovalId === approval.id}
-                        className="inline-flex items-center justify-center gap-2 rounded-full bg-[#e2904f] px-4 py-2 text-sm font-semibold text-[#21130c] disabled:cursor-not-allowed disabled:opacity-60"
+                        className="inline-flex items-center justify-center gap-2 rounded-full bg-[color:var(--pico-accent)] px-4 py-2 text-sm font-semibold text-[color:var(--pico-accent-contrast)] disabled:cursor-not-allowed disabled:opacity-60"
                       >
                         {resolvingApprovalId === approval.id ? 'Working...' : 'Approve'}
                       </button>
@@ -1397,13 +1381,20 @@ export function PicoAutopilotPageClient() {
                         type="button"
                         onClick={() => void resolveApproval(approval.id, 'reject')}
                         disabled={resolvingApprovalId === approval.id}
-                        className="rounded-full border border-[#4a3423] px-4 py-2 text-sm font-medium text-[#efe1cf] disabled:cursor-not-allowed disabled:opacity-60"
+                        className="rounded-full border border-[color:var(--pico-border)] px-4 py-2 text-sm font-medium text-[color:var(--pico-text-secondary)] disabled:cursor-not-allowed disabled:opacity-60"
                       >
                         {resolvingApprovalId === approval.id ? 'Working...' : 'Reject'}
                       </button>
                     </div>
                   </article>
                 ))}
+                {pendingApprovals.length > visiblePendingApprovals.length ? (
+                  <div className={picoSoft('p-4')}>
+                    <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      {pendingApprovals.length - visiblePendingApprovals.length} more pending approval{pendingApprovals.length - visiblePendingApprovals.length === 1 ? '' : 's'} stayed out of view so the queue keeps the sharpest decisions on top.
+                    </p>
+                  </div>
+                ) : null}
               </>
             )}
           </div>
@@ -1411,19 +1402,110 @@ export function PicoAutopilotPageClient() {
 
         <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start">
           <section className={picoPanel('p-5')}>
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className={picoClasses.label}>Create a gated action</p>
+                <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                  Exercise the live approval queue here instead of waiting for another surface to create the request first.
+                </p>
+              </div>
+              <span className={picoClasses.chip}>live queue write</span>
+            </div>
+
+            <div className="mt-4 grid gap-4">
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-1">
+                <label className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
+                  <span className={picoClasses.label}>Agent ID</span>
+                  <input
+                    value={approvalDraft.agentId}
+                    onChange={(event) =>
+                      setApprovalDraft((current) => ({ ...current, agentId: event.target.value }))
+                    }
+                    className="rounded-[20px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
+                    placeholder="agent-founder-lab"
+                  />
+                </label>
+
+                <label className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
+                  <span className={picoClasses.label}>Session or run ID</span>
+                  <input
+                    value={approvalDraft.sessionId}
+                    onChange={(event) =>
+                      setApprovalDraft((current) => ({ ...current, sessionId: event.target.value }))
+                    }
+                    className="rounded-[20px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
+                    placeholder="ses-pico-approval"
+                  />
+                </label>
+              </div>
+
+              <label className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
+                <span className={picoClasses.label}>Action type</span>
+                <input
+                  value={approvalDraft.actionType}
+                  onChange={(event) =>
+                    setApprovalDraft((current) => ({ ...current, actionType: event.target.value }))
+                  }
+                  className="rounded-[20px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
+                  placeholder="OUTBOUND_SEND"
+                />
+              </label>
+
+              <label className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
+                <span className={picoClasses.label}>Why this action needs a gate</span>
+                <textarea
+                  value={approvalDraft.summary}
+                  onChange={(event) =>
+                    setApprovalDraft((current) => ({ ...current, summary: event.target.value }))
+                  }
+                  rows={4}
+                  className="rounded-[20px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
+                  placeholder="Describe the risky action clearly."
+                />
+              </label>
+
+              <div className="grid gap-3">
+                <button
+                  type="button"
+                  onClick={() => void createApprovalRequest()}
+                  disabled={creatingApproval}
+                  className={picoClasses.primaryButton}
+                >
+                  {creatingApproval ? 'Creating request...' : 'Create approval request'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setApprovalDraft({
+                      agentId: latestRun?.agent_id || 'agent-founder-lab',
+                      sessionId: latestRun?.id || 'ses-pico-approval',
+                      actionType: 'OUTBOUND_SEND',
+                      summary:
+                        'Outbound send requires a human decision before the runtime crosses the line.',
+                    })
+                  }
+                  className={picoClasses.secondaryButton}
+                >
+                  Reset draft
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <section className={picoPanel('p-5')}>
             <p className={picoClasses.label}>Gate status</p>
             <div className="mt-4 grid gap-3">
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Pending actions</p>
-                <p className="mt-1 text-2xl font-semibold text-[#fff4e6]">{liveValue(String(pendingApprovals.length))}</p>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Pending actions</p>
+                <p className="mt-1 text-2xl font-semibold text-[color:var(--pico-text)]">{liveValue(String(pendingApprovals.length))}</p>
               </div>
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Decision history</p>
-                <p className="mt-1 text-2xl font-semibold text-[#fff4e6]">{liveValue(String(resolvedApprovals.length))}</p>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Decision history</p>
+                <p className="mt-1 text-2xl font-semibold text-[color:var(--pico-text)]">{liveValue(String(resolvedApprovals.length))}</p>
               </div>
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Configured locally</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Configured locally</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {progress.autopilot.approvalGateEnabled ? 'yes' : 'no'}
                 </p>
               </div>
@@ -1434,7 +1516,7 @@ export function PicoAutopilotPageClient() {
             <section className={picoPanel('p-5')}>
               <p className={picoClasses.label}>Recent decisions</p>
               <div className="mt-4 grid gap-3">
-                {resolvedApprovals.map((approval) => (
+                {visibleResolvedApprovals.map((approval) => (
                   <article
                     key={approval.id}
                     className={`rounded-[24px] border p-4 ${severityClasses(approval.status === 'APPROVED' ? 'good' : 'critical')}`}
@@ -1442,7 +1524,7 @@ export function PicoAutopilotPageClient() {
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <p className="text-xs uppercase tracking-[0.18em]">{approval.status}</p>
-                        <h3 className="mt-2 text-base font-semibold text-[#fff4e6]">{approval.action_type}</h3>
+                        <h3 className="mt-2 text-base font-semibold text-[color:var(--pico-text)]">{approval.action_type}</h3>
                       </div>
                       <span className={picoClasses.chip}>
                         {formatRelativeTime(approval.resolved_at ?? approval.created_at)}
@@ -1453,11 +1535,18 @@ export function PicoAutopilotPageClient() {
                         ? approval.payload.summary
                         : `${approval.requester} requested this action for agent ${approval.agent_id}.`}
                     </p>
-                    <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                    <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                       Why it matters: {explainApprovalImpact(approval)}
                     </p>
                   </article>
                 ))}
+                {resolvedApprovals.length > visibleResolvedApprovals.length ? (
+                  <div className={picoSoft('p-4')}>
+                    <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      {resolvedApprovals.length - visibleResolvedApprovals.length} older decision{resolvedApprovals.length - visibleResolvedApprovals.length === 1 ? '' : 's'} are hidden so the recent record stays readable.
+                    </p>
+                  </div>
+                ) : null}
               </div>
             </section>
           ) : null}

--- a/components/pico/PicoFooter.tsx
+++ b/components/pico/PicoFooter.tsx
@@ -1,10 +1,32 @@
 import { useTranslations } from 'next-intl'
 import Image from 'next/image'
+import Link from 'next/link'
 
 import { cn } from '@/lib/utils'
 import core from '@/components/site/marketing/MarketingCore.module.css'
 
 const SITE = 'https://mutx.dev'
+
+const atlasLinks = [
+  { href: '/pico/onboarding', label: 'Onboarding', note: 'first visible win' },
+  { href: '/pico/academy', label: 'Academy', note: 'the working path' },
+  { href: '/pico/tutor', label: 'Tutor', note: 'grounded critique' },
+  { href: '/pico/autopilot', label: 'Autopilot', note: 'live control room' },
+  { href: '/pico/support', label: 'Support', note: 'the messy edge' },
+] as const
+
+const mutxLinks: Array<{
+  href: string
+  labelKey: string
+  external?: boolean
+}> = [
+  { href: `${SITE}/releases`, labelKey: 'links.releases' },
+  { href: 'https://docs.mutx.dev', labelKey: 'links.docs', external: true },
+  { href: 'https://github.com/mutx-dev/mutx-dev', labelKey: 'links.github', external: true },
+  { href: `${SITE}/download`, labelKey: 'links.download' },
+  { href: `${SITE}/contact`, labelKey: 'links.contact' },
+  { href: `${SITE}/privacy-policy`, labelKey: 'links.privacy' },
+] as const
 
 export function PicoFooter({ className }: { className?: string }) {
   const t = useTranslations('pico.footer')
@@ -12,77 +34,90 @@ export function PicoFooter({ className }: { className?: string }) {
   return (
     <footer
       data-testid="pico-footer"
-      className={cn(className)}
-      style={{
-        borderTop: '1px solid var(--pico-border)',
-        background: 'var(--pico-bg)',
-        color: 'var(--pico-text-secondary)',
-        padding: 'clamp(2rem, 4vw, 3rem) 0',
-        fontFamily: 'var(--font-site-body), sans-serif',
-      }}
+      className={cn(
+        className,
+        'relative z-[1] border-t border-[color:var(--pico-border)] bg-[linear-gradient(180deg,rgba(6,12,8,0.96),rgba(2,6,3,0.99))] text-[color:var(--pico-text-secondary)] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]',
+      )}
     >
-      <div className={core.shell}>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.6rem 1.4rem', alignItems: 'center' }}>
-          <a
-            href={`${SITE}/releases`}
-            style={{ fontSize: '0.85rem', color: 'inherit', textDecoration: 'none' }}
-          >
-            {t('links.releases')}
-          </a>
-          <a
-            href="https://docs.mutx.dev"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ fontSize: '0.85rem', color: 'inherit', textDecoration: 'none' }}
-          >
-            {t('links.docs')}
-          </a>
-          <a
-            href="https://github.com/mutx-dev/mutx-dev"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ fontSize: '0.85rem', color: 'inherit', textDecoration: 'none' }}
-          >
-            {t('links.github')}
-          </a>
-          <a
-            href={`${SITE}/download`}
-            style={{ fontSize: '0.85rem', color: 'inherit', textDecoration: 'none' }}
-          >
-            {t('links.download')}
-          </a>
-          <a
-            href={`${SITE}/contact`}
-            style={{ fontSize: '0.85rem', color: 'inherit', textDecoration: 'none' }}
-          >
-            {t('links.contact')}
-          </a>
-          <a
-            href={`${SITE}/privacy-policy`}
-            style={{ fontSize: '0.85rem', color: 'inherit', textDecoration: 'none' }}
-          >
-            {t('links.privacy')}
-          </a>
-        </div>
-        <p style={{ margin: '1.2rem 0 0', fontSize: '0.82rem', lineHeight: 1.5, color: 'var(--pico-text-muted)' }}>
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.6rem' }}>
-            <span
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                width: '1.9rem',
-                height: '1.9rem',
-                borderRadius: '0.55rem',
-                background: 'linear-gradient(135deg, rgba(var(--pico-accent-rgb), 0.1), rgba(15, 42, 11, 0.72))',
-                border: '1px solid var(--pico-border)',
-              }}
-            >
+      <div className={cn(core.shell, 'grid gap-10 py-10 sm:py-12 lg:grid-cols-[minmax(0,1.2fr),minmax(0,0.8fr),minmax(0,0.8fr)]')}>
+        <div className="grid gap-5">
+          <Link href="/pico" className="inline-flex w-fit items-center gap-3 text-[color:var(--pico-text)] no-underline">
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-[16px] border border-[color:var(--pico-border)] bg-[linear-gradient(145deg,rgba(var(--pico-accent-rgb),0.12),rgba(8,18,10,0.82))] shadow-[0_16px_36px_rgba(0,0,0,0.26)]">
               <Image src="/pico/logo.png" alt="PicoMUTX logo" width={22} height={22} />
             </span>
-            {t('copyright')}
-          </span>
-        </p>
+            <span className="grid gap-1">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--pico-text-muted)]">
+                PicoMUTX
+              </span>
+              <span className="font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em]">
+                operator atlas
+              </span>
+            </span>
+          </Link>
+
+          <p className="max-w-[32rem] text-sm leading-7 text-[color:var(--pico-text-secondary)]">
+            Pico should feel like one premium studio product from the first lesson to the messy edge.
+            The route matters. The proof matters. Human help is the last lane, not the default one.
+          </p>
+
+          <div className="flex flex-wrap gap-2">
+            <span className="inline-flex rounded-full border border-[color:rgba(var(--pico-accent-rgb),0.22)] bg-[rgba(var(--pico-accent-rgb),0.08)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-accent-bright)]">
+              green studio system
+            </span>
+            <span className="inline-flex rounded-full border border-[color:rgba(var(--pico-accent-rgb),0.22)] bg-[rgba(var(--pico-accent-rgb),0.08)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-accent-bright)]">
+              proof-first learning
+            </span>
+            <span className="inline-flex rounded-full border border-[color:rgba(var(--pico-accent-rgb),0.22)] bg-[rgba(var(--pico-accent-rgb),0.08)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-accent-bright)]">
+              premium operator flow
+            </span>
+          </div>
+        </div>
+
+        <div className="grid gap-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--pico-text-muted)]">
+            Atlas routes
+          </p>
+          <div className="grid gap-2">
+            {atlasLinks.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="grid gap-1 rounded-[20px] border border-[color:rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.015)] px-4 py-3 no-underline transition duration-200 hover:border-[color:var(--pico-border-hover)] hover:bg-[rgba(var(--pico-accent-rgb),0.08)]"
+              >
+                <span className="font-medium text-[color:var(--pico-text)]">{item.label}</span>
+                <span className="text-xs text-[color:var(--pico-text-muted)]">{item.note}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid gap-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--pico-text-muted)]">
+            MUTX links
+          </p>
+          <div className="grid gap-2">
+            {mutxLinks.map((item) => (
+              <a
+                key={item.href}
+                href={item.href}
+                target={item.external ? '_blank' : undefined}
+                rel={item.external ? 'noopener noreferrer' : undefined}
+                className="inline-flex items-center rounded-[18px] border border-[color:rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.015)] px-4 py-3 text-sm text-[color:var(--pico-text-secondary)] no-underline transition duration-200 hover:border-[color:var(--pico-border-hover)] hover:bg-[rgba(255,255,255,0.03)] hover:text-[color:var(--pico-text)]"
+              >
+                {t(item.labelKey)}
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t border-[color:rgba(255,255,255,0.05)]">
+        <div className={cn(core.shell, 'flex flex-wrap items-center justify-between gap-3 py-4')}>
+          <p className="text-sm text-[color:var(--pico-text-muted)]">{t('copyright')}</p>
+          <p className="text-[11px] uppercase tracking-[0.22em] text-[color:var(--pico-text-muted)]">
+            pico.mutx.dev / operator atlas
+          </p>
+        </div>
       </div>
     </footer>
   )

--- a/components/pico/PicoLandingPage.tsx
+++ b/components/pico/PicoLandingPage.tsx
@@ -13,6 +13,76 @@ import { PicoContactForm } from './PicoContactForm'
 import { PicoLangSwitcher } from './PicoLangSwitcher'
 
 const HOW_ICONS = ['path', 'support', 'shield', 'expert'] as const
+const ATLAS_ROUTES = [
+  {
+    href: '/pico/onboarding',
+    chapter: '01',
+    title: 'Onboarding',
+    note: 'first visible win',
+    body: 'Get Hermes open, run one bounded prompt, and capture one proof artifact before the world gets noisy.',
+  },
+  {
+    href: '/pico/academy',
+    chapter: '02',
+    title: 'Academy',
+    note: 'brief, deliverable, critique',
+    body: 'Follow the route lesson by lesson with a studio-style brief and a real validation line.',
+  },
+  {
+    href: '/pico/tutor',
+    chapter: '03',
+    title: 'Tutor',
+    note: 'grounded critique desk',
+    body: 'Bring one blocker, leave with one next move, and go back into motion immediately.',
+  },
+  {
+    href: '/pico/autopilot',
+    chapter: '04',
+    title: 'Autopilot',
+    note: 'live control room',
+    body: 'Read the run, the budget line, and the approval gate before you trust the automation.',
+  },
+  {
+    href: '/pico/support',
+    chapter: '05',
+    title: 'Support',
+    note: 'the messy edge',
+    body: 'Escalate with a clean packet when the product path stops being honest enough on its own.',
+  },
+] as const
+
+const HERO_METHOD = [
+  {
+    label: '01',
+    title: 'Brief',
+    body: 'Start with one exact outcome and one visible finish line.',
+  },
+  {
+    label: '02',
+    title: 'Deliverable',
+    body: 'Every chapter ends with an artifact, not a vague feeling of progress.',
+  },
+  {
+    label: '03',
+    title: 'Critique',
+    body: 'Tutor, Autopilot, and Support exist to sharpen the next move fast.',
+  },
+] as const
+
+const HERO_LEDGER = [
+  {
+    label: 'Five authored rooms',
+    body: 'Onboarding, Academy, Tutor, Autopilot, and Support all behave like one system.',
+  },
+  {
+    label: 'One proof per chapter',
+    body: 'The learning path only counts when the route leaves behind evidence.',
+  },
+  {
+    label: 'Human help at the edge',
+    body: 'The product should carry the load until the messy edge is real.',
+  },
+] as const
 
 function HowItWorksIcon({ kind }: { kind: string }) {
   const sz = 20
@@ -92,44 +162,187 @@ export function PicoLandingPage() {
         <section className={s.hero}>
           <div className={s.heroAmbient} aria-hidden="true" />
           <div className={s.heroGrid}>
-            <SiteReveal delay={0.05}>
-              <span className={s.heroBadge}>{t('hero.badge')}</span>
-            </SiteReveal>
+            <div className={s.heroCopy}>
+              <SiteReveal delay={0.05}>
+                <span className={s.heroBadge}>{t('hero.badge')}</span>
+              </SiteReveal>
 
-            <SiteReveal delay={0.1}>
-              <h1 className={s.heroTitle}>
-                {t('hero.title')}
-                <span className={s.heroTitleAccent}>{t('hero.titleAccent')}</span>
-              </h1>
-            </SiteReveal>
+              <SiteReveal delay={0.1}>
+                <h1 className={s.heroTitle}>
+                  {t('hero.title')}
+                  <span className={s.heroTitleAccent}>{t('hero.titleAccent')}</span>
+                </h1>
+              </SiteReveal>
 
-            <SiteReveal delay={0.16}>
-              <p className={s.heroSub}>{t('hero.subtitle')}</p>
-            </SiteReveal>
+              <SiteReveal delay={0.16}>
+                <p className={s.heroSub}>{t('hero.subtitle')}</p>
+              </SiteReveal>
 
-            <SiteReveal delay={0.22}>
-              <div className={s.heroActions}>
-                <button onClick={() => openForm()} className={s.btnPrimary} type="button">
-                  {t('hero.cta')}
-                  <ArrowRight className="h-4 w-4" />
-                </button>
-              </div>
-            </SiteReveal>
+              <SiteReveal delay={0.22}>
+                <div className={s.heroActions}>
+                  <Link href="/pico/onboarding" className={s.btnPrimary}>
+                    Enter the atlas
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                  <button onClick={() => openForm()} className={s.btnSecondary} type="button">
+                    {t('hero.cta')}
+                  </button>
+                </div>
+              </SiteReveal>
 
-            <SiteReveal delay={0.26}>
-              <p className={s.heroMeta}>{t('hero.meta')}</p>
-            </SiteReveal>
+              <SiteReveal delay={0.26}>
+                <p className={s.heroMeta}>
+                  Pico behaves like a studio learning product when every room has one job, one tone,
+                  and one irreversible next move.
+                </p>
+              </SiteReveal>
 
-            <SiteReveal delay={0.3}>
-              <div className={s.trustBar}>
-                {Array.from({ length: 3 }, (_, i) => (
-                  <span key={i} className={s.trustItem}>
-                    {i > 0 && <span className={s.trustSep} aria-hidden="true">|</span>}
-                    {t(`trustBar.items.${i}`)}
-                  </span>
-                ))}
-              </div>
-            </SiteReveal>
+              <SiteReveal delay={0.3}>
+                <div className={s.heroLedger}>
+                  {HERO_LEDGER.map((item) => (
+                    <div key={item.label} className={s.heroLedgerItem}>
+                      <p className={s.heroLedgerLabel}>{item.label}</p>
+                      <p className={s.heroLedgerBody}>{item.body}</p>
+                    </div>
+                  ))}
+                </div>
+              </SiteReveal>
+
+              <SiteReveal delay={0.34}>
+                <div className={s.trustBar}>
+                  {Array.from({ length: 3 }, (_, i) => (
+                    <span key={i} className={s.trustItem}>
+                      {i > 0 && <span className={s.trustSep} aria-hidden="true">|</span>}
+                      {t(`trustBar.items.${i}`)}
+                    </span>
+                  ))}
+                </div>
+              </SiteReveal>
+            </div>
+
+            <div className={s.heroStage}>
+              <SiteReveal delay={0.2}>
+                <div className={s.heroStageTop}>
+                  <div className={s.heroMethodCard}>
+                    <div className={s.heroCardHeader}>
+                      <span className={s.heroCardEyebrow}>Studio method</span>
+                      <span className={s.heroCardChip}>brief / deliverable / critique</span>
+                    </div>
+                    <p className={s.heroCardTitle}>Learn the product the way a serious studio would teach it.</p>
+                    <div className={s.heroMethodList}>
+                      {HERO_METHOD.map((item) => (
+                        <div key={item.label} className={s.heroMethodItem}>
+                          <span className={s.heroMethodIndex}>{item.label}</span>
+                          <div>
+                            <p className={s.heroMethodTitle}>{item.title}</p>
+                            <p className={s.heroMethodBody}>{item.body}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className={s.heroRouteCard}>
+                    <div className={s.heroCardHeader}>
+                      <span className={s.heroCardEyebrow}>Atlas rooms</span>
+                      <span className={s.heroCardChip}>all paths live</span>
+                    </div>
+                    <div className={s.heroRouteList}>
+                      {ATLAS_ROUTES.map((route) => (
+                        <Link key={route.href} href={route.href} className={s.heroRouteRow}>
+                          <span className={s.heroRouteChapter}>{route.chapter}</span>
+                          <div className={s.heroRouteMeta}>
+                            <p className={s.heroRouteTitle}>{route.title}</p>
+                            <p className={s.heroRouteNote}>{route.note}</p>
+                          </div>
+                          <ArrowRight className="h-4 w-4" />
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </SiteReveal>
+
+              <SiteReveal delay={0.36}>
+                <motion.div
+                  className={s.heroVisual}
+                  whileHover={prefersReducedMotion ? undefined : { y: -4, scale: 1.01 }}
+                  transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
+                >
+                  <div className={s.terminal} aria-hidden="true">
+                    <div className={s.terminalBar}>
+                      <span className={s.terminalDot} style={{ background: 'var(--pico-red)' }} />
+                      <span className={s.terminalDot} style={{ background: 'var(--pico-yellow)' }} />
+                      <span className={s.terminalDot} style={{ background: 'var(--pico-accent)' }} />
+                      <span className={s.terminalTitle}>pico.mutx.dev / operator atlas</span>
+                    </div>
+                    <div className={s.terminalBody}>
+                      <div className={s.terminalLine}>
+                        <span className={s.tGreen}>MISSION</span>
+                        <span className={s.tDim}>//</span>
+                        <span className={s.tWhite}>ship the first working agent before the room gets noisy</span>
+                      </div>
+                      <div className={s.terminalLine}>
+                        <span className={s.tMuted}>surface.start</span>
+                        <span className={s.tDim}>→</span>
+                        <span className={s.tWhite}>onboarding / first visible win</span>
+                      </div>
+                      <div className={s.terminalLine}>
+                        <span className={s.tMuted}>surface.lesson</span>
+                        <span className={s.tDim}>→</span>
+                        <span className={s.tWhite}>proof captured / command survives</span>
+                      </div>
+                      <div className={s.terminalLine}>
+                        <span className={s.tMuted}>surface.tutor</span>
+                        <span className={s.tDim}>→</span>
+                        <span className={s.tWhite}>one grounded next step</span>
+                      </div>
+                      <div className={s.terminalLine}>
+                        <span className={s.tMuted}>surface.autopilot</span>
+                        <span className={s.tDim}>→</span>
+                        <span className={s.tWhite}>runs, budget, approvals, live truth</span>
+                      </div>
+                      <div className={s.terminalStatusBar}>
+                        <span><span className={s.tGreen}>FOUNDING</span> access</span>
+                        <span><span className={s.tWhite}>PREMIUM</span> operator flow</span>
+                        <span><span className={s.tYellow}>GREEN</span> studio system</span>
+                      </div>
+                    </div>
+                  </div>
+                </motion.div>
+              </SiteReveal>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${s.section} ${s.sectionAtlas}`}>
+          <div className={s.shell}>
+            <div className={s.sectionHeader}>
+              <span className={s.eyebrow}>Operator atlas</span>
+              <h2 className={s.sectionTitle}>Every route in one authored system.</h2>
+              <p className={s.sectionBody}>
+                Pico is strongest when each surface has one job, one mood, and one next move. Start in the right room.
+              </p>
+            </div>
+
+            <div className={s.atlasGrid}>
+              {ATLAS_ROUTES.map((route, index) => (
+                <SiteReveal key={route.href} delay={0.04 * index}>
+                  <Link href={route.href} className={s.atlasCard}>
+                    <div className={s.atlasMeta}>
+                      <span className={s.atlasChapter}>{route.chapter}</span>
+                      <span className={s.atlasNote}>{route.note}</span>
+                    </div>
+                    <h3 className={s.atlasTitle}>{route.title}</h3>
+                    <p className={s.atlasBody}>{route.body}</p>
+                    <span className={s.atlasLink}>
+                      Open route
+                      <ArrowRight className="h-4 w-4" />
+                    </span>
+                  </Link>
+                </SiteReveal>
+              ))}
+            </div>
           </div>
         </section>
 

--- a/components/pico/PicoLangSwitcher.tsx
+++ b/components/pico/PicoLangSwitcher.tsx
@@ -51,55 +51,26 @@ export function PicoLangSwitcher() {
   }, [router])
 
   return (
-    <div ref={containerRef} style={{ position: 'relative', display: 'inline-flex' }}>
+    <div ref={containerRef} className="relative inline-flex">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-haspopup="listbox"
         aria-expanded={open}
-        style={{
-          minHeight: '2.5rem',
-          padding: '0 0.95rem',
-          borderRadius: '999px',
-          background: 'var(--pico-bg-surface)',
-          border: '1px solid var(--pico-border)',
-          cursor: 'pointer',
-          fontSize: '0.82rem',
-          fontWeight: 600,
-          lineHeight: 1,
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: '0.35rem',
-          color: 'var(--pico-text)',
-          boxSizing: 'border-box',
-          transition: 'transform 160ms ease, background 160ms ease, border-color 160ms ease, box-shadow 160ms ease',
-          boxShadow: '0 10px 24px rgba(0,0,0,0.16)',
-        }}
+        className="inline-flex min-h-[2.45rem] items-center justify-center gap-2 rounded-full border border-[color:var(--pico-border)] bg-[rgba(7,14,9,0.82)] px-3 py-2 text-sm font-semibold text-[color:var(--pico-text)] shadow-[0_12px_30px_rgba(0,0,0,0.24)] backdrop-blur transition duration-200 hover:border-[color:var(--pico-border-hover)] hover:bg-[rgba(var(--pico-accent-rgb),0.08)]"
       >
         <span aria-hidden="true">{current.flag}</span>
+        <span className="hidden text-[11px] uppercase tracking-[0.18em] text-[color:var(--pico-text-muted)] sm:inline">
+          {current.code}
+        </span>
         <span className="sr-only">{current.label}</span>
-        <span style={{ fontSize: '0.68rem', opacity: 0.6 }}>▾</span>
+        <span className="text-[0.68rem] text-[color:var(--pico-text-muted)]">▾</span>
       </button>
 
       {open && (
         <div
           role="listbox"
-          style={{
-            position: 'absolute',
-            top: 'calc(100% + 6px)',
-            right: 0,
-            background: 'rgba(9, 16, 8, 0.98)',
-            border: '1px solid var(--pico-border)',
-            borderRadius: '10px',
-            padding: '6px',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '2px',
-            minWidth: '120px',
-            zIndex: 100,
-            boxShadow: '0 8px 32px rgba(0,0,0,0.5)',
-          }}
+          className="absolute right-0 top-[calc(100%+0.45rem)] z-[100] flex max-h-80 min-w-[14rem] flex-col gap-1 overflow-y-auto rounded-[20px] border border-[color:var(--pico-border)] bg-[linear-gradient(180deg,rgba(8,15,10,0.96),rgba(4,9,6,0.98))] p-2 shadow-[0_24px_60px_rgba(0,0,0,0.34)] backdrop-blur-xl"
         >
           {LOCALES.map((l) => (
             <button
@@ -108,33 +79,19 @@ export function PicoLangSwitcher() {
               role="option"
               aria-selected={l.code === locale}
               onClick={() => handleSelect(l.code)}
-              style={{
-                background: l.code === locale ? 'rgba(var(--pico-accent-rgb),0.14)' : 'transparent',
-                border: 'none',
-                cursor: 'pointer',
-                padding: '7px 10px',
-                borderRadius: '6px',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '8px',
-                fontSize: '0.85rem',
-                color: l.code === locale ? 'var(--pico-accent)' : 'var(--pico-text-secondary)',
-                textAlign: 'left',
-                transition: 'background 0.15s',
-              }}
-              onMouseEnter={(e) => {
-                if (l.code !== locale) {
-                  ;(e.currentTarget as HTMLButtonElement).style.background = 'rgba(var(--pico-accent-rgb),0.08)'
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (l.code !== locale) {
-                  ;(e.currentTarget as HTMLButtonElement).style.background = 'transparent'
-                }
-              }}
+              className={`flex items-center gap-3 rounded-2xl border px-3 py-2 text-left text-sm transition duration-150 ${
+                l.code === locale
+                  ? 'border-[color:var(--pico-border-hover)] bg-[rgba(var(--pico-accent-rgb),0.12)] text-[color:var(--pico-text)]'
+                  : 'border-transparent bg-transparent text-[color:var(--pico-text-secondary)] hover:border-[color:rgba(255,255,255,0.05)] hover:bg-[rgba(255,255,255,0.03)] hover:text-[color:var(--pico-text)]'
+              }`}
             >
-              <span>{l.flag}</span>
-              <span>{l.label}</span>
+              <span className="text-base">{l.flag}</span>
+              <span className="min-w-0 flex-1">
+                <span className="block font-medium">{l.label}</span>
+                <span className="block text-[11px] uppercase tracking-[0.18em] text-[color:var(--pico-text-muted)]">
+                  {l.code.toUpperCase()}
+                </span>
+              </span>
             </button>
           ))}
         </div>

--- a/components/pico/PicoLessonDetail.tsx
+++ b/components/pico/PicoLessonDetail.tsx
@@ -101,7 +101,40 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
         ? 'local only'
         : session.status === 'error'
           ? 'auth error'
-          : 'checking'
+        : 'checking'
+
+  const studioReviewBoard = [
+    {
+      label: '01 • Brief',
+      title: 'The outcome the studio is chasing',
+      body: lesson.objective,
+    },
+    {
+      label: '02 • Deliverable',
+      title: 'What the finished artifact should prove',
+      body: lesson.expectedResult,
+    },
+    {
+      label: '03 • Critique',
+      title: 'The review line before you move on',
+      body: lesson.validation,
+    },
+  ]
+
+  const studioContext = [
+    {
+      label: 'Track arc',
+      value: track?.outcome ?? 'Build one real operator outcome.',
+    },
+    {
+      label: 'Lesson outcome',
+      value: lesson.outcome,
+    },
+    {
+      label: 'Time and weight',
+      value: `${lesson.estimatedMinutes}m • ${lesson.xp} xp • ${formatDifficulty(lesson.difficulty)}`,
+    },
+  ]
 
   useEffect(() => {
     if (!missingPrerequisiteLesson && !started && !completed) {
@@ -151,7 +184,7 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
 
     if (approvalLesson) {
       return (
-        <div className="flex flex-wrap gap-3">
+        <div className="grid gap-3 sm:flex sm:flex-wrap">
           <Link href={approvalSetupHref} className={buttonClassName}>
             Open live approval setup
           </Link>
@@ -200,20 +233,20 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
         data-testid="pico-lesson-campaign-hero"
       >
         <div className="grid gap-8 lg:grid-cols-[8rem,minmax(0,1fr)]">
-          <div className="grid content-between gap-6 border-b border-[#5d412d] pb-6 lg:border-b-0 lg:border-r lg:pb-0 lg:pr-8">
+          <div className="grid content-between gap-6 border-b border-[color:var(--pico-border)] pb-6 lg:border-b-0 lg:border-r lg:pb-0 lg:pr-8">
             <div className="grid gap-2">
               <p className={picoClasses.label}>Lesson</p>
-              <p className="font-[family:var(--font-site-display)] text-7xl leading-none tracking-[-0.08em] text-[#f0bb83] sm:text-8xl">
+              <p className="font-[family:var(--font-site-display)] text-7xl leading-none tracking-[-0.08em] text-[color:var(--pico-accent)] sm:text-8xl">
                 {String(Math.max(lessonIndex, 0) + 1).padStart(2, '0')}
               </p>
             </div>
 
             <div className="grid gap-2">
               <p className={picoClasses.label}>Track</p>
-              <p className="font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+              <p className="font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                 {track?.title ?? 'Unmapped'}
               </p>
-              <p className="text-sm leading-6 text-[#d8c0a4]">
+              <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                 {track && lessonIndex >= 0 ? `${lessonIndex + 1}/${trackLessons.length}` : 'not mapped'}
               </p>
             </div>
@@ -229,18 +262,18 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
             </div>
 
             <div className="grid gap-4">
-              <h1 className="max-w-4xl font-[family:var(--font-site-display)] text-5xl leading-[0.92] tracking-[-0.08em] text-[#fff4e6] sm:text-7xl">
+              <h1 className="max-w-4xl font-[family:var(--font-site-display)] text-5xl leading-[0.92] tracking-[-0.08em] text-[color:var(--pico-text)] sm:text-7xl">
                 {lesson.title}
               </h1>
-              <p className="max-w-3xl text-lg leading-8 text-[#e2ccb3]">
+              <p className="max-w-3xl text-lg leading-8 text-[color:var(--pico-text-secondary)]">
                 {lesson.objective}
               </p>
-              <p className="max-w-3xl text-sm leading-6 text-[#b99879]">
+              <p className="max-w-3xl text-sm leading-6 text-[color:var(--pico-text-muted)]">
                 Expected result: {lesson.expectedResult}
               </p>
             </div>
 
-            <div className="flex flex-wrap gap-3">
+            <div className="grid gap-3 sm:flex sm:flex-wrap">
               {renderPrimaryLessonAction(picoClasses.primaryButton)}
               <Link
                 href={toHref(`/tutor?lesson=${lesson.slug}`)}
@@ -250,41 +283,103 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
               </Link>
             </div>
 
-            <div className="grid gap-3 border-t border-[#5d412d] pt-5 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="grid gap-3 border-t border-[color:var(--pico-border)] pt-5 sm:grid-cols-2 xl:grid-cols-4">
               <div className="grid gap-1">
                 <p className={picoClasses.label}>State</p>
-                <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
+                <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                   {missingPrerequisiteLesson ? 'blocked' : completed ? 'sealed' : 'active'}
                 </p>
-                <p className="text-sm leading-6 text-[#bfa78c]">
+                <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   {missingPrerequisiteLesson ? 'finish the prerequisite first' : 'one route lane'}
                 </p>
               </div>
               <div className="grid gap-1">
                 <p className={picoClasses.label}>Proof</p>
-                <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
+                <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                   {evidenceReady ? 'captured' : 'pending'}
                 </p>
-                <p className="text-sm leading-6 text-[#bfa78c]">
+                <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   {activeWorkspaceStep?.title ?? 'Choose a step'}
                 </p>
               </div>
               <div className="grid gap-1">
                 <p className={picoClasses.label}>Progress</p>
-                <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
+                <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                   {completedStepCount}/{lesson.steps.length}
                 </p>
-                <p className="text-sm leading-6 text-[#bfa78c]">steps cleared</p>
+                <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">steps cleared</p>
               </div>
               <div className="grid gap-1">
                 <p className={picoClasses.label}>Telemetry</p>
-                <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
+                <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                   {lesson.estimatedMinutes}m
                 </p>
-                <p className="text-sm leading-6 text-[#bfa78c]">
+                <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   {lesson.xp} xp • {formatDifficulty(lesson.difficulty)}
                 </p>
               </div>
+            </div>
+          </div>
+        </div>
+      </motion.section>
+
+      <motion.section
+        initial={{ opacity: 0, y: 22 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ ...revealTransition, delay: 0.04 }}
+        className={picoCodexFrame('px-6 py-6 sm:px-8 sm:py-8')}
+        data-testid="pico-lesson-studio-review"
+      >
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.08fr),20rem]">
+          <div>
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className={picoClasses.label}>Studio review board</p>
+                <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)]">
+                  Brief, deliverable, critique
+                </h2>
+              </div>
+              <span className={picoCodex.stamp}>one real lesson at a time</span>
+            </div>
+
+            <div className="mt-6 grid gap-4 xl:grid-cols-3">
+              {studioReviewBoard.map((item) => (
+                <article key={item.label} className={picoCodexInset('flex h-full flex-col p-5')}>
+                  <p className={picoClasses.label}>{item.label}</p>
+                  <h3 className="mt-5 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                    {item.title}
+                  </h3>
+                  <p className="mt-4 text-sm leading-7 text-[color:var(--pico-text-secondary)]">
+                    {item.body}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-4">
+            <div className={picoCodexNote('p-5')}>
+              <p className={picoClasses.label}>Chapter context</p>
+              <div className="mt-4 grid gap-4">
+                {studioContext.map((item) => (
+                  <div
+                    key={item.label}
+                    className="grid gap-2 border-t border-[color:var(--pico-border)] pt-4 first:border-t-0 first:pt-0"
+                  >
+                    <p className={picoClasses.label}>{item.label}</p>
+                    <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      {item.value}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className={picoCodexInset('p-5')}>
+              <p className={picoClasses.label}>Studio posture</p>
+              <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                Keep this chapter narrow. The goal is not to feel busy or advanced. The goal is to produce one artifact a sharp operator would still trust tomorrow.
+              </p>
             </div>
           </div>
         </div>
@@ -305,8 +400,8 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
                   className={cn(
                     'grid min-w-[13rem] gap-2 rounded-[24px] border px-4 py-4 text-left transition',
                     active
-                      ? 'border-[#e2904f] bg-[linear-gradient(180deg,rgba(103,57,29,0.28),rgba(43,24,15,0.28))] text-[#fff4e6]'
-                      : 'border-[#4a3423] bg-[rgba(255,247,235,0.03)] text-[#d5c0a8]',
+                      ? 'border-[color:var(--pico-accent)] bg-[linear-gradient(180deg,rgba(var(--pico-accent-rgb),0.22),rgba(8,16,10,0.32))] text-[color:var(--pico-text)]'
+                      : 'border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] text-[color:var(--pico-text-secondary)]',
                   )}
                 >
                   <div className="flex flex-wrap items-center gap-2">
@@ -355,8 +450,8 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
                       className={cn(
                         'grid gap-2 border-l pl-4 text-left transition',
                         active
-                          ? 'border-[#e2904f] text-[#fff4e6]'
-                          : 'border-[#4a3423] text-[#d5c0a8] hover:border-[#8a623d] hover:text-[#fff4e6]',
+                          ? 'border-[color:var(--pico-accent)] text-[color:var(--pico-text)]'
+                          : 'border-[color:var(--pico-border)] text-[color:var(--pico-text-secondary)] hover:border-[color:var(--pico-border-hover)] hover:text-[color:var(--pico-text)]',
                       )}
                     >
                       <div className="flex flex-wrap items-center gap-2">
@@ -378,12 +473,12 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
         <section className={picoCodexFrame('p-6 sm:p-7')} data-testid="pico-lesson-workspace">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
-              <p className={picoClasses.label}>Active route lane</p>
-              <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[#fff4e6]">
+              <p className={picoClasses.label}>Studio workspace</p>
+              <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)]">
                 {activeWorkspaceStep?.title ?? 'Select a step'}
               </h2>
             </div>
-            <div className="flex flex-wrap gap-3">
+            <div className="grid gap-3 sm:flex sm:flex-wrap">
               <button
                 type="button"
                 onClick={() => workspaceActions.reset()}
@@ -410,53 +505,53 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
 
           <div className="mt-6 grid gap-5">
             <article className={picoCodexSheet('p-5')}>
-              <p className={picoClasses.label}>Command brief</p>
-              <p className="mt-4 text-base leading-8 text-[#f0deca]">
+              <p className={picoClasses.label}>Studio brief</p>
+              <p className="mt-4 text-base leading-8 text-[color:var(--pico-text-secondary)]">
                 {activeWorkspaceStep?.body ??
                   'Choose a step from the chapter spine to start the lane.'}
               </p>
               {activeWorkspaceStep?.command ? (
-                <pre className="mt-5 overflow-x-auto rounded-[22px] border border-[#6a452a] bg-[#16100d] p-4 text-sm text-[#ffc88f]">
+                <pre className="mt-5 overflow-x-auto rounded-[22px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-input)] p-4 text-sm text-[color:var(--pico-accent-bright)]">
                   <code>{activeWorkspaceStep.command}</code>
                 </pre>
               ) : null}
               {activeWorkspaceStep?.note ? (
                 <div className={picoCodexNote('mt-5 p-4')}>
-                  <p className="text-sm leading-6 text-[#f0deca]">{activeWorkspaceStep.note}</p>
+                  <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">{activeWorkspaceStep.note}</p>
                 </div>
               ) : null}
             </article>
 
             <div id="pico-proof-composer" className="grid gap-4 lg:grid-cols-2">
               <label className={picoCodexInset('grid gap-3 p-4')}>
-                <span className={picoClasses.label}>Proof captured</span>
+                <span className={picoClasses.label}>Deliverable artifact</span>
                 <textarea
                   value={workspace.evidence}
                   onChange={(event) => workspaceActions.setEvidence(event.target.value)}
                   placeholder="Paste the output, transcript note, or artifact that proves this chapter worked."
-                  className="min-h-40 rounded-[18px] border border-[#4a3423] bg-[#120d0a] px-4 py-3 text-sm text-[#fff4e6] outline-none placeholder:text-[#8f7157]"
+                  className="min-h-40 rounded-[18px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-input)] px-4 py-3 text-sm text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
                   data-testid="pico-lesson-proof"
                 />
               </label>
 
               <label className={picoCodexInset('grid gap-3 p-4')}>
-                <span className={picoClasses.label}>Working notes</span>
+                <span className={picoClasses.label}>Bench notes</span>
                 <textarea
                   value={workspace.notes}
                   onChange={(event) => workspaceActions.setNotes(event.target.value)}
                   placeholder="Capture the blocker, file path, or command variation that mattered."
-                  className="min-h-40 rounded-[18px] border border-[#4a3423] bg-[#120d0a] px-4 py-3 text-sm text-[#fff4e6] outline-none placeholder:text-[#8f7157]"
+                  className="min-h-40 rounded-[18px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-input)] px-4 py-3 text-sm text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
                 />
               </label>
             </div>
 
             <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr),18rem]">
               <div className={picoCodexNote('p-5')}>
-                <p className={picoClasses.label}>Seal state</p>
-                <p className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+                <p className={picoClasses.label}>Review state</p>
+                <p className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                   {completed ? 'sealed' : evidenceReady ? 'ready' : 'pending'}
                 </p>
-                <p className="mt-3 text-sm leading-6 text-[#f0deca]">
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   {completed
                     ? 'The chapter is sealed. Move on while the route is still fresh.'
                     : evidenceReady
@@ -468,21 +563,21 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
 
               <div className="grid gap-4">
                 <div className={picoCodexInset('p-4')}>
-                  <p className={picoClasses.label}>Progress meter</p>
-                  <p className="mt-2 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+                  <p className={picoClasses.label}>Chapter completion</p>
+                  <p className="mt-2 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                     {completedStepCount}/{lesson.steps.length}
                   </p>
-                  <div className="mt-4 overflow-hidden rounded-full bg-[#1b120d]">
+                  <div className="mt-4 overflow-hidden rounded-full bg-[color:var(--pico-bg-input)]">
                     <div
-                      className="h-2 rounded-full bg-[linear-gradient(90deg,#e2904f,#ffd0a4)]"
+                      className="h-2 rounded-full bg-[linear-gradient(90deg,var(--pico-accent),var(--pico-accent-bright))]"
                       style={{ width: `${progressPercent}%` }}
                     />
                   </div>
                 </div>
 
                 <div className={picoCodexInset('p-4')}>
-                  <p className={picoClasses.label}>Next move</p>
-                  <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
+                  <p className={picoClasses.label}>Creative direction</p>
+                  <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                     Finish the live step, log one proof artifact, then either seal the chapter or hand off to the next surface.
                   </p>
                 </div>
@@ -498,32 +593,32 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
               <div className="mt-4 grid gap-3">
                 <div className={picoCodexInset('p-4')}>
                   <p className={picoClasses.label}>Stay here when</p>
-                  <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
+                  <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                     the current step still contains the answer and the route does not need escalation yet.
                   </p>
                 </div>
                 <Link
                   href={toHref(`/tutor?lesson=${lesson.slug}`)}
-                  className={picoCodexNote('p-4 transition hover:border-[#a1714b]')}
+                  className={picoCodexNote('p-4 transition hover:border-[color:var(--pico-border-hover)]')}
                 >
                   <p className={picoClasses.label}>Exact blocker</p>
-                  <p className="mt-2 text-lg font-medium text-[#fff4e6]">Ask tutor</p>
+                  <p className="mt-2 text-lg font-medium text-[color:var(--pico-text)]">Ask tutor</p>
                 </Link>
                 <Link
                   href={approvalLesson ? approvalSetupHref : toHref('/autopilot')}
-                  className={picoCodexInset('p-4 transition hover:border-[#8a623d] hover:text-[#fff4e6]')}
+                  className={picoCodexInset('p-4 transition hover:border-[color:var(--pico-border-hover)] hover:text-[color:var(--pico-text)]')}
                 >
                   <p className={picoClasses.label}>Runtime truth</p>
-                  <p className="mt-2 text-lg font-medium text-[#fff4e6]">
+                  <p className="mt-2 text-lg font-medium text-[color:var(--pico-text)]">
                     {approvalLesson ? 'Open live approval setup' : 'Inspect Autopilot'}
                   </p>
                 </Link>
                 <Link
                   href={toHref('/support')}
-                  className={picoCodexInset('p-4 transition hover:border-[#8a623d] hover:text-[#fff4e6]')}
+                  className={picoCodexInset('p-4 transition hover:border-[color:var(--pico-border-hover)] hover:text-[color:var(--pico-text)]')}
                 >
                   <p className={picoClasses.label}>Messy edge</p>
-                  <p className="mt-2 text-lg font-medium text-[#fff4e6]">Open support lane</p>
+                  <p className="mt-2 text-lg font-medium text-[color:var(--pico-text)]">Open support lane</p>
                 </Link>
               </div>
             </section>
@@ -590,7 +685,7 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
               <p className={picoClasses.label}>Troubleshooting appendix</p>
-              <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.06em] text-[#fff4e6]">
+              <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.06em] text-[color:var(--pico-text)]">
                 The smaller notes you only read when the route goes crooked
               </h2>
             </div>
@@ -599,7 +694,7 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
 
           <div className="mt-6 grid gap-4">
             {lesson.troubleshooting.map((item) => (
-              <div key={item} className={picoCodexInset('px-4 py-4 text-sm leading-6 text-[#d5c0a8]')}>
+              <div key={item} className={picoCodexInset('px-4 py-4 text-sm leading-6 text-[color:var(--pico-text-secondary)]')}>
                 {item}
               </div>
             ))}
@@ -611,10 +706,10 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
             <section className={picoCodexFrame('p-5')}>
               <p className={picoClasses.label}>Next capability</p>
               <div className={picoCodexNote('mt-4 p-5')}>
-                <h3 className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
+                <h3 className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                   {derived.nextCapability.title}
                 </h3>
-                <p className="mt-3 text-sm leading-6 text-[#f0deca]">
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   {derived.nextCapability.description}
                 </p>
                 <Link

--- a/components/pico/PicoOnboardingPageClient.tsx
+++ b/components/pico/PicoOnboardingPageClient.tsx
@@ -122,6 +122,37 @@ export function PicoOnboardingPageClient() {
     firstRunWorkspace.workspace.activeStepIndex >= 0
       ? firstRunLesson?.steps[firstRunWorkspace.workspace.activeStepIndex]?.title ?? 'not set'
       : 'not set'
+  const storyRailClass =
+    'mt-6 grid grid-flow-col auto-cols-[minmax(16rem,82vw)] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory md:grid-flow-row md:auto-cols-auto md:overflow-visible xl:grid-cols-3'
+  const missionRailClass =
+    'mt-6 grid grid-flow-col auto-cols-[minmax(18rem,88vw)] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory md:grid-flow-row md:auto-cols-auto md:overflow-visible xl:grid-cols-2'
+  const compactRailClass =
+    'grid grid-flow-col auto-cols-[minmax(15rem,82vw)] gap-3 overflow-x-auto pb-2 snap-x snap-mandatory sm:grid-flow-row sm:auto-cols-auto sm:overflow-visible sm:grid-cols-2'
+  const timelineRailClass =
+    'grid grid-flow-col auto-cols-[minmax(15rem,82vw)] gap-3 overflow-x-auto pb-2 snap-x snap-mandatory md:grid-flow-row md:auto-cols-auto md:overflow-visible'
+  const kickoffDoctrine = [
+    {
+      label: '01 • Brief',
+      title: 'Make the runtime open cleanly',
+      body:
+        installLesson?.objective ??
+        'Install Hermes and get the command working from a fresh shell.',
+    },
+    {
+      label: '02 • Deliverable',
+      title: 'Produce one obvious proof artifact',
+      body:
+        firstRunLesson?.expectedResult ??
+        'Save one prompt and one answer in a file you can reopen later.',
+    },
+    {
+      label: '03 • Review line',
+      title: 'Do not widen the surface early',
+      body:
+        firstRunLesson?.validation ??
+        'Verify one bounded run before you touch more advanced surfaces.',
+    },
+  ]
 
   const hostedCompletionRatio = useMemo(() => {
     if (!setup.onboarding || setup.onboarding.steps.length === 0) {
@@ -215,7 +246,7 @@ export function PicoOnboardingPageClient() {
         actions.setPlatform({ helpLaneOpen: !progress.platform.helpLaneOpen })
       }
       actions={
-        <div className="flex flex-wrap gap-3">
+        <div className="grid gap-3 sm:flex sm:flex-wrap">
           <Link
             href={
               firstRunDone && !derived.nextLesson
@@ -285,20 +316,73 @@ export function PicoOnboardingPageClient() {
         ]}
       />
 
+      <section className={picoPanel('p-6 sm:p-7')} data-testid="pico-onboarding-kickoff-doctrine">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.08fr),20rem]">
+          <div>
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className={picoClasses.label}>Kickoff doctrine</p>
+                <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)]">
+                  Start like a sharp studio, not a hobby project
+                </h2>
+              </div>
+              <span className={picoClasses.chip}>brief • deliverable • review</span>
+            </div>
+
+            <div className={storyRailClass}>
+              {kickoffDoctrine.map((item) => (
+                <article key={item.label} className={picoInset('snap-start flex h-full flex-col p-5')}>
+                  <p className={picoClasses.label}>{item.label}</p>
+                  <h3 className="mt-5 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                    {item.title}
+                  </h3>
+                  <p className="mt-4 text-sm leading-7 text-[color:var(--pico-text-secondary)]">
+                    {item.body}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-4">
+            <div className={picoEmber('p-5')}>
+              <p className={picoClasses.label}>Chapter posture</p>
+              <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                The premium version of onboarding is narrow on purpose. No browsing, no stack tourism, no decorative busywork before one real artifact exists.
+              </p>
+            </div>
+
+            <div className={picoInset('p-5')}>
+              <p className={picoClasses.label}>Track checklist</p>
+              <div className="mt-4 grid gap-3">
+                {activeTrack.checklist.map((item) => (
+                  <div key={item} className="flex items-start gap-3">
+                    <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full border border-[color:var(--pico-border)] bg-[rgba(var(--pico-accent-rgb),0.12)] text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--pico-accent)]">
+                      ok
+                    </span>
+                    <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">{item}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr),22rem]">
         <div className={picoPanel('overflow-hidden p-0')}>
-          <div className="grid gap-0 border-b border-[#3a291d] lg:grid-cols-[minmax(0,1fr),18rem]">
+          <div className="grid gap-0 border-b border-[color:var(--pico-border)] lg:grid-cols-[minmax(0,1fr),18rem]">
             <div className="p-6 sm:p-7">
-              <p className={picoClasses.label}>Opening sequence</p>
-              <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[#fff4e6] sm:text-5xl">
+              <p className={picoClasses.label}>Chapter 01 brief</p>
+              <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)] sm:text-5xl">
                 Make one command work and keep the proof
               </h2>
-              <p className="mt-4 max-w-3xl text-sm leading-7 text-[#d5c0a8] sm:text-base">
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-[color:var(--pico-text-secondary)] sm:text-base">
                 This first chapter should narrow the world fast: install Hermes, run one tiny prompt, and hold on to the output so the first win becomes something real.
               </p>
 
               <div className={joinClasses(picoEmber('mt-6 p-5 text-sm leading-7'), 'sm:p-6')}>
-                <p className="font-medium text-[#fff5e8]">Fastest path to value</p>
+                <p className="font-medium text-[color:var(--pico-text)]">Fastest path to value</p>
                 <p className="mt-2">
                   {firstRunDone
                     ? 'You already cleared the first win. Do not linger here. Open the next lesson and keep the sequence moving.'
@@ -308,38 +392,22 @@ export function PicoOnboardingPageClient() {
                 </p>
               </div>
 
-              <div className="mt-6 grid gap-4 md:grid-cols-3">
-                {activationChecklist.map((item) => (
-                  <article key={item.title} className={picoInset('grid gap-3 p-5')}>
-                    <div className="flex items-center gap-3">
-                      <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[#6e4d31] bg-[rgba(226,144,79,0.12)] text-xs font-semibold uppercase tracking-[0.18em] text-[#f0bb83]">
-                        {item.chapter}
-                      </span>
-                      <h3 className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                        {item.title}
-                      </h3>
-                    </div>
-                    <p className={picoClasses.body}>{item.body}</p>
-                  </article>
-                ))}
-              </div>
-
               <div className={picoInset('mt-6 grid gap-4 p-5 lg:grid-cols-3')}>
                 <div>
                   <p className={picoClasses.label}>Track locked</p>
-                  <p className="mt-2 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+                  <p className="mt-2 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                     {activeTrack.title}
                   </p>
                 </div>
                 <div>
                   <p className={picoClasses.label}>Next move</p>
-                  <p className="mt-2 text-lg font-medium text-[#fff4e6]">
+                  <p className="mt-2 text-lg font-medium text-[color:var(--pico-text)]">
                     {derived.nextLesson?.title ?? 'none'}
                   </p>
                 </div>
                 <div>
                   <p className={picoClasses.label}>Visible success</p>
-                  <p className="mt-2 text-lg font-medium text-[#fff4e6]">
+                  <p className="mt-2 text-lg font-medium text-[color:var(--pico-text)]">
                     {firstRunWorkspace.workspace.evidence.trim() || firstRunDone
                       ? 'recorded'
                       : installDone
@@ -350,30 +418,30 @@ export function PicoOnboardingPageClient() {
               </div>
             </div>
 
-            <div className="border-t border-[#3a291d] bg-[rgba(255,247,235,0.03)] p-6 lg:border-l lg:border-t-0">
-              <p className={picoClasses.label}>Launch ledger</p>
+            <div className="border-t border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] p-6 lg:border-l lg:border-t-0">
+              <p className={picoClasses.label}>Studio ledger</p>
               <div className="mt-4 grid gap-3">
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Completed lessons</p>
-                  <p className="mt-1 text-2xl font-semibold text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Completed lessons</p>
+                  <p className="mt-1 text-2xl font-semibold text-[color:var(--pico-text)]">
                     {derived.completedLessonCount}
                   </p>
                 </div>
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Hosted sync</p>
-                  <p className="mt-1 text-2xl font-semibold text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Hosted sync</p>
+                  <p className="mt-1 text-2xl font-semibold text-[color:var(--pico-text)]">
                     {session.status === 'authenticated' ? `${hostedCompletionRatio}%` : 'sign in'}
                   </p>
                 </div>
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Runtime status</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Runtime status</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {setup.runtime?.status ?? 'not attached'}
                   </p>
                 </div>
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Workspace</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Workspace</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {setup.onboarding?.workspace ?? currentBinding?.workspace ?? 'not recorded'}
                   </p>
                 </div>
@@ -396,7 +464,7 @@ export function PicoOnboardingPageClient() {
 
               <div className={picoInset('mt-4 p-4')}>
                 <p className={picoClasses.label}>Operating rule</p>
-                <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   More choice this early is just prettier procrastination. Get the first win, then widen the surface.
                 </p>
               </div>
@@ -406,39 +474,15 @@ export function PicoOnboardingPageClient() {
 
         <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start">
           <section className={picoPanel('p-5')}>
-            <p className={picoClasses.label}>First win definition</p>
-            <div className="mt-4 grid gap-3">
-              <div className={picoInset('p-4')}>
-                <p className="font-medium text-[#fff4e6]">1. Command opens</p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                  Hermes runs from a fresh shell without hand-waving or invisible environment fixes.
-                </p>
-              </div>
-              <div className={picoInset('p-4')}>
-                <p className="font-medium text-[#fff4e6]">2. Prompt returns</p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                  One tiny prompt produces an obvious answer you can inspect in seconds.
-                </p>
-              </div>
-              <div className={picoInset('p-4')}>
-                <p className="font-medium text-[#fff4e6]">3. Proof survives</p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                  The output becomes an artifact you can reuse, not a vague memory of success.
-                </p>
-              </div>
-            </div>
-          </section>
-
-          <section className={picoPanel('p-5')}>
             <p className={picoClasses.label}>Current pressure</p>
             <div className="mt-4 grid gap-3">
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Install</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">{installDone ? 'done' : 'pending'}</p>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Install</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">{installDone ? 'done' : 'pending'}</p>
               </div>
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">First prompt</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                <p className="text-sm text-[color:var(--pico-text-muted)]">First prompt</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {firstRunWorkspace.workspace.evidence.trim() || firstRunDone ? 'proof captured' : 'pending'}
                 </p>
               </div>
@@ -447,26 +491,58 @@ export function PicoOnboardingPageClient() {
         </aside>
       </section>
 
+      <section className={picoPanel('mt-6 p-6 sm:p-7')} data-testid="pico-onboarding-proof-protocol">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <p className={picoClasses.label}>Proof protocol</p>
+            <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)] sm:text-4xl">
+              Three visible moves to clear Chapter 01
+            </h2>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+              The opening sequence should read like a clean launch ritual, not a pile of setup advice. These are the only moves that count before the surface earns the right to get wider.
+            </p>
+          </div>
+          <span className={picoClasses.chip}>first win protocol</span>
+        </div>
+
+        <div className={storyRailClass}>
+          {activationChecklist.map((item, index) => (
+            <article key={item.title} className={picoInset('snap-start flex h-full flex-col p-5 sm:p-6')}>
+              <div className="flex items-center justify-between gap-3">
+                <span className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:var(--pico-border)] bg-[rgba(var(--pico-accent-rgb),0.12)] text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-accent)]">
+                  {item.chapter}
+                </span>
+                <span className={picoClasses.label}>{index === 0 ? 'Do this now' : 'Visible move'}</span>
+              </div>
+              <h3 className="mt-6 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                {item.title}
+              </h3>
+              <p className="mt-4 text-sm leading-7 text-[color:var(--pico-text-secondary)]">{item.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
       <section className={picoPanel('p-6 sm:p-7')} data-testid="pico-onboarding-mission-board">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
             <p className={picoClasses.label}>Mission board</p>
-            <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6] sm:text-4xl">
+            <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)] sm:text-4xl">
               Keep the first two missions visibly grounded
             </h2>
-            <p className="mt-3 max-w-3xl text-sm leading-6 text-[#d5c0a8]">
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-[color:var(--pico-text-secondary)]">
               Onboarding should know where the operator left off. These mission cards mirror the lesson workspace so the first win survives route changes instead of dissolving into memory.
             </p>
           </div>
           <span className={picoClasses.chip}>workspace continuity</span>
         </div>
 
-        <div className="mt-6 grid gap-4 xl:grid-cols-2">
+        <div className={missionRailClass}>
           <article className={picoInset('grid gap-4 p-5')} data-testid="pico-onboarding-install-mission">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
                 <p className={picoClasses.label}>Mission 01</p>
-                <h3 className="mt-2 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+                <h3 className="mt-2 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                   Install Hermes
                 </h3>
               </div>
@@ -474,25 +550,25 @@ export function PicoOnboardingPageClient() {
                 {installWorkspace.completedStepCount}/{installLesson?.steps.length ?? 0} steps
               </span>
             </div>
-            <div className="overflow-hidden rounded-full bg-[#1b120d]">
+            <div className="overflow-hidden rounded-full bg-[color:var(--pico-bg-input)]">
               <div
-                className="h-2 rounded-full bg-[linear-gradient(90deg,#e2904f,#ffd0a4)]"
+                className="h-2 rounded-full bg-[linear-gradient(90deg,var(--pico-accent),var(--pico-accent-bright))]"
                 style={{ width: `${installWorkspace.progressPercent}%` }}
               />
             </div>
             <div className="grid gap-3 sm:grid-cols-2">
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Focused step</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">{installFocusedStep}</p>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Focused step</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">{installFocusedStep}</p>
               </div>
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Proof state</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Proof state</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {installWorkspace.workspace.evidence.trim() ? 'captured' : installDone ? 'completed' : 'missing'}
                 </p>
               </div>
             </div>
-            <div className="flex flex-wrap gap-3">
+            <div className="grid gap-3 sm:flex sm:flex-wrap">
               <Link href={toHref(`/academy/${installLessonSlug}`)} className={picoClasses.secondaryButton}>
                 Resume install mission
               </Link>
@@ -506,7 +582,7 @@ export function PicoOnboardingPageClient() {
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
                 <p className={picoClasses.label}>Mission 02</p>
-                <h3 className="mt-2 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+                <h3 className="mt-2 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                   Run one bounded prompt
                 </h3>
               </div>
@@ -514,25 +590,25 @@ export function PicoOnboardingPageClient() {
                 {firstRunWorkspace.completedStepCount}/{firstRunLesson?.steps.length ?? 0} steps
               </span>
             </div>
-            <div className="overflow-hidden rounded-full bg-[#1b120d]">
+            <div className="overflow-hidden rounded-full bg-[color:var(--pico-bg-input)]">
               <div
-                className="h-2 rounded-full bg-[linear-gradient(90deg,#e2904f,#ffd0a4)]"
+                className="h-2 rounded-full bg-[linear-gradient(90deg,var(--pico-accent),var(--pico-accent-bright))]"
                 style={{ width: `${firstRunWorkspace.progressPercent}%` }}
               />
             </div>
             <div className="grid gap-3 sm:grid-cols-2">
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Focused step</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">{firstRunFocusedStep}</p>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Focused step</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">{firstRunFocusedStep}</p>
               </div>
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Proof state</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Proof state</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {firstRunWorkspace.workspace.evidence.trim() ? 'captured' : firstRunDone ? 'completed' : 'missing'}
                 </p>
               </div>
             </div>
-            <div className="flex flex-wrap gap-3">
+            <div className="grid gap-3 sm:flex sm:flex-wrap">
               <Link href={toHref(`/academy/${firstRunLessonSlug}`)} className={picoClasses.secondaryButton}>
                 Resume prompt mission
               </Link>
@@ -544,294 +620,288 @@ export function PicoOnboardingPageClient() {
         </div>
       </section>
 
-      <section className="grid gap-6 xl:grid-cols-[minmax(0,1fr),minmax(0,1fr)]">
-        <section className={picoPanel('p-6 sm:p-7')}>
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <p className={picoClasses.label}>Hosted setup state</p>
-              <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6] sm:text-4xl">
-                Real onboarding sync
-              </h2>
-              <p className="mt-3 max-w-2xl text-sm leading-6 text-[#d5c0a8]">
-                This is the hosted operator record for this Pico account: wizard progress, provider selection, and the latest runtime snapshot.
-              </p>
-            </div>
-            {session.status === 'authenticated' ? (
-              <button
-                type="button"
-                onClick={() => void setup.refresh()}
-                className={picoClasses.tertiaryButton}
-              >
-                Refresh sync
-              </button>
-            ) : null}
+      <section className={picoPanel('p-6 sm:p-7')} data-testid="pico-onboarding-operator-record">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <p className={picoClasses.label}>Operator record</p>
+            <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)] sm:text-4xl">
+              Keep hosted kickoff and runtime truth in one place
+            </h2>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+              This is the single operator record for Chapter 01: hosted onboarding state, runtime state, and the next activation move. The page should stop feeling like three tools pretending not to know about each other.
+            </p>
           </div>
+          {session.status === 'authenticated' ? (
+            <button
+              type="button"
+              onClick={() => void setup.refresh()}
+              className={picoClasses.tertiaryButton}
+            >
+              Refresh sync
+            </button>
+          ) : null}
+        </div>
 
-          {session.status !== 'authenticated' ? (
-            <div className={picoSoft('mt-5 p-5')}>
-              <p className={picoClasses.body}>
-                Sign in on the Pico host to attach the hosted onboarding wizard and the last synced runtime snapshot to this page.
-              </p>
-            </div>
-          ) : setup.loading ? (
-            <div className={picoSoft('mt-5 p-5')}>
-              <p className={picoClasses.body}>Loading backend onboarding and runtime state.</p>
-            </div>
-          ) : setup.error ? (
-            <div className={picoEmber('mt-5 p-5')}>
-              <p className={picoClasses.body}>{setup.error}</p>
-            </div>
-          ) : setup.onboarding ? (
-            <div className="mt-5 grid gap-4">
-              <div className="grid gap-3 sm:grid-cols-2">
-                {(setup.onboarding.providers ?? []).map((provider) => {
-                  const active = provider.id === setup.onboarding?.provider
-                  return (
-                    <article
-                      key={provider.id}
-                      className={joinClasses(
-                        picoInset('grid gap-2 p-4'),
-                        active && 'border-[#7d5232] bg-[rgba(226,144,79,0.09)]',
-                        !provider.enabled && 'opacity-70',
-                      )}
-                    >
-                      <div className="flex items-center justify-between gap-3">
-                        <div className="flex items-center gap-3">
-                          <span className="text-xl">{provider.cue ?? '•'}</span>
-                          <div>
-                            <p className="font-medium text-[#fff4e6]">{provider.label}</p>
-                            <p className="text-xs uppercase tracking-[0.18em] text-[#a8896e]">
-                              {active ? 'current provider' : provider.enabled ? 'available soon' : 'locked'}
-                            </p>
-                          </div>
-                        </div>
-                        <span className={picoClasses.chip}>{provider.enabled ? 'ready' : 'later'}</span>
-                      </div>
-                      <p className="text-sm leading-6 text-[#d5c0a8]">{provider.summary}</p>
-                    </article>
-                  )
-                })}
+        <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.08fr),22rem]">
+          <div className="grid gap-4">
+            {session.status !== 'authenticated' ? (
+              <div className={picoSoft('p-5')}>
+                <p className={picoClasses.body}>
+                  Sign in on the Pico host to attach the hosted onboarding wizard and the latest runtime snapshot to this page.
+                </p>
               </div>
-
-              <div className={picoInset('grid gap-4 p-5')}>
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div>
-                    <p className={picoClasses.label}>Wizard state</p>
-                    <h3 className="mt-2 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                      {hostedCompletionRatio}% complete
-                    </h3>
+            ) : setup.loading ? (
+              <div className={picoSoft('p-5')}>
+                <p className={picoClasses.body}>Loading backend onboarding and runtime state.</p>
+              </div>
+            ) : setup.error ? (
+              <div className={picoEmber('p-5')}>
+                <p className={picoClasses.body}>{setup.error}</p>
+              </div>
+            ) : (
+              <>
+                {setup.onboarding ? (
+                  <div className={compactRailClass}>
+                    {(setup.onboarding.providers ?? []).map((provider) => {
+                      const active = provider.id === setup.onboarding?.provider
+                      return (
+                        <article
+                          key={provider.id}
+                          className={joinClasses(
+                            picoInset('snap-start grid gap-2 p-4'),
+                            active && 'border-[color:var(--pico-border-hover)] bg-[rgba(var(--pico-accent-rgb),0.09)]',
+                            !provider.enabled && 'opacity-70',
+                          )}
+                        >
+                          <div className="flex items-center justify-between gap-3">
+                            <div className="flex items-center gap-3">
+                              <span className="text-xl">{provider.cue ?? '•'}</span>
+                              <div>
+                                <p className="font-medium text-[color:var(--pico-text)]">{provider.label}</p>
+                                <p className="text-xs uppercase tracking-[0.18em] text-[color:var(--pico-text-muted)]">
+                                  {active ? 'current provider' : provider.enabled ? 'available soon' : 'locked'}
+                                </p>
+                              </div>
+                            </div>
+                            <span className={picoClasses.chip}>{provider.enabled ? 'ready' : 'later'}</span>
+                          </div>
+                          <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">{provider.summary}</p>
+                        </article>
+                      )
+                    })}
                   </div>
-                  <span className={picoClasses.chip}>{setup.onboarding.status}</span>
-                </div>
-
-                <div className="h-2 overflow-hidden rounded-full bg-[#1b120d]">
-                  <div
-                    className="h-full rounded-full bg-[#e2904f] transition-[width] duration-300"
-                    style={{ width: `${hostedCompletionRatio}%` }}
-                  />
-                </div>
-
-                <div className="grid gap-3 sm:grid-cols-2">
-                  <div>
-                    <p className="text-sm text-[#a8896e]">Current step</p>
-                    <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                      {setup.onboarding.current_step}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-sm text-[#a8896e]">Checklist</p>
-                    <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                      {setup.onboarding.checklist_dismissed ? 'dismissed' : 'visible'}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-sm text-[#a8896e]">Assistant</p>
-                    <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                      {setup.onboarding.assistant_name ?? 'not recorded'}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-sm text-[#a8896e]">Workspace</p>
-                    <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                      {setup.onboarding.workspace ?? 'not recorded'}
-                    </p>
-                  </div>
-                </div>
-
-                {setup.onboarding.last_error ? (
-                  <p className="text-sm leading-6 text-[#f0bb83]">{setup.onboarding.last_error}</p>
                 ) : null}
 
-                <div className="grid gap-3">
-                  {setup.onboarding.steps.map((step) => {
-                    const active = step.id === setup.onboarding?.current_step
-                    const failed = step.id === setup.onboarding?.failed_step
-                    return (
-                      <div
-                        key={step.id}
-                        className={joinClasses(
-                          picoInset('flex items-center justify-between gap-4 px-4 py-3'),
-                          active && 'border-[#7d5232] bg-[rgba(226,144,79,0.08)]',
-                        )}
-                      >
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                  <div className={picoInset('p-4')}>
+                    <p className="text-sm text-[color:var(--pico-text-muted)]">Wizard progress</p>
+                    <p className="mt-1 text-2xl font-semibold text-[color:var(--pico-text)]">
+                      {setup.onboarding ? `${hostedCompletionRatio}%` : 'not started'}
+                    </p>
+                  </div>
+                  <div className={picoInset('p-4')}>
+                    <p className="text-sm text-[color:var(--pico-text-muted)]">Current step</p>
+                    <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                      {setup.onboarding?.current_step ?? 'not recorded'}
+                    </p>
+                  </div>
+                  <div className={picoInset('p-4')}>
+                    <p className="text-sm text-[color:var(--pico-text-muted)]">Runtime status</p>
+                    <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                      {setup.runtime?.status ?? 'not attached'}
+                    </p>
+                  </div>
+                  <div className={picoInset('p-4')}>
+                    <p className="text-sm text-[color:var(--pico-text-muted)]">Current binding</p>
+                    <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                      {currentBinding?.assistant_name ?? currentBinding?.assistant_id ?? 'none'}
+                    </p>
+                  </div>
+                </div>
+
+                {setup.onboarding ? (
+                  <div className={picoInset('grid gap-4 p-5')}>
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <p className={picoClasses.label}>Hosted kickoff review</p>
+                        <h3 className="mt-2 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                          {setup.onboarding.status}
+                        </h3>
+                      </div>
+                      <span className={picoClasses.chip}>
+                        {setup.onboarding.checklist_dismissed ? 'checklist dismissed' : 'checklist visible'}
+                      </span>
+                    </div>
+
+                    {setup.onboarding.last_error ? (
+                      <p className="text-sm leading-6 text-[color:var(--pico-accent)]">{setup.onboarding.last_error}</p>
+                    ) : null}
+
+                    <div className={timelineRailClass}>
+                      {setup.onboarding.steps.map((step) => {
+                        const active = step.id === setup.onboarding?.current_step
+                        const failed = step.id === setup.onboarding?.failed_step
+                        return (
+                          <div
+                            key={step.id}
+                            className={joinClasses(
+                              picoInset('snap-start flex items-center justify-between gap-4 px-4 py-3'),
+                              active && 'border-[color:var(--pico-border-hover)] bg-[rgba(var(--pico-accent-rgb),0.08)]',
+                            )}
+                          >
+                            <div>
+                              <p className="text-sm font-medium text-[color:var(--pico-text)]">{step.title}</p>
+                              <p className="mt-1 text-xs uppercase tracking-[0.2em] text-[color:var(--pico-text-muted)]">
+                                {step.id}
+                              </p>
+                            </div>
+                            <span className={picoClasses.chip}>
+                              {failed ? 'failed' : step.completed ? 'done' : active ? 'active' : 'pending'}
+                            </span>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                ) : (
+                  <div className={picoSoft('p-5')}>
+                    <p className={picoClasses.body}>No hosted onboarding state has been recorded yet.</p>
+                  </div>
+                )}
+
+                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr),18rem]">
+                  <div className={picoInset('p-5')}>
+                    <p className={picoClasses.label}>Operator host snapshot</p>
+                    {setup.runtime ? (
+                      <div className="mt-4 grid gap-3 sm:grid-cols-2">
                         <div>
-                          <p className="text-sm font-medium text-[#fff4e6]">{step.title}</p>
-                          <p className="mt-1 text-xs uppercase tracking-[0.2em] text-[#a8896e]">
-                            {step.id}
+                          <p className="text-sm text-[color:var(--pico-text-muted)]">Gateway</p>
+                          <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                            {setup.runtime.gateway_url ?? 'not recorded'}
                           </p>
                         </div>
-                        <span className={picoClasses.chip}>
-                          {failed ? 'failed' : step.completed ? 'done' : active ? 'active' : 'pending'}
-                        </span>
+                        <div>
+                          <p className="text-sm text-[color:var(--pico-text-muted)]">Install method</p>
+                          <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                            {setup.runtime.install_method ?? 'not recorded'}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-sm text-[color:var(--pico-text-muted)]">Last seen</p>
+                          <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                            {formatTimestamp(setup.runtime.last_seen_at)}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-sm text-[color:var(--pico-text-muted)]">Bindings</p>
+                          <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                            {setup.runtime.binding_count}
+                          </p>
+                        </div>
                       </div>
+                    ) : (
+                      <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                        No runtime snapshot has been synced yet.
+                      </p>
+                    )}
+                  </div>
+
+                  <div className={picoEmber('p-5')}>
+                    <p className={picoClasses.label}>Gateway health</p>
+                    <p className="mt-2 text-lg text-[color:var(--pico-text)]">
+                      {setup.runtime?.gateway?.status ?? 'unknown'}
+                    </p>
+                    <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      {typeof setup.runtime?.gateway?.doctor_summary === 'string'
+                        ? setup.runtime.gateway.doctor_summary
+                        : 'No doctor summary was synced yet.'}
+                    </p>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+
+          <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start">
+            <section className={picoPanel('p-5')}>
+              <p className={picoClasses.label}>Activation track</p>
+              <article className={picoInset('mt-4 grid gap-4 p-5')}>
+                <div className="flex flex-col gap-3">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span className={picoClasses.chip}>Do this first</span>
+                    <span className={picoClasses.chip}>Outcome-driven</span>
+                  </div>
+                  <h2 className="font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                    {firstTrack.title}
+                  </h2>
+                  <p className={picoClasses.body}>{firstTrack.intro}</p>
+                  <p className="text-sm text-[color:var(--pico-accent)]">Outcome: {firstTrack.outcome}</p>
+                </div>
+                <div className="grid gap-3">
+                  {firstTrack.checklist.map((item) => (
+                    <div key={item} className={picoInset('px-4 py-3 text-sm text-[color:var(--pico-text-secondary)]')}>
+                      {item}
+                    </div>
+                  ))}
+                </div>
+                <div className={picoSoft('p-4')}>
+                  <p className={picoClasses.body}>
+                    {firstRunDone
+                      ? 'You already got the first win. Use the main action above and keep the sequence moving.'
+                      : installDone
+                        ? 'Hermes is installed. Skip the overview and open the first prompt lesson now.'
+                        : 'Everything else can wait. Open the install lesson and get the command working.'}
+                  </p>
+                </div>
+              </article>
+            </section>
+
+            <section className={picoPanel('p-5')}>
+              <p className={picoClasses.label}>Operator rule</p>
+              <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                More choice this early is still prettier procrastination. Keep the chapter narrow until one local run and one proof artifact are both real.
+              </p>
+              {firstRunDone ? (
+                <div className="mt-4 grid gap-3">
+                  {PICO_TRACKS.slice(1).map((track) => {
+                    const selected = progress.selectedTrack === track.slug
+                    const unlocked = derived.unlockedTrackSlugs.includes(track.slug)
+                    return (
+                      <article key={track.slug} className={picoInset('grid gap-3 p-4')}>
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <h3 className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                              {track.title}
+                            </h3>
+                            <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">{track.intro}</p>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => actions.pickTrack(track.slug)}
+                            disabled={!unlocked}
+                            className={picoClasses.tertiaryButton}
+                          >
+                            {selected ? 'Active track' : unlocked ? 'Set as track' : 'Locked'}
+                          </button>
+                        </div>
+                      </article>
                     )
                   })}
                 </div>
-
-                <div className={picoSoft('p-4')}>
-                  <div className="flex flex-wrap gap-3">
-                    <button
-                      type="button"
-                      onClick={() => void setup.completeCurrentStep()}
-                      className={picoClasses.primaryButton}
-                      disabled={setup.pendingAction !== null}
-                    >
-                      {setup.pendingAction === 'complete_step' ? 'Updating step...' : 'Mark current step complete'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => void setup.dismissChecklist()}
-                      className={picoClasses.secondaryButton}
-                      disabled={setup.pendingAction !== null || setup.onboarding.checklist_dismissed}
-                    >
-                      {setup.onboarding.checklist_dismissed ? 'Checklist dismissed' : 'Dismiss checklist'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => void setup.completeAll()}
-                      className={picoClasses.tertiaryButton}
-                      disabled={setup.pendingAction !== null}
-                    >
-                      Complete wizard
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => void setup.resetWizard()}
-                      className={picoClasses.tertiaryButton}
-                      disabled={setup.pendingAction !== null}
-                    >
-                      Reset wizard
-                    </button>
-                  </div>
-                  <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
-                    This block is backed by the hosted onboarding/runtime APIs, not just local lesson progress.
-                  </p>
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div className={picoSoft('mt-5 p-5')}>
-              <p className={picoClasses.body}>No hosted onboarding state has been recorded yet.</p>
-            </div>
-          )}
-        </section>
-
-        <section className={picoPanel('p-6 sm:p-7')}>
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <p className={picoClasses.label}>Runtime snapshot</p>
-              <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6] sm:text-4xl">
-                Last synced operator host
-              </h2>
-            </div>
-            {setup.runtime ? <span className={picoClasses.chip}>{setup.runtime.status}</span> : null}
-          </div>
-
-          {session.status !== 'authenticated' ? (
-            <div className={picoSoft('mt-4 p-5')}>
-              <p className={picoClasses.body}>
-                Sign in to view the runtime snapshot tied to this Pico operator.
-              </p>
-            </div>
-          ) : setup.runtime ? (
-            <div className="mt-4 grid gap-4">
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Gateway</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                    {setup.runtime.gateway_url ?? 'not recorded'}
-                  </p>
-                </div>
-                <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Install method</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                    {setup.runtime.install_method ?? 'not recorded'}
-                  </p>
-                </div>
-                <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Last seen</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                    {formatTimestamp(setup.runtime.last_seen_at)}
-                  </p>
-                </div>
-                <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Bindings</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                    {setup.runtime.binding_count}
-                  </p>
-                </div>
-              </div>
-
-              <div className={picoEmber('p-5')}>
-                <p className={picoClasses.label}>Gateway health</p>
-                <p className="mt-2 text-lg text-[#fff4e6]">
-                  {setup.runtime.gateway?.status ?? 'unknown'}
-                </p>
-                <p className="mt-3 text-sm leading-6 text-[#f0deca]">
-                  {typeof setup.runtime.gateway?.doctor_summary === 'string'
-                    ? setup.runtime.gateway.doctor_summary
-                    : 'No doctor summary was synced yet.'}
-                </p>
-              </div>
-
-              <div className="grid gap-3">
-                {(setup.runtime.bindings.length ? setup.runtime.bindings : [null]).map((binding, index) =>
-                  binding ? (
-                    <article key={`${binding.assistant_name ?? 'binding'}-${index}`} className={picoInset('grid gap-2 p-4')}>
-                      <div className="flex items-center justify-between gap-3">
-                        <p className="font-medium text-[#fff4e6]">
-                          {binding.assistant_name ?? binding.assistant_id ?? 'Unnamed binding'}
-                        </p>
-                        <span className={picoClasses.chip}>{binding.model ?? 'model pending'}</span>
-                      </div>
-                      <p className="text-sm leading-6 text-[#d5c0a8]">
-                        Workspace: {binding.workspace ?? 'not recorded'}
-                      </p>
-                    </article>
-                  ) : (
-                    <div key="binding-empty" className={picoSoft('p-4')}>
-                      <p className={picoClasses.body}>No assistant binding has been synced yet.</p>
-                    </div>
-                  ),
-                )}
-              </div>
-            </div>
-          ) : (
-            <div className={picoSoft('mt-4 p-5')}>
-              <p className={picoClasses.body}>No runtime snapshot has been synced yet.</p>
-            </div>
-          )}
-        </section>
+              ) : null}
+            </section>
+          </aside>
+        </div>
       </section>
 
-      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.02fr),minmax(0,0.98fr)]">
+      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.04fr),22rem]">
         <section className={picoPanel('p-6 sm:p-7')}>
           <p className={picoClasses.label}>Hosted runtime editor</p>
-          <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6] sm:text-4xl">
-            Update the operator snapshot
+          <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)] sm:text-4xl">
+            Update the operator record without leaving the route
           </h2>
-          <p className="mt-3 max-w-2xl text-sm leading-6 text-[#d5c0a8]">
-            This does not pretend to install anything from the browser. It stores the latest truthful runtime snapshot for the Pico account so the product surfaces stay coherent.
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+            This does not pretend to install anything from the browser. It stores the latest truthful runtime snapshot so the rest of Pico stops guessing.
           </p>
 
           {session.status !== 'authenticated' ? (
@@ -840,27 +910,27 @@ export function PicoOnboardingPageClient() {
             </div>
           ) : (
             <div className="mt-5 grid gap-4">
-              <div className="grid gap-4 md:grid-cols-2">
-                <label className="grid gap-2 text-sm text-[#d5c0a8]">
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <label className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
                   <span className={picoClasses.label}>Runtime label</span>
                   <input
                     value={runtimeDraft.label}
                     onChange={(event) =>
                       setRuntimeDraft((current) => ({ ...current, label: event.target.value }))
                     }
-                    className="rounded-[20px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-3 text-[#fff4e6] outline-none placeholder:text-[#8f7157]"
+                    className="rounded-[20px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
                     placeholder="OpenClaw"
                   />
                 </label>
 
-                <label className="grid gap-2 text-sm text-[#d5c0a8]">
+                <label className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
                   <span className={picoClasses.label}>Runtime status</span>
                   <select
                     value={runtimeDraft.status}
                     onChange={(event) =>
                       setRuntimeDraft((current) => ({ ...current, status: event.target.value }))
                     }
-                    className="rounded-[20px] border border-[#4a3423] bg-[#120d0a] px-4 py-3 text-[#fff4e6] outline-none"
+                    className="rounded-[20px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-input)] px-4 py-3 text-[color:var(--pico-text)] outline-none"
                   >
                     {runtimeStatusOptions.map((status) => (
                       <option key={status} value={status}>
@@ -870,14 +940,14 @@ export function PicoOnboardingPageClient() {
                   </select>
                 </label>
 
-                <label className="grid gap-2 text-sm text-[#d5c0a8]">
+                <label className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
                   <span className={picoClasses.label}>Install method</span>
                   <select
                     value={runtimeDraft.installMethod}
                     onChange={(event) =>
                       setRuntimeDraft((current) => ({ ...current, installMethod: event.target.value }))
                     }
-                    className="rounded-[20px] border border-[#4a3423] bg-[#120d0a] px-4 py-3 text-[#fff4e6] outline-none"
+                    className="rounded-[20px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-input)] px-4 py-3 text-[color:var(--pico-text)] outline-none"
                   >
                     {installMethodOptions.map((method) => (
                       <option key={method} value={method}>
@@ -887,57 +957,57 @@ export function PicoOnboardingPageClient() {
                   </select>
                 </label>
 
-                <label className="grid gap-2 text-sm text-[#d5c0a8]">
+                <label className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
                   <span className={picoClasses.label}>Gateway URL</span>
                   <input
                     value={runtimeDraft.gatewayUrl}
                     onChange={(event) =>
                       setRuntimeDraft((current) => ({ ...current, gatewayUrl: event.target.value }))
                     }
-                    className="rounded-[20px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-3 text-[#fff4e6] outline-none placeholder:text-[#8f7157]"
+                    className="rounded-[20px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
                     placeholder="http://127.0.0.1:4111"
                   />
                 </label>
 
-                <label className="grid gap-2 text-sm text-[#d5c0a8]">
+                <label className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
                   <span className={picoClasses.label}>Assistant name</span>
                   <input
                     value={runtimeDraft.assistantName}
                     onChange={(event) =>
                       setRuntimeDraft((current) => ({ ...current, assistantName: event.target.value }))
                     }
-                    className="rounded-[20px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-3 text-[#fff4e6] outline-none placeholder:text-[#8f7157]"
+                    className="rounded-[20px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
                     placeholder="Pico Starter"
                   />
                 </label>
 
-                <label className="grid gap-2 text-sm text-[#d5c0a8]">
+                <label className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
                   <span className={picoClasses.label}>Workspace</span>
                   <input
                     value={runtimeDraft.workspace}
                     onChange={(event) =>
                       setRuntimeDraft((current) => ({ ...current, workspace: event.target.value }))
                     }
-                    className="rounded-[20px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-3 text-[#fff4e6] outline-none placeholder:text-[#8f7157]"
+                    className="rounded-[20px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
                     placeholder="founder-lab"
                   />
                 </label>
               </div>
 
-              <label className="grid gap-2 text-sm text-[#d5c0a8]">
+              <label className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
                 <span className={picoClasses.label}>Model</span>
                 <input
                   value={runtimeDraft.model}
                   onChange={(event) =>
                     setRuntimeDraft((current) => ({ ...current, model: event.target.value }))
                   }
-                  className="rounded-[20px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-3 text-[#fff4e6] outline-none placeholder:text-[#8f7157]"
+                  className="rounded-[20px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
                   placeholder="gpt-5.4-mini"
                 />
               </label>
 
               <div className={picoSoft('p-4')}>
-                <div className="flex flex-wrap gap-3">
+                <div className="grid gap-3 sm:flex sm:flex-wrap">
                   <button
                     type="button"
                     onClick={() => void saveRuntimeSnapshot()}
@@ -950,7 +1020,7 @@ export function PicoOnboardingPageClient() {
                     Open install lesson
                   </Link>
                 </div>
-                <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   Save only what is true on the operator host right now: gateway URL, runtime health, and the bound assistant.
                 </p>
               </div>
@@ -958,74 +1028,71 @@ export function PicoOnboardingPageClient() {
           )}
         </section>
 
-        <section className={picoPanel('p-6 sm:p-7')}>
-          <p className={picoClasses.label}>Activation track</p>
-          <article className={picoInset('mt-4 grid gap-4 p-5')}>
-            <div className="flex flex-col gap-3">
-              <div className="flex flex-wrap items-center gap-3">
-                <span className={picoClasses.chip}>Do this first</span>
-                <span className={picoClasses.chip}>Outcome-driven</span>
+        <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start">
+          <section className={picoPanel('p-5')}>
+            <p className={picoClasses.label}>Current binding</p>
+            <div className="mt-4 grid gap-3">
+              <div className={picoSoft('p-4')}>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Assistant</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                  {currentBinding?.assistant_name ?? currentBinding?.assistant_id ?? 'not recorded'}
+                </p>
               </div>
-              <h2 className="font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
-                {firstTrack.title}
-              </h2>
-              <p className={picoClasses.body}>{firstTrack.intro}</p>
-              <p className="text-sm text-[#f0bb83]">Outcome: {firstTrack.outcome}</p>
+              <div className={picoSoft('p-4')}>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Workspace</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                  {currentBinding?.workspace ?? setup.onboarding?.workspace ?? 'not recorded'}
+                </p>
+              </div>
+              <div className={picoSoft('p-4')}>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Model</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                  {currentBinding?.model ?? 'not recorded'}
+                </p>
+              </div>
             </div>
-            <div className="grid gap-3">
-              {firstTrack.checklist.map((item) => (
-                <div key={item} className={picoInset('px-4 py-3 text-sm text-[#d8c1a6]')}>
-                  {item}
-                </div>
-              ))}
-            </div>
-            <div className={picoSoft('p-4')}>
-              <p className={picoClasses.body}>
-                {firstRunDone
-                  ? 'You already got the first win. Use the main action above and keep the sequence moving.'
-                  : installDone
-                    ? 'Hermes is installed. Skip the overview and open the first prompt lesson now.'
-                    : 'Everything else can wait. Open the install lesson and get the command working.'}
-              </p>
-            </div>
-          </article>
+          </section>
 
-          {firstRunDone ? (
-            <div className="mt-6 grid gap-4">
-              <p className={picoClasses.label}>Unlocked next</p>
-              {PICO_TRACKS.slice(1).map((track) => {
-                const selected = progress.selectedTrack === track.slug
-                const unlocked = derived.unlockedTrackSlugs.includes(track.slug)
-                return (
-                  <article key={track.slug} className={picoInset('grid gap-4 p-5')}>
-                    <div className="flex items-start justify-between gap-4">
-                      <div>
-                        <h3 className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                          {track.title}
-                        </h3>
-                        <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">{track.intro}</p>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => actions.pickTrack(track.slug)}
-                        disabled={!unlocked}
-                        className={picoClasses.tertiaryButton}
-                      >
-                        {selected ? 'Active track' : unlocked ? 'Set as track' : 'Locked'}
-                      </button>
-                    </div>
-                  </article>
-                )
-              })}
-            </div>
-          ) : (
-            <div className={picoSoft('mt-6 p-5')}>
-              <p className={picoClasses.body}>
-                Ignore the later tracks until the first local run works. More choices this early are just prettier procrastination.
-              </p>
-            </div>
-          )}
-        </section>
+          {session.status === 'authenticated' && setup.onboarding ? (
+            <section className={picoPanel('p-5')}>
+              <p className={picoClasses.label}>Hosted actions</p>
+              <div className="mt-4 grid gap-3">
+                <button
+                  type="button"
+                  onClick={() => void setup.completeCurrentStep()}
+                  className={picoClasses.primaryButton}
+                  disabled={setup.pendingAction !== null}
+                >
+                  {setup.pendingAction === 'complete_step' ? 'Updating step...' : 'Mark current step complete'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void setup.dismissChecklist()}
+                  className={picoClasses.secondaryButton}
+                  disabled={setup.pendingAction !== null || setup.onboarding.checklist_dismissed}
+                >
+                  {setup.onboarding.checklist_dismissed ? 'Checklist dismissed' : 'Dismiss checklist'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void setup.completeAll()}
+                  className={picoClasses.tertiaryButton}
+                  disabled={setup.pendingAction !== null}
+                >
+                  Complete wizard
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void setup.resetWizard()}
+                  className={picoClasses.tertiaryButton}
+                  disabled={setup.pendingAction !== null}
+                >
+                  Reset wizard
+                </button>
+              </div>
+            </section>
+          ) : null}
+        </aside>
       </section>
     </PicoShell>
   )

--- a/components/pico/PicoPlatformSurface.tsx
+++ b/components/pico/PicoPlatformSurface.tsx
@@ -11,6 +11,7 @@ import {
 import { usePicoHref } from '@/lib/pico/navigation'
 import { type PicoSessionState } from '@/components/pico/usePicoSession'
 import { picoClasses, picoEmber, picoInset, picoPanel, picoSoft } from '@/components/pico/picoTheme'
+import { cn } from '@/lib/utils'
 
 type PicoPlatformSurfaceProps = {
   session: PicoSessionState
@@ -119,10 +120,10 @@ export function PicoPlatformSurface({
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
           <p className={picoClasses.label}>Platform desk</p>
-          <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.06em] text-[#fff4e6] sm:text-4xl">
+          <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.06em] text-[color:var(--pico-text)] sm:text-4xl">
             Identity, route memory, and limits in one place
           </h2>
-          <p className="mt-3 max-w-3xl text-sm leading-6 text-[#d5c0a8]">
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-[color:var(--pico-text-secondary)]">
             This is the operator-facing control desk for the Pico account. It should tell the truth
             about plan limits, where the operator was last working, and whether the product chrome
             is tuned for focus or recovery.
@@ -136,12 +137,12 @@ export function PicoPlatformSurface({
           <div className={picoInset('grid gap-4 p-5')}>
             <div className="grid gap-4 sm:grid-cols-3">
               <div>
-                <p className="text-sm text-[#a8896e]">Plan</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">{plan.toUpperCase()}</p>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Plan</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">{plan.toUpperCase()}</p>
               </div>
               <div>
-                <p className="text-sm text-[#a8896e]">Verification</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Verification</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {session.status === 'authenticated'
                     ? session.user.isEmailVerified === false
                       ? 'pending'
@@ -152,8 +153,8 @@ export function PicoPlatformSurface({
                 </p>
               </div>
               <div>
-                <p className="text-sm text-[#a8896e]">Workspace saves</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Workspace saves</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {Object.keys(progress.lessonWorkspaces).length}
                 </p>
               </div>
@@ -163,7 +164,7 @@ export function PicoPlatformSurface({
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <p className={picoClasses.label}>Route memory</p>
-                  <p className="mt-1 text-sm leading-6 text-[#d5c0a8]">
+                  <p className="mt-1 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                     The current surface should match what the operator is actually doing. Keep this
                     updated when the product shifts lanes.
                   </p>
@@ -173,10 +174,7 @@ export function PicoPlatformSurface({
                 </span>
               </div>
 
-              <div
-                className="grid gap-3 md:grid-cols-2 xl:grid-cols-3"
-                data-testid="pico-platform-surface-memory"
-              >
+              <div className="grid gap-3" data-testid="pico-platform-surface-memory">
                 {surfaceOptions.map((option) => {
                   const selected = activeSurface === option.surface
                   return (
@@ -186,15 +184,22 @@ export function PicoPlatformSurface({
                       onClick={() => setActiveSurface(option.surface)}
                       aria-pressed={selected}
                       className={picoSoft(
-                        `grid gap-2 rounded-[24px] px-4 py-4 text-left transition hover:border-[#7d5232] hover:bg-[rgba(255,247,235,0.06)] ${
-                          selected ? 'border-[#e2904f] bg-[rgba(226,144,79,0.1)]' : ''
+                        `grid gap-3 rounded-[24px] px-4 py-4 text-left transition sm:grid-cols-[minmax(0,1fr),auto] sm:items-center hover:border-[color:var(--pico-border-hover)] hover:bg-[color:var(--pico-bg-surface-hover)] ${
+                          selected
+                            ? 'border-[color:var(--pico-accent)] bg-[rgba(var(--pico-accent-rgb),0.1)]'
+                            : ''
                         }`,
                       )}
                     >
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#a8896e]">
-                        {option.note}
-                      </p>
-                      <p className="text-lg font-medium text-[#fff4e6]">{option.label}</p>
+                      <div>
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-text-muted)]">
+                          {option.note}
+                        </p>
+                        <p className="mt-2 text-xl font-medium text-[color:var(--pico-text)]">{option.label}</p>
+                      </div>
+                      <span className={cn(picoClasses.chip, selected && 'text-[color:var(--pico-text)]')}>
+                        {selected ? 'active now' : 'set route'}
+                      </span>
                     </button>
                   )
                 })}
@@ -204,10 +209,10 @@ export function PicoPlatformSurface({
             <div className="grid gap-4 md:grid-cols-2">
               <div className={picoSoft('p-4')}>
                 <p className={picoClasses.label}>Current surface</p>
-                <p className="mt-2 text-lg font-medium text-[#fff4e6]">
+                <p className="mt-2 text-lg font-medium text-[color:var(--pico-text)]">
                   {activeSurface ?? 'not recorded'}
                 </p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
+                <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   Route memory should follow the operator through Pico instead of resetting every
                   time the page changes.
                 </p>
@@ -215,42 +220,42 @@ export function PicoPlatformSurface({
 
               <div className={picoSoft('p-4')}>
                 <p className={picoClasses.label}>Last lesson context</p>
-                <p className="mt-2 text-lg font-medium text-[#fff4e6]">
+                <p className="mt-2 text-lg font-medium text-[color:var(--pico-text)]">
                   {lastOpenedLesson ?? 'not recorded'}
                 </p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
+                <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   This is the recovery point when the operator needs to re-enter the lesson spine.
                 </p>
               </div>
             </div>
 
             <div className="grid gap-4 md:grid-cols-2">
-              <label className="flex items-start gap-3 rounded-[24px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-4 text-sm leading-6 text-[#d5c0a8]">
+              <label className="flex items-start gap-3 rounded-[24px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-4 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                 <input
                   type="checkbox"
                   checked={progress.platform.railCollapsed}
                   onChange={(event) => onSave({ railCollapsed: event.target.checked })}
-                  className="mt-1 h-4 w-4 rounded border-[#6e4d31] bg-transparent text-[#e2904f] accent-[#e2904f]"
+                  className="mt-1 h-4 w-4 rounded border-[color:var(--pico-border)] bg-transparent text-[color:var(--pico-accent)] accent-[color:var(--pico-accent)]"
                 />
                 <span>
-                  <span className="block font-medium text-[#fff4e6]">Collapse rail</span>
-                  <span className="block text-[#c7af93]">
+                  <span className="block font-medium text-[color:var(--pico-text)]">Collapse rail</span>
+                  <span className="block text-[color:var(--pico-text-secondary)]">
                     Use a tighter chrome when the operator already knows the route and needs more
                     room for the live surface.
                   </span>
                 </span>
               </label>
 
-              <label className="flex items-start gap-3 rounded-[24px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-4 text-sm leading-6 text-[#d5c0a8]">
+              <label className="flex items-start gap-3 rounded-[24px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-4 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                 <input
                   type="checkbox"
                   checked={progress.platform.helpLaneOpen}
                   onChange={(event) => onSave({ helpLaneOpen: event.target.checked })}
-                  className="mt-1 h-4 w-4 rounded border-[#6e4d31] bg-transparent text-[#e2904f] accent-[#e2904f]"
+                  className="mt-1 h-4 w-4 rounded border-[color:var(--pico-border)] bg-transparent text-[color:var(--pico-accent)] accent-[color:var(--pico-accent)]"
                 />
                 <span>
-                  <span className="block font-medium text-[#fff4e6]">Keep help lane open</span>
-                  <span className="block text-[#c7af93]">
+                  <span className="block font-medium text-[color:var(--pico-text)]">Keep help lane open</span>
+                  <span className="block text-[color:var(--pico-text-secondary)]">
                     Keep recovery guidance visible when the operator is still learning the product
                     routes.
                   </span>
@@ -292,12 +297,12 @@ export function PicoPlatformSurface({
               {(Object.entries(planMatrix) as Array<[keyof typeof planMatrix, string]>).map(([feature, value]) => (
                 <div
                   key={feature}
-                  className="flex items-start justify-between gap-4 border-b border-[#4a3423] pb-3 last:border-b-0 last:pb-0"
+                  className="flex items-start justify-between gap-4 border-b border-[color:var(--pico-border)] pb-3 last:border-b-0 last:pb-0"
                 >
-                  <span className="text-sm uppercase tracking-[0.18em] text-[#b58d65]">
+                  <span className="text-sm uppercase tracking-[0.18em] text-[color:var(--pico-text-muted)]">
                     {feature.replace('_', ' ')}
                   </span>
-                  <span className="max-w-[14rem] text-right text-sm leading-6 text-[#fff4e6]">
+                  <span className="max-w-[14rem] text-right text-sm leading-6 text-[color:var(--pico-text)]">
                     {value}
                   </span>
                 </div>
@@ -311,18 +316,18 @@ export function PicoPlatformSurface({
             <p className={picoClasses.label}>Route ledger</p>
             <div className="mt-4 grid gap-3">
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Current path</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">{currentPath}</p>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Current path</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">{currentPath}</p>
               </div>
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Platform state updated</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Platform state updated</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {formatTimestamp(progress.platform.updatedAt)}
                 </p>
               </div>
               <div className={picoSoft('p-4')}>
-                <p className="text-sm text-[#a8896e]">Sync confidence</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Sync confidence</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {formatSyncState(syncState, ready)}
                 </p>
               </div>
@@ -331,7 +336,7 @@ export function PicoPlatformSurface({
 
           <div className={picoInset('p-5')}>
             <p className={picoClasses.label}>Operator truth</p>
-            <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+            <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
               The product should remember the route and lesson context without pretending it knows
               more than it does. `activeSurface`, `lastOpenedLessonSlug`, the rail state, and the
               help lane are the minimum persisted memory needed to make Pico feel like one platform.

--- a/components/pico/PicoSessionBanner.tsx
+++ b/components/pico/PicoSessionBanner.tsx
@@ -26,6 +26,10 @@ export function PicoSessionBanner({ session, nextPath }: PicoSessionBannerProps)
     loading: false,
     error: null,
   })
+  const authenticatedRailClass =
+    'mt-4 grid grid-flow-col auto-cols-[minmax(12rem,72vw)] gap-3 overflow-x-auto pb-2 snap-x snap-mandatory sm:grid-flow-row sm:auto-cols-auto sm:overflow-visible sm:grid-cols-2 xl:grid-cols-4'
+  const anonymousRailClass =
+    'mt-4 grid grid-flow-col auto-cols-[minmax(12rem,72vw)] gap-3 overflow-x-auto pb-2 snap-x snap-mandatory sm:grid-flow-row sm:auto-cols-auto sm:overflow-visible sm:grid-cols-3'
 
   useEffect(() => {
     if (session.status !== 'authenticated') {
@@ -123,26 +127,26 @@ export function PicoSessionBanner({ session, nextPath }: PicoSessionBannerProps)
               </span>
             </div>
 
-            <p className="mt-4 text-sm leading-6 text-[#d5c0a8]">
-              Signed in as <span className="text-[#fff4e6]">{session.user.email ?? session.user.name ?? 'operator'}</span>. Progress sync, onboarding state, approvals, and live runtime data can now use the hosted MUTX account on this host.
+            <p className="mt-4 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+              Signed in as <span className="text-[color:var(--pico-text)]">{session.user.email ?? session.user.name ?? 'operator'}</span>. Progress sync, onboarding state, approvals, and live runtime data can now use the hosted MUTX account on this host.
             </p>
 
-            <div className="mt-4 grid gap-3 sm:grid-cols-3">
-              <div className={picoInset('p-4')}>
-                <p className="text-sm text-[#a8896e]">Identity</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+            <div className={authenticatedRailClass}>
+              <div className={picoInset('snap-start p-4')}>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Identity</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {session.user.name ?? 'operator'}
                 </p>
               </div>
-              <div className={picoInset('p-4')}>
-                <p className="text-sm text-[#a8896e]">Plan</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+              <div className={picoInset('snap-start p-4')}>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Plan</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {session.user.plan ? session.user.plan.toLowerCase() : 'unknown'}
                 </p>
               </div>
-              <div className={picoInset('p-4')}>
-                <p className="text-sm text-[#a8896e]">Email state</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+              <div className={picoInset('snap-start p-4')}>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Email state</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {session.user.isEmailVerified === false
                     ? 'pending'
                     : session.user.isEmailVerified === true
@@ -150,9 +154,9 @@ export function PicoSessionBanner({ session, nextPath }: PicoSessionBannerProps)
                       : 'unknown'}
                 </p>
               </div>
-              <div className={picoInset('p-4')}>
-                <p className="text-sm text-[#a8896e]">Webhook routes</p>
-                <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+              <div className={picoInset('snap-start p-4')}>
+                <p className="text-sm text-[color:var(--pico-text-muted)]">Webhook routes</p>
+                <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                   {readiness.loading
                     ? 'loading'
                     : readiness.webhookCount != null
@@ -163,28 +167,28 @@ export function PicoSessionBanner({ session, nextPath }: PicoSessionBannerProps)
             </div>
 
             {session.user.isEmailVerified === false && session.user.email ? (
-              <p className="mt-4 text-sm leading-6 text-[#f0deca]">
+              <p className="mt-4 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                 Password accounts stay limited until the inbox link is confirmed. Finish that before treating the hosted session as production-ready.
               </p>
             ) : null}
             {readiness.error ? (
-              <p className="mt-4 text-sm leading-6 text-[#f0deca]">{readiness.error}</p>
+              <p className="mt-4 text-sm leading-6 text-[color:var(--pico-text-secondary)]">{readiness.error}</p>
             ) : null}
           </div>
 
           <div className={picoSoft('grid gap-3 p-4')}>
             <p className={picoClasses.label}>Product truth</p>
-            <p className="text-sm leading-6 text-[#d5c0a8]">
+            <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
               The product can now tell the truth about progress, runtime state, approvals, and hosted setup. If this account is not production-ready yet, fix that here before trusting the rest of the surface.
             </p>
-            <div className="grid gap-2 text-sm text-[#d5c0a8]">
-              <div className="flex items-center justify-between gap-3 border-b border-[#3a291d] pb-2">
+            <div className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
+              <div className="flex items-center justify-between gap-3 border-b border-[color:var(--pico-border)] pb-2">
                 <span>Progress sync</span>
-                <span className="text-[#fff4e6]">live</span>
+                <span className="text-[color:var(--pico-text)]">live</span>
               </div>
-              <div className="flex items-center justify-between gap-3 border-b border-[#3a291d] pb-2">
+              <div className="flex items-center justify-between gap-3 border-b border-[color:var(--pico-border)] pb-2">
                 <span>Runtime truth</span>
-                <span className="text-right text-[#fff4e6]">
+                <span className="text-right text-[color:var(--pico-text)]">
                   {readiness.loading
                     ? 'checking'
                     : readiness.webhookCount != null && readiness.webhookCount > 0
@@ -194,7 +198,7 @@ export function PicoSessionBanner({ session, nextPath }: PicoSessionBannerProps)
               </div>
               <div className="flex items-center justify-between gap-3">
                 <span>Approval confidence</span>
-                <span className="text-right text-[#fff4e6]">
+                <span className="text-right text-[color:var(--pico-text)]">
                   {session.user.isEmailVerified === false ? 'limited' : 'usable'}
                 </span>
               </div>
@@ -217,7 +221,7 @@ export function PicoSessionBanner({ session, nextPath }: PicoSessionBannerProps)
     return (
       <div className={picoPanel('p-4 sm:p-5')}>
         <p className={picoClasses.label}>Hosted session</p>
-        <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
+        <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
           Checking whether this Pico host has an operator session attached.
         </p>
       </div>
@@ -228,7 +232,7 @@ export function PicoSessionBanner({ session, nextPath }: PicoSessionBannerProps)
     return (
       <div className={picoEmber('p-4 sm:p-5')}>
         <p className={picoClasses.label}>Hosted session</p>
-        <p className="mt-2 text-sm leading-6 text-[#f0deca]">{session.error}</p>
+        <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">{session.error}</p>
       </div>
     )
   }
@@ -241,42 +245,42 @@ export function PicoSessionBanner({ session, nextPath }: PicoSessionBannerProps)
             <span className={picoClasses.chip}>hosted session required</span>
             <span className={picoClasses.chip}>pico host auth</span>
           </div>
-          <p className="mt-4 max-w-3xl text-sm leading-6 text-[#f0deca]">
+          <p className="mt-4 max-w-3xl text-sm leading-6 text-[color:var(--pico-text-secondary)]">
             The Pico platform routes are live here, but the hosted session is not attached yet on this domain. Sign in on Pico to persist progress, read live runs, and use the backend onboarding/runtime state. Google, GitHub, Discord, password signup, and email confirmation all terminate on this host now.
           </p>
-          <div className="mt-4 grid gap-3 sm:grid-cols-3">
-            <div className={picoInset('p-4')}>
-              <p className="text-sm text-[#d6b695]">Progress</p>
-              <p className="mt-1 text-lg font-medium text-[#fff4e6]">won’t persist</p>
+          <div className={anonymousRailClass}>
+            <div className={picoInset('snap-start p-4')}>
+              <p className="text-sm text-[color:var(--pico-text-muted)]">Progress</p>
+              <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">won’t persist</p>
             </div>
-            <div className={picoInset('p-4')}>
-              <p className="text-sm text-[#d6b695]">Runtime truth</p>
-              <p className="mt-1 text-lg font-medium text-[#fff4e6]">limited</p>
+            <div className={picoInset('snap-start p-4')}>
+              <p className="text-sm text-[color:var(--pico-text-muted)]">Runtime truth</p>
+              <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">limited</p>
             </div>
-            <div className={picoInset('p-4')}>
-              <p className="text-sm text-[#d6b695]">Approvals</p>
-              <p className="mt-1 text-lg font-medium text-[#fff4e6]">read-only feeling</p>
+            <div className={picoInset('snap-start p-4')}>
+              <p className="text-sm text-[color:var(--pico-text-muted)]">Approvals</p>
+              <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">read-only feeling</p>
             </div>
           </div>
         </div>
 
         <div className={picoSoft('grid gap-3 p-4')}>
           <p className={picoClasses.label}>Without session</p>
-          <div className="grid gap-2 text-sm text-[#d5c0a8]">
-            <div className="flex items-center justify-between gap-3 border-b border-[#3a291d] pb-2">
+          <div className="grid gap-2 text-sm text-[color:var(--pico-text-secondary)]">
+            <div className="flex items-center justify-between gap-3 border-b border-[color:var(--pico-border)] pb-2">
               <span>Progress sync</span>
-              <span className="text-[#fff4e6]">local only</span>
+              <span className="text-[color:var(--pico-text)]">local only</span>
             </div>
-            <div className="flex items-center justify-between gap-3 border-b border-[#3a291d] pb-2">
+            <div className="flex items-center justify-between gap-3 border-b border-[color:var(--pico-border)] pb-2">
               <span>Runtime truth</span>
-              <span className="text-right text-[#fff4e6]">not trustworthy yet</span>
+              <span className="text-right text-[color:var(--pico-text)]">not trustworthy yet</span>
             </div>
             <div className="flex items-center justify-between gap-3">
               <span>Approvals + webhooks</span>
-              <span className="text-right text-[#fff4e6]">blocked</span>
+              <span className="text-right text-[color:var(--pico-text)]">blocked</span>
             </div>
           </div>
-          <p className="text-sm leading-6 text-[#d5c0a8]">
+          <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
             Attach the Pico account on this host before you trust progress, live runtime state, or approval behavior.
           </p>
           <div className="flex flex-wrap gap-3">

--- a/components/pico/PicoShell.tsx
+++ b/components/pico/PicoShell.tsx
@@ -13,6 +13,7 @@ import {
   picoCodexNote,
   picoPanel,
 } from '@/components/pico/picoTheme'
+import { PicoFooter } from '@/components/pico/PicoFooter'
 import { PicoWelcomeTour } from '@/components/pico/PicoWelcomeTour'
 import { picoHref } from '@/lib/pico/navigation'
 import { cn } from '@/lib/utils'
@@ -53,17 +54,17 @@ function ShellBackground({ academyMode }: { academyMode: boolean }) {
         className={cn(
           'pointer-events-none absolute inset-0',
           academyMode
-            ? 'bg-[radial-gradient(circle_at_18%_0%,rgba(212,171,115,0.18),transparent_22%),radial-gradient(circle_at_82%_10%,rgba(142,121,196,0.08),transparent_18%),linear-gradient(180deg,#141218_0%,#0e0d12_52%,#08070b_100%)]'
-            : 'bg-[radial-gradient(circle_at_18%_0%,rgba(212,171,115,0.16),transparent_24%),radial-gradient(circle_at_88%_16%,rgba(142,121,196,0.08),transparent_18%),linear-gradient(180deg,#121116_0%,#08070b_100%)]',
+            ? 'bg-[radial-gradient(circle_at_18%_0%,rgba(var(--pico-accent-rgb),0.18),transparent_22%),radial-gradient(circle_at_82%_10%,rgba(115,239,190,0.08),transparent_18%),linear-gradient(180deg,#091209_0%,#050905_52%,#030603_100%)]'
+            : 'bg-[radial-gradient(circle_at_18%_0%,rgba(var(--pico-accent-rgb),0.14),transparent_24%),radial-gradient(circle_at_88%_16%,rgba(115,239,190,0.08),transparent_18%),linear-gradient(180deg,#081108_0%,#030603_100%)]',
         )}
       />
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-[0.05] [background-image:linear-gradient(rgba(255,255,255,0.14)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.08)_1px,transparent_1px)] [background-size:56px_56px] [mask-image:linear-gradient(180deg,rgba(0,0,0,0.92),transparent_92%)]"
+        className="pointer-events-none absolute inset-0 opacity-[0.06] [background-image:linear-gradient(rgba(255,255,255,0.14)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.08)_1px,transparent_1px)] [background-size:56px_56px] [mask-image:linear-gradient(180deg,rgba(0,0,0,0.95),transparent_92%)]"
       />
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 top-0 h-[24rem] bg-[radial-gradient(circle_at_50%_-10%,rgba(255,233,205,0.08),transparent_44%)]"
+        className="pointer-events-none absolute inset-x-0 top-0 h-[24rem] bg-[radial-gradient(circle_at_50%_-10%,rgba(var(--pico-accent-rgb),0.14),transparent_44%)]"
       />
     </>
   )
@@ -72,18 +73,68 @@ function ShellBackground({ academyMode }: { academyMode: boolean }) {
 function PicoWordmark({ pathname }: { pathname: string }) {
   return (
     <Link href={picoHref(pathname, '/onboarding')} className="inline-flex items-center gap-3">
-      <span className="inline-flex h-12 w-12 items-center justify-center overflow-hidden rounded-[16px] border border-[rgba(255,233,204,0.12)] bg-[rgba(255,247,235,0.04)] shadow-[0_18px_36px_rgba(2,2,5,0.28)]">
+      <span className="inline-flex h-12 w-12 items-center justify-center overflow-hidden rounded-[16px] border border-[color:var(--pico-border)] bg-[linear-gradient(145deg,rgba(var(--pico-accent-rgb),0.1),rgba(8,18,10,0.82))] shadow-[0_18px_36px_rgba(0,0,0,0.28),0_0_28px_rgba(var(--pico-accent-rgb),0.12)]">
         <Image src="/pico/logo.png" alt="PicoMUTX logo" width={28} height={28} priority />
       </span>
       <span className="grid gap-1">
-        <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-[#b78f67]">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-[color:var(--pico-text-muted)]">
           PicoMUTX
         </span>
-        <span className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
+        <span className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
           operator atlas
         </span>
       </span>
     </Link>
+  )
+}
+
+function ShellHelpLane({
+  pathname,
+  currentItem,
+  nextItem,
+}: {
+  pathname: string
+  currentItem: (typeof navItems)[number]
+  nextItem: (typeof navItems)[number] | null
+}) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-3" data-testid="pico-help-lane-panel">
+      <div className={picoCodexInset('p-4')}>
+        <p className={picoClasses.label}>Stay here when</p>
+        <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+          the next move is still inside{' '}
+          <span className="text-[color:var(--pico-text)]">{currentItem.label}</span>.
+        </p>
+      </div>
+      <Link
+        href={picoHref(pathname, '/support')}
+        className={picoCodexNote(
+          'p-4 transition duration-200 hover:border-[color:var(--pico-border-hover)] hover:bg-[rgba(var(--pico-accent-rgb),0.16)]',
+        )}
+      >
+        <p className={picoClasses.label}>Recovery route</p>
+        <p className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+          Open help lane
+        </p>
+        <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+          Use this when the product route is no longer honest about the blocker.
+        </p>
+      </Link>
+      <Link
+        href={picoHref(pathname, nextItem?.href ?? '/support')}
+        className={picoCodexInset(
+          'p-4 transition duration-200 hover:border-[color:var(--pico-border-hover)] hover:bg-[rgba(255,255,255,0.03)]',
+        )}
+      >
+        <p className={picoClasses.label}>Continue sequence</p>
+        <p className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+          {nextItem ? nextItem.label : 'Human help'}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+          Keep momentum if the next chapter is already the right tool.
+        </p>
+      </Link>
+    </div>
   )
 }
 
@@ -102,8 +153,7 @@ export function PicoShell({
   const pathname = usePathname()
   const [tourOpen, setTourOpen] = useState(false)
   const academyMode = mode === 'academy'
-  const currentItem =
-    navItems.find((item) => routeIsActive(pathname, item.href)) ?? navItems[0]
+  const currentItem = navItems.find((item) => routeIsActive(pathname, item.href)) ?? navItems[0]
   const currentIndex = navItems.findIndex((item) => item.href === currentItem.href)
   const previousItem = currentIndex > 0 ? navItems[currentIndex - 1] : null
   const nextItem = currentIndex < navItems.length - 1 ? navItems[currentIndex + 1] : null
@@ -130,110 +180,104 @@ export function PicoShell({
 
   if (academyMode) {
     return (
-      <div className="relative min-h-screen overflow-hidden bg-[#09080b] text-[#fff0df]">
+      <div className="relative min-h-screen overflow-hidden bg-[color:var(--pico-bg)] text-[color:var(--pico-text)]">
         <ShellBackground academyMode />
 
-        <div className="relative mx-auto max-w-[96rem] px-4 pb-32 pt-4 sm:px-6 lg:px-8 lg:pb-12">
-          <header className={picoCodexFrame('px-5 py-5 sm:px-6 lg:px-8')}>
+        <div className="relative mx-auto max-w-[98rem] px-4 pb-32 pt-5 sm:px-6 lg:px-8 lg:pb-12">
+          <header className={picoCodexFrame('overflow-hidden px-5 py-5 sm:px-6 lg:px-8')}>
             <div className="flex flex-wrap items-center justify-between gap-4">
               <PicoWordmark pathname={pathname} />
 
               <div className="flex flex-wrap items-center gap-2">
                 <span className={picoCodex.stamp}>Chapter {currentItem.chapter}</span>
-                <button
-                  type="button"
-                  onClick={() => setTourOpen(true)}
-                  className={picoClasses.tertiaryButton}
-                  data-testid="pico-open-tour"
-                >
-                  How this works
-                </button>
-                {onToggleRail ? (
+                <div className="hidden sm:flex sm:flex-wrap sm:items-center sm:gap-2">
                   <button
                     type="button"
-                    onClick={onToggleRail}
-                    aria-pressed={!railCollapsed}
-                    className={cn(
-                      picoClasses.tertiaryButton,
-                      !railCollapsed && 'border-[rgba(212,171,115,0.24)] text-[#fff4e6]',
-                    )}
+                    onClick={() => setTourOpen(true)}
+                    className={picoClasses.tertiaryButton}
+                    data-testid="pico-open-tour"
                   >
-                    Map
+                    How this works
                   </button>
-                ) : null}
-                {onToggleHelpLane ? (
-                  <button
-                    type="button"
-                    onClick={onToggleHelpLane}
-                    aria-pressed={helpLaneOpen}
-                    className={cn(
-                      picoClasses.tertiaryButton,
-                      helpLaneOpen && 'border-[rgba(212,171,115,0.24)] text-[#fff4e6]',
-                    )}
-                  >
-                    Help
-                  </button>
-                ) : null}
+                  {onToggleRail ? (
+                    <button
+                      type="button"
+                      onClick={onToggleRail}
+                      aria-pressed={!railCollapsed}
+                      className={cn(
+                        picoClasses.tertiaryButton,
+                        !railCollapsed &&
+                          'border-[color:var(--pico-border-hover)] bg-[rgba(var(--pico-accent-rgb),0.08)] text-[color:var(--pico-text)]',
+                      )}
+                    >
+                      Map
+                    </button>
+                  ) : null}
+                  {onToggleHelpLane ? (
+                    <button
+                      type="button"
+                      onClick={onToggleHelpLane}
+                      aria-pressed={helpLaneOpen}
+                      className={cn(
+                        picoClasses.tertiaryButton,
+                        helpLaneOpen &&
+                          'border-[color:var(--pico-border-hover)] bg-[rgba(var(--pico-accent-rgb),0.08)] text-[color:var(--pico-text)]',
+                      )}
+                    >
+                      Help
+                    </button>
+                  ) : null}
+                </div>
               </div>
             </div>
 
-            <div className="mt-5 flex flex-wrap items-end justify-between gap-4 border-t border-[rgba(255,233,204,0.1)] pt-4">
-              <div className="grid gap-1">
-                <p className={picoClasses.label}>
-                  {eyebrow ?? `Chapter ${currentItem.chapter}`}
+            <div className="mt-5 grid gap-5 border-t border-[color:var(--pico-border)] pt-5 lg:grid-cols-[minmax(0,1fr),22rem] lg:items-end">
+              <div className="grid gap-2">
+                <div className="sm:hidden">
+                  <button
+                    type="button"
+                    onClick={() => setTourOpen(true)}
+                    className={picoClasses.tertiaryButton}
+                    data-testid="pico-open-tour-mobile"
+                  >
+                    How this works
+                  </button>
+                </div>
+                <p className={picoClasses.label}>{eyebrow ?? `Chapter ${currentItem.chapter}`}</p>
+                <p className="font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)] sm:text-4xl">
+                  {title}
                 </p>
-                <p className="font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
-                  {currentItem.label}
-                </p>
-                <p className="max-w-2xl text-sm leading-6 text-[#d3bea6]">
-                  {currentItem.note}. {railCollapsed ? 'Focus mode is active.' : 'The codex map is open.'}
+                <p className="max-w-3xl text-sm leading-6 text-[color:var(--pico-text-secondary)] sm:text-base">
+                  {description}
                 </p>
               </div>
 
-              <div className="grid gap-1 text-right text-sm text-[#b99879]">
-                <span>{title}</span>
-                <span>{description}</span>
+              <div className={picoCodexInset('grid gap-3 p-4 lg:p-5')}>
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p className={picoClasses.label}>Route mode</p>
+                  <span className={picoCodex.stamp}>{currentItem.label}</span>
+                </div>
+                <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                  {currentItem.note}. {railCollapsed ? 'Focus mode is active.' : 'The map stays open.'}
+                </p>
+                <div className="grid gap-1 text-[11px] uppercase tracking-[0.22em] text-[color:var(--pico-text-muted)]">
+                  <span>{previousItem ? `Previous: ${previousItem.label}` : 'Start of sequence'}</span>
+                  <span>{nextItem ? `Next: ${nextItem.label}` : 'Final chapter'}</span>
+                </div>
               </div>
             </div>
 
             {helpLaneOpen && !isAcademyLessonRoute ? (
-              <div
-                className="mt-5 grid gap-3 border-t border-[rgba(255,233,204,0.1)] pt-5 lg:grid-cols-3"
-                data-testid="pico-help-lane-panel"
-              >
-                <div className={picoCodexInset('p-4')}>
-                  <p className={picoClasses.label}>Stay here when</p>
-                  <p className="mt-3 text-sm leading-6 text-[#dbc6ae]">
-                    the next move is still visible on this page and you only need a clearer reading of the mission.
-                  </p>
-                </div>
-
-                <Link href={picoHref(pathname, '/tutor')} className={picoCodexNote('p-4 transition hover:border-[#a1714b]')}>
-                  <p className={picoClasses.label}>Exact blocker</p>
-                  <p className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                    Ask tutor
-                  </p>
-                  <p className="mt-2 text-sm leading-6 text-[#f1dfcb]">
-                    Use this when a command, path, or validation step is failing.
-                  </p>
-                </Link>
-
-                <div className="grid gap-3">
-                  <Link href={picoHref(pathname, '/autopilot')} className={picoCodexInset('p-4 transition hover:border-[rgba(212,171,115,0.24)] hover:text-[#fff4e6]')}>
-                    <p className={picoClasses.label}>Runtime truth</p>
-                    <p className="mt-2 text-lg font-medium text-[#fff4e6]">Open Autopilot</p>
-                  </Link>
-                  <Link href={picoHref(pathname, '/support')} className={picoCodexInset('p-4 transition hover:border-[rgba(212,171,115,0.24)] hover:text-[#fff4e6]')}>
-                    <p className={picoClasses.label}>Messy edge</p>
-                    <p className="mt-2 text-lg font-medium text-[#fff4e6]">Open support lane</p>
-                  </Link>
-                </div>
+              <div className="mt-5 border-t border-[color:var(--pico-border)] pt-5">
+                <ShellHelpLane pathname={pathname} currentItem={currentItem} nextItem={nextItem} />
               </div>
             ) : null}
           </header>
 
           <main className="mt-6 space-y-8">{children}</main>
         </div>
+
+        <PicoFooter />
 
         <div className="fixed inset-x-4 bottom-4 z-40 lg:hidden">
           <div className={picoCodexFrame('px-3 py-3')}>
@@ -242,19 +286,19 @@ export function PicoShell({
                 <>
                   <Link
                     href={picoHref(pathname, '/academy')}
-                    className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[rgba(255,233,204,0.12)] px-3 text-xs font-semibold uppercase tracking-[0.18em] text-[#e3c7aa]"
+                    className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[color:var(--pico-border)] px-3 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-text-secondary)]"
                   >
                     Back to map
                   </Link>
                   <a
                     href="#pico-proof-composer"
-                    className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[rgba(212,171,115,0.24)] bg-[rgba(212,171,115,0.08)] px-3 text-xs font-semibold uppercase tracking-[0.18em] text-[#fff4e6]"
+                    className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[color:var(--pico-border-hover)] bg-[rgba(var(--pico-accent-rgb),0.08)] px-3 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-text)]"
                   >
                     Proof
                   </a>
                   <a
                     href="#pico-lesson-recovery"
-                    className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[rgba(255,233,204,0.12)] px-3 text-xs font-semibold uppercase tracking-[0.18em] text-[#e3c7aa]"
+                    className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[color:var(--pico-border)] px-3 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-text-secondary)]"
                   >
                     Help
                   </a>
@@ -263,21 +307,21 @@ export function PicoShell({
                 <>
                   <a
                     href="#pico-academy-workspace-summary"
-                    className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[rgba(212,171,115,0.24)] bg-[rgba(212,171,115,0.08)] px-3 text-xs font-semibold uppercase tracking-[0.18em] text-[#fff4e6]"
+                    className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[color:var(--pico-border-hover)] bg-[rgba(var(--pico-accent-rgb),0.08)] px-3 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-text)]"
                   >
                     Open mission
                   </a>
                   <button
                     type="button"
                     onClick={onToggleRail}
-                    className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[rgba(255,233,204,0.12)] px-3 text-xs font-semibold uppercase tracking-[0.18em] text-[#e3c7aa]"
+                    className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[color:var(--pico-border)] px-3 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-text-secondary)]"
                   >
                     Map
                   </button>
                   <button
                     type="button"
                     onClick={onToggleHelpLane}
-                    className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[rgba(255,233,204,0.12)] px-3 text-xs font-semibold uppercase tracking-[0.18em] text-[#e3c7aa]"
+                    className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[color:var(--pico-border)] px-3 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-text-secondary)]"
                   >
                     Help
                   </button>
@@ -300,23 +344,23 @@ export function PicoShell({
   }
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#0c0806] text-[#fff0df]">
+    <div className="relative min-h-screen overflow-hidden bg-[color:var(--pico-bg)] text-[color:var(--pico-text)]">
       <ShellBackground academyMode={false} />
 
-      <div className="relative mx-auto max-w-[104rem] px-4 py-4 pb-28 sm:px-6 lg:px-8 lg:pb-4">
-        <div className="grid gap-6 lg:grid-cols-[17rem,minmax(0,1fr)]">
+      <div className="relative mx-auto max-w-[106rem] px-4 py-5 pb-28 sm:px-6 lg:px-8 lg:pb-4">
+        <div className="grid grid-cols-[minmax(0,1fr)] gap-6 lg:grid-cols-[18rem,minmax(0,1fr)]">
           <aside className="hidden lg:block lg:sticky lg:top-4 lg:self-start">
             <div className={picoPanel('overflow-hidden')}>
-              <div className="border-b border-[#3a291d] p-5">
+              <div className="border-b border-[color:var(--pico-border)] p-5">
                 <PicoWordmark pathname={pathname} />
               </div>
 
-              <div className="border-b border-[#3a291d] px-5 py-4">
+              <div className="border-b border-[color:var(--pico-border)] px-5 py-4">
                 <p className={picoClasses.label}>Current chapter</p>
-                <p className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+                <p className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                   {currentItem.label}
                 </p>
-                <p className="mt-2 text-sm text-[#c7af93]">{currentItem.note}</p>
+                <p className="mt-2 text-sm text-[color:var(--pico-text-secondary)]">{currentItem.note}</p>
               </div>
 
               <nav className="grid gap-2 p-4">
@@ -327,17 +371,17 @@ export function PicoShell({
                       key={item.href}
                       href={picoHref(pathname, item.href)}
                       className={cn(
-                        'grid gap-1 rounded-[22px] border px-4 py-3 transition',
+                        'grid gap-1 rounded-[22px] border px-4 py-3 transition duration-200',
                         active
-                          ? 'border-[rgba(212,171,115,0.24)] bg-[linear-gradient(180deg,rgba(212,171,115,0.18),rgba(37,31,25,0.28))] text-[#fff0df]'
-                          : 'border-[#3e2c20] bg-[rgba(255,247,235,0.03)] text-[#d3b99d] hover:border-[#5d412b] hover:bg-[rgba(255,247,235,0.06)] hover:text-[#fff4e6]',
+                          ? 'border-[color:var(--pico-border-hover)] bg-[linear-gradient(180deg,rgba(var(--pico-accent-rgb),0.16),rgba(10,19,11,0.38))] text-[color:var(--pico-text)] shadow-[0_18px_42px_rgba(var(--pico-accent-rgb),0.08)]'
+                          : 'border-[color:rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.015)] text-[color:var(--pico-text-secondary)] hover:border-[color:var(--pico-border)] hover:bg-[rgba(255,255,255,0.03)] hover:text-[color:var(--pico-text)]',
                       )}
                     >
-                      <span className="text-[10px] font-semibold uppercase tracking-[0.24em] text-[#b58d65]">
+                      <span className="text-[10px] font-semibold uppercase tracking-[0.24em] text-[color:var(--pico-text-muted)]">
                         {item.chapter}
                       </span>
                       <span className="font-medium">{item.label}</span>
-                      <span className="text-xs text-[#b59a7f]">{item.note}</span>
+                      <span className="text-xs text-[color:var(--pico-text-muted)]">{item.note}</span>
                     </Link>
                   )
                 })}
@@ -345,20 +389,20 @@ export function PicoShell({
             </div>
           </aside>
 
-          <div className="space-y-6">
+          <div className="min-w-0 space-y-6">
             <header className={picoPanel('overflow-hidden')}>
-              <div className="border-b border-[#3a291d] px-6 py-4 sm:px-7">
+              <div className="border-b border-[color:var(--pico-border)] px-6 py-4 sm:px-7">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div className="flex flex-wrap items-center gap-3">
-                    <span className="inline-flex rounded-full border border-[rgba(255,233,204,0.12)] bg-[rgba(255,247,235,0.04)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-[#e1a56b]">
+                    <span className="inline-flex rounded-full border border-[color:var(--pico-border)] bg-[rgba(255,255,255,0.02)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--pico-accent-bright)]">
                       Chapter {currentItem.chapter}
                     </span>
-                    <span className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#a8896e]">
+                    <span className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--pico-text-muted)]">
                       {currentItem.note}
                     </span>
                   </div>
 
-                  <div className="flex flex-wrap gap-2">
+                  <div className="hidden sm:flex sm:flex-wrap sm:gap-2">
                     <button
                       type="button"
                       onClick={() => setTourOpen(true)}
@@ -394,63 +438,52 @@ export function PicoShell({
                 </div>
               </div>
 
-              <div className="grid gap-5 px-6 py-6 sm:px-7 lg:grid-cols-[minmax(0,1fr),18rem] lg:items-start">
-                <div className="grid gap-3">
+              <div className="grid grid-cols-[minmax(0,1fr)] gap-5 px-6 py-6 sm:px-7 lg:grid-cols-[minmax(0,1fr),20rem] lg:items-start">
+                <div className="grid min-w-0 gap-4">
+                  <div className="sm:hidden">
+                    <button
+                      type="button"
+                      onClick={() => setTourOpen(true)}
+                      className={picoClasses.tertiaryButton}
+                      data-testid="pico-open-tour-mobile"
+                    >
+                      Quick help
+                    </button>
+                  </div>
                   {eyebrow ? (
-                    <span className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#a8896e]">
+                    <span className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--pico-text-muted)]">
                       {eyebrow}
                     </span>
                   ) : null}
-                  <h1 className="max-w-4xl font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[#fff4e6] sm:text-6xl">
+                  <h1 className="max-w-[11ch] font-[family:var(--font-site-display)] text-[clamp(2.6rem,10vw,4rem)] leading-[0.92] tracking-[-0.06em] text-[color:var(--pico-text)] sm:max-w-4xl sm:text-6xl">
                     {title}
                   </h1>
-                  <p className="max-w-3xl text-sm leading-7 text-[#d2bca2] sm:text-base">
+                  <p className="max-w-3xl text-sm leading-7 text-[color:var(--pico-text-secondary)] sm:text-base">
                     {description}
                   </p>
                 </div>
 
-                <div className="grid gap-4">
+                <div className="grid min-w-0 gap-4">
                   <div className={picoCodexInset('p-5')}>
                     <p className={picoClasses.label}>Chapter note</p>
-                    <p className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
+                    <p className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                       {currentItem.note}
                     </p>
-                    <p className="mt-3 text-sm leading-6 text-[#c7af93]">
+                    <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                       This surface should reduce uncertainty immediately and point to the next irreversible action.
                     </p>
                   </div>
-                  {actions ? <div className="flex flex-wrap gap-3">{actions}</div> : null}
+                  {actions ? (
+                    <div className="grid w-full min-w-0 gap-3 [&>*]:min-w-0 [&>*]:w-full sm:flex sm:flex-wrap sm:[&>*]:w-auto">
+                      {actions}
+                    </div>
+                  ) : null}
                 </div>
               </div>
 
               {helpLaneOpen ? (
-                <div className="border-t border-[#3a291d] px-6 py-5 sm:px-7" data-testid="pico-help-lane-panel">
-                  <div className="grid gap-4 lg:grid-cols-3">
-                    <div className={picoCodexInset('p-4')}>
-                      <p className={picoClasses.label}>Stay here when</p>
-                      <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
-                        the next move is still inside <span className="text-[#fff4e6]">{currentItem.label}</span>.
-                      </p>
-                    </div>
-                    <Link
-                      href={picoHref(pathname, '/support')}
-                      className={picoCodexInset('p-4 transition hover:border-[rgba(212,171,115,0.24)] hover:bg-[rgba(255,247,235,0.05)]')}
-                    >
-                      <p className={picoClasses.label}>Recovery route</p>
-                      <p className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                        Open help lane
-                      </p>
-                    </Link>
-                    <Link
-                      href={picoHref(pathname, nextItem?.href ?? '/support')}
-                      className={picoCodexInset('p-4 transition hover:border-[rgba(212,171,115,0.24)] hover:bg-[rgba(255,247,235,0.05)]')}
-                    >
-                      <p className={picoClasses.label}>Continue sequence</p>
-                      <p className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                        {nextItem ? nextItem.label : 'Human help'}
-                      </p>
-                    </Link>
-                  </div>
+                <div className="border-t border-[color:var(--pico-border)] px-6 py-5 sm:px-7">
+                  <ShellHelpLane pathname={pathname} currentItem={currentItem} nextItem={nextItem} />
                 </div>
               ) : null}
             </header>
@@ -460,21 +493,23 @@ export function PicoShell({
         </div>
       </div>
 
+      <PicoFooter />
+
       <div className="fixed inset-x-4 bottom-4 z-40 lg:hidden">
-        <div className="grid grid-cols-[auto,1fr,auto,auto] items-center gap-2 rounded-[24px] border border-[rgba(255,233,204,0.12)] bg-[rgba(13,12,16,0.94)] p-2 shadow-[0_24px_60px_rgba(2,2,5,0.4)] backdrop-blur">
+        <div className="grid grid-cols-[auto,1fr,auto,auto] items-center gap-2 rounded-[24px] border border-[color:var(--pico-border)] bg-[rgba(6,12,8,0.94)] p-2 shadow-[0_24px_60px_rgba(0,0,0,0.4)] backdrop-blur">
           <Link
             href={picoHref(pathname, previousItem?.href ?? '/onboarding')}
             aria-label={previousItem ? `Go to previous chapter: ${previousItem.label}` : 'Go to onboarding'}
-            className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[rgba(255,233,204,0.12)] px-3 text-xs font-medium uppercase tracking-[0.16em] text-[#d9c1a4]"
+            className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[color:var(--pico-border)] px-3 text-xs font-medium uppercase tracking-[0.16em] text-[color:var(--pico-text-secondary)]"
           >
             Prev
           </Link>
 
           <div className="min-w-0 px-2">
-            <p className="truncate text-[11px] font-semibold uppercase tracking-[0.22em] text-[#a8896e]">
+            <p className="truncate text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--pico-text-muted)]">
               Chapter {currentItem.chapter}
             </p>
-            <p className="truncate font-[family:var(--font-site-display)] text-xl tracking-[-0.05em] text-[#fff4e6]">
+            <p className="truncate font-[family:var(--font-site-display)] text-xl tracking-[-0.05em] text-[color:var(--pico-text)]">
               {currentItem.label}
             </p>
           </div>
@@ -482,7 +517,7 @@ export function PicoShell({
           <Link
             href={picoHref(pathname, nextItem?.href ?? '/support')}
             aria-label={nextItem ? `Go to next chapter: ${nextItem.label}` : 'Go to support'}
-            className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[rgba(255,233,204,0.12)] px-3 text-xs font-medium uppercase tracking-[0.16em] text-[#d9c1a4]"
+            className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[color:var(--pico-border)] px-3 text-xs font-medium uppercase tracking-[0.16em] text-[color:var(--pico-text-secondary)]"
           >
             Next
           </Link>
@@ -490,7 +525,7 @@ export function PicoShell({
           <Link
             href={picoHref(pathname, currentItem.href === '/support' ? '/academy' : '/support')}
             aria-label={currentItem.href === '/support' ? 'Open academy map' : 'Open help lane'}
-            className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[rgba(212,171,115,0.28)] bg-[linear-gradient(135deg,#f2dfc4_0%,#c89b62_100%)] px-3 text-xs font-semibold uppercase tracking-[0.16em] text-[#0f0d11]"
+            className="inline-flex min-h-11 items-center justify-center rounded-[18px] border border-[color:rgba(var(--pico-accent-rgb),0.28)] bg-[linear-gradient(135deg,var(--pico-accent-bright)_0%,var(--pico-accent)_48%,var(--pico-accent-deep)_100%)] px-3 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--pico-accent-contrast)]"
           >
             {currentItem.href === '/support' ? 'Map' : 'Help'}
           </Link>

--- a/components/pico/PicoSupportPageClient.tsx
+++ b/components/pico/PicoSupportPageClient.tsx
@@ -22,12 +22,6 @@ import { usePicoSetupState } from '@/components/pico/usePicoSetupState'
 import { usePicoHref } from '@/lib/pico/navigation'
 import { cn } from '@/lib/utils'
 
-const escalationChecklist = [
-  'Say which lesson or Autopilot section you were using.',
-  'Paste the exact command, error, or approval problem.',
-  'Say the last thing that actually worked.',
-] as const
-
 const supportLanes = [
   {
     id: 'fixing-existing',
@@ -38,6 +32,24 @@ const supportLanes = [
     id: 'other',
     title: 'Office hours or deeper walkthrough',
     body: 'Use this when the problem is bigger than one blocker and you need a guided operator session.',
+  },
+] as const
+
+const escalationStandards = [
+  {
+    label: '01 • Route',
+    title: 'Name the exact surface that broke',
+    body: 'Say whether the failure belongs to a lesson, Tutor, Autopilot, approvals, or hosted account state.',
+  },
+  {
+    label: '02 • Evidence',
+    title: 'Attach the failure, not the feeling',
+    body: 'Paste the command, error, packet, or approval state that proves where the route stopped.',
+  },
+  {
+    label: '03 • Return',
+    title: 'Ask for the route back in',
+    body: 'Great support returns you to the product with one clearer move than before.',
   },
 ] as const
 
@@ -161,7 +173,7 @@ export function PicoSupportPageClient() {
           actions.setPlatform({ helpLaneOpen: !progress.platform.helpLaneOpen })
         }
         actions={
-          <div className="flex flex-wrap gap-3">
+          <div className="grid gap-3 sm:flex sm:flex-wrap">
             <button
               type="button"
               onClick={() => openEscalation('fixing-existing')}
@@ -209,46 +221,80 @@ export function PicoSupportPageClient() {
           ]}
         />
 
+        <section className={picoPanel('p-6 sm:p-7')} data-testid="pico-support-escalation-standards">
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1.08fr),20rem]">
+            <div>
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                  <p className={picoClasses.label}>Escalation standards</p>
+                  <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)]">
+                    Hand off the problem like a sharp operator
+                  </h2>
+                </div>
+                <span className={picoClasses.chip}>route • evidence • return</span>
+              </div>
+
+              <div className="mt-6 grid gap-4 xl:grid-cols-3">
+                {escalationStandards.map((item) => (
+                  <article key={item.label} className={picoInset('flex h-full flex-col p-5')}>
+                    <p className={picoClasses.label}>{item.label}</p>
+                    <h3 className="mt-5 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                      {item.title}
+                    </h3>
+                    <p className="mt-4 text-sm leading-7 text-[color:var(--pico-text-secondary)]">
+                      {item.body}
+                    </p>
+                  </article>
+                ))}
+              </div>
+            </div>
+
+            <div className="grid gap-4">
+              <div className={picoEmber('p-5')}>
+                <p className={picoClasses.label}>Packet posture</p>
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                  Premium support starts with a clean packet. The best escalation reads like an operator handoff, not a panic dump.
+                </p>
+              </div>
+              <div className={picoInset('p-5')}>
+                <p className={picoClasses.label}>Best first move</p>
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                  Copy the packet, choose the right lane, and ask for the shortest route back into Academy, Tutor, or Autopilot.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
         <section className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr),22rem]">
           <div className={picoPanel('overflow-hidden p-0')}>
-            <div className="grid gap-0 border-b border-[#3a291d] lg:grid-cols-[minmax(0,1fr),18rem]">
+            <div className="grid gap-0 border-b border-[color:var(--pico-border)] lg:grid-cols-[minmax(0,1fr),18rem]">
               <div className="p-6 sm:p-7">
-                <p className={picoClasses.label}>Escalation board</p>
-                <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[#fff4e6] sm:text-5xl">
-                  Send context, not panic
+                <p className={picoClasses.label}>Support desk</p>
+                <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)] sm:text-5xl">
+                  Send context, not noise
                 </h2>
-                <p className="mt-4 max-w-3xl text-sm leading-7 text-[#d5c0a8] sm:text-base">
+                <p className="mt-4 max-w-3xl text-sm leading-7 text-[color:var(--pico-text-secondary)] sm:text-base">
                   Human help is for the part the product cannot truthfully close on its own. The faster you frame the blocker, the faster support can send you back to the product path.
                 </p>
 
                 <div className={picoEmber('mt-6 p-5')}>
-                  <p className="font-medium text-[#fff4e6]">
+                  <p className="font-medium text-[color:var(--pico-text)]">
                     If the next move is still obvious, go back and do it.
                   </p>
-                  <p className="mt-2 text-sm leading-6 text-[#f0deca]">
+                  <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                     Support exists for the messy edge, not for skipping the lesson, the tutor, or the live control surface.
                   </p>
-                </div>
-
-                <div className="mt-6 grid gap-4 md:grid-cols-3">
-                  {escalationChecklist.map((item, index) => (
-                    <div key={item} className={picoInset('p-5')}>
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#a8896e]">
-                        Step {String(index + 1).padStart(2, '0')}
-                      </p>
-                      <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">{item}</p>
-                    </div>
-                  ))}
                 </div>
 
                 <div className="mt-6 grid gap-4 lg:grid-cols-2">
                   {supportLanes.map((lane) => (
                     <article key={lane.id} className={picoInset('grid gap-4 p-5')}>
                       <div>
-                        <h3 className="font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+                        <h3 className="font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                           {lane.title}
                         </h3>
-                        <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">{lane.body}</p>
+                        <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">{lane.body}</p>
                       </div>
                       <button
                         type="button"
@@ -262,26 +308,26 @@ export function PicoSupportPageClient() {
                 </div>
               </div>
 
-              <div className="border-t border-[#3a291d] bg-[rgba(255,247,235,0.03)] p-6 lg:border-l lg:border-t-0">
+              <div className="border-t border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] p-6 lg:border-l lg:border-t-0">
                 <p className={picoClasses.label}>Operator rail</p>
                 <div className="mt-4 grid gap-3">
                   <div className={picoSoft('p-4')}>
-                    <p className="text-sm text-[#a8896e]">Support requests</p>
-                    <p className="mt-1 text-2xl font-semibold text-[#fff4e6]">{progress.supportRequests}</p>
+                    <p className="text-sm text-[color:var(--pico-text-muted)]">Support requests</p>
+                    <p className="mt-1 text-2xl font-semibold text-[color:var(--pico-text)]">{progress.supportRequests}</p>
                   </div>
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Tutor questions</p>
-                  <p className="mt-1 text-2xl font-semibold text-[#fff4e6]">{progress.tutorQuestions}</p>
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Tutor questions</p>
+                  <p className="mt-1 text-2xl font-semibold text-[color:var(--pico-text)]">{progress.tutorQuestions}</p>
                 </div>
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Plan</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Plan</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {session.status === 'authenticated' ? session.user.plan ?? 'unknown' : 'sign in'}
                   </p>
                 </div>
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Active surface</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Active surface</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {progress.platform.activeSurface ?? 'none'}
                   </p>
                 </div>
@@ -320,7 +366,7 @@ export function PicoSupportPageClient() {
               <div className="flex items-start justify-between gap-4">
                 <div>
                   <p className={picoClasses.label}>Diagnostic packet</p>
-                  <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+                  <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
                     Operator packet
                   </h2>
                 </div>
@@ -328,7 +374,7 @@ export function PicoSupportPageClient() {
               </div>
 
               <div className={picoSoft('mt-4 p-5')}>
-                <pre className="overflow-x-auto whitespace-pre-wrap text-sm leading-6 text-[#d5c0a8]">
+                <pre className="overflow-x-auto whitespace-pre-wrap text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   <code>{diagnosticPacket}</code>
                 </pre>
               </div>
@@ -355,40 +401,40 @@ export function PicoSupportPageClient() {
               <p className={picoClasses.label}>Live operator state</p>
               <div className="mt-4 grid gap-3">
                 <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Hosted onboarding</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Hosted onboarding</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {setup.onboarding?.status ?? 'not attached'}
                   </p>
                 </div>
                 <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Runtime status</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Runtime status</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {setup.runtime?.status ?? 'not attached'}
                   </p>
                 </div>
                 <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Current track</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Current track</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {progress.selectedTrack ?? 'not chosen yet'}
                   </p>
                 </div>
                 <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Next lesson</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Next lesson</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {derived.nextLesson?.title ?? 'none'}
                   </p>
                 </div>
                 {recoveryLesson ? (
                   <>
                     <div className={picoInset('p-4')}>
-                      <p className="text-sm text-[#a8896e]">Lesson workspace</p>
-                      <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                      <p className="text-sm text-[color:var(--pico-text-muted)]">Lesson workspace</p>
+                      <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                         {recoveryWorkspace.completedStepCount}/{recoveryLesson.steps.length}
                       </p>
                     </div>
                     <div className={picoInset('p-4')}>
-                      <p className="text-sm text-[#a8896e]">Focused step</p>
-                      <p className="mt-1 text-lg font-medium text-[#fff4e6]">{recoveryFocusedStep}</p>
+                      <p className="text-sm text-[color:var(--pico-text-muted)]">Focused step</p>
+                      <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">{recoveryFocusedStep}</p>
                     </div>
                   </>
                 ) : null}
@@ -397,121 +443,128 @@ export function PicoSupportPageClient() {
           </aside>
         </section>
 
-        <section className="grid gap-6 xl:grid-cols-[1.02fr,0.98fr]">
-          <div className={picoPanel('p-6 sm:p-7')}>
-            <p className={picoClasses.label}>What happens here</p>
-            <div className="mt-4 grid gap-4">
-              <div className={picoInset('p-5')}>
-                <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                  1. Send one clear problem
-                </p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                  Do not send a life story. Send the blocker.
-                </p>
-              </div>
-              <div className={picoInset('p-5')}>
-                <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                  2. We reply with the next move
-                </p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                  The goal is to unblock the product path, not create a support maze.
-                </p>
-              </div>
-              <div className={picoInset('p-5')}>
-                <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                  3. You go back to the product
-                </p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                  Human help exists to restore momentum, not replace the product.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div className={picoPanel('p-6 sm:p-7')}>
-            <p className={picoClasses.label}>Support model</p>
-            <div className="mt-4 grid gap-4">
-              <div className={picoSoft('p-5')}>
-                <p className="font-medium text-[#fff4e6]">Tutor first</p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                  Use tutor when the next step is probably still in the lesson corpus and you want a grounded answer fast.
-                </p>
-              </div>
-              <div className={picoSoft('p-5')}>
-                <p className="font-medium text-[#fff4e6]">Human help second</p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                  Escalate when runtime truth, approvals, security, or account state turns the situation messy.
-                </p>
-              </div>
-              <div className={picoSoft('p-5')}>
-                <p className="font-medium text-[#fff4e6]">One lane back into the product</p>
-                <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
-                  The answer should return you to the lesson or Autopilot surface with a clearer next move than before.
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section className={picoPanel('p-6 sm:p-7')}>
+        <section className={picoPanel('p-6 sm:p-7')} data-testid="pico-support-return-map">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
-              <p className={picoClasses.label}>Return routes</p>
-              <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
-                Support should send you back into the product
+              <p className={picoClasses.label}>Return map</p>
+              <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)] sm:text-4xl">
+                Human help should end in one cleaner route back into Pico
               </h2>
             </div>
             <span className={picoClasses.chip}>operator return map</span>
           </div>
 
-          <div className="mt-5 grid gap-4 lg:grid-cols-3">
-            <article className={picoInset('grid gap-4 p-5')}>
-              <div>
-                <p className={picoClasses.label}>Lesson path</p>
-                <h3 className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                  Resume the academy lane
-                </h3>
-                <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
-                  Use this when the blocker was still fundamentally a lesson or setup sequence problem.
-                </p>
-              </div>
-              <Link
-                href={derived.nextLesson ? toHref(`/academy/${derived.nextLesson.slug}`) : toHref('/academy')}
-                className={picoClasses.secondaryButton}
-              >
-                {derived.nextLesson ? `Open ${derived.nextLesson.title}` : 'Return to academy'}
-              </Link>
-            </article>
+          <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,0.92fr),minmax(0,1.08fr)]">
+            <div className="grid gap-4">
+              <article className={picoInset('grid gap-4 p-5')}>
+                <p className={picoClasses.label}>Support return model</p>
+                <div className="grid gap-3">
+                  <div className={picoSoft('p-4')}>
+                    <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                      1. Route the blocker fast
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      Do not send a life story. Lead with the exact surface that broke.
+                    </p>
+                  </div>
+                  <div className={picoSoft('p-4')}>
+                    <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                      2. Attach the evidence
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      Send the command, runtime fact, or approval state that proves what failed.
+                    </p>
+                  </div>
+                  <div className={picoSoft('p-4')}>
+                    <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                      3. Return to the product
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      The response should restore momentum, not create a support maze.
+                    </p>
+                  </div>
+                </div>
+              </article>
 
-            <article className={picoInset('grid gap-4 p-5')}>
-              <div>
-                <p className={picoClasses.label}>Grounded answer</p>
-                <h3 className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                  Ask tutor first if the next move is still knowable
-                </h3>
-                <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
-                  Go back here when the product still likely knows the answer but you need the exact next step.
-                </p>
-              </div>
-              <Link href={toHref('/tutor')} className={picoClasses.tertiaryButton}>
-                Open tutor
-              </Link>
-            </article>
+              <article className={picoInset('grid gap-4 p-5')}>
+                <div>
+                  <p className={picoClasses.label}>Packet anatomy</p>
+                  <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                    A premium escalation packet always reads in the same order: route, evidence, return lane.
+                  </p>
+                </div>
+                <div className="grid gap-3 md:grid-cols-3">
+                  <div className={picoSoft('p-4')}>
+                    <p className="font-medium text-[color:var(--pico-text)]">Route first</p>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      Name the exact surface that broke.
+                    </p>
+                  </div>
+                  <div className={picoSoft('p-4')}>
+                    <p className="font-medium text-[color:var(--pico-text)]">Evidence second</p>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      Attach the signal that proves the failure.
+                    </p>
+                  </div>
+                  <div className={picoSoft('p-4')}>
+                    <p className="font-medium text-[color:var(--pico-text)]">Return third</p>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      Ask for the cleanest way back into motion.
+                    </p>
+                  </div>
+                </div>
+              </article>
+            </div>
 
-            <article className={picoInset('grid gap-4 p-5')}>
-              <div>
-                <p className={picoClasses.label}>Runtime truth</p>
-                <h3 className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
-                  Re-enter the control room
-                </h3>
-                <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
-                  Use Autopilot when the blocker depends on live runs, budget, approvals, or alert state.
-                </p>
-              </div>
-              <Link href={toHref('/autopilot')} className={picoClasses.tertiaryButton}>
-                Open Autopilot
-              </Link>
-            </article>
+            <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-1">
+              <article className={picoInset('grid gap-4 p-5')}>
+                <div>
+                  <p className={picoClasses.label}>Lesson path</p>
+                  <h3 className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                    Resume the academy lane
+                  </h3>
+                  <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                    Use this when the blocker was still fundamentally a lesson or setup sequence problem.
+                  </p>
+                </div>
+                <Link
+                  href={derived.nextLesson ? toHref(`/academy/${derived.nextLesson.slug}`) : toHref('/academy')}
+                  className={picoClasses.secondaryButton}
+                >
+                  {derived.nextLesson ? `Open ${derived.nextLesson.title}` : 'Return to academy'}
+                </Link>
+              </article>
+
+              <article className={picoInset('grid gap-4 p-5')}>
+                <div>
+                  <p className={picoClasses.label}>Grounded answer</p>
+                  <h3 className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                    Ask tutor if the next move is still knowable
+                  </h3>
+                  <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                    Go back here when the product likely still knows the answer but you need the exact next step.
+                  </p>
+                </div>
+                <Link href={toHref('/tutor')} className={picoClasses.tertiaryButton}>
+                  Open tutor
+                </Link>
+              </article>
+
+              <article className={picoInset('grid gap-4 p-5')}>
+                <div>
+                  <p className={picoClasses.label}>Runtime truth</p>
+                  <h3 className="mt-3 font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                    Re-enter the control room
+                  </h3>
+                  <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                    Use Autopilot when the blocker depends on live runs, budget, approvals, or alert state.
+                  </p>
+                </div>
+                <Link href={toHref('/autopilot')} className={picoClasses.tertiaryButton}>
+                  Open Autopilot
+                </Link>
+              </article>
+            </div>
           </div>
         </section>
       </PicoShell>

--- a/components/pico/PicoSurfaceCompass.tsx
+++ b/components/pico/PicoSurfaceCompass.tsx
@@ -23,14 +23,14 @@ type PicoSurfaceCompassProps = {
 
 function itemClasses(tone: PicoSurfaceCompassTone = 'secondary') {
   if (tone === 'primary') {
-    return picoEmber('group grid gap-3 p-5 transition hover:border-[#e2904f] hover:bg-[linear-gradient(180deg,rgba(117,64,33,0.28),rgba(45,27,16,0.32))]')
+    return picoEmber('group grid gap-3 p-5 transition hover:border-[color:var(--pico-accent)] hover:bg-[linear-gradient(180deg,rgba(117,64,33,0.28),rgba(45,27,16,0.32))]')
   }
 
   if (tone === 'soft') {
-    return picoSoft('group grid gap-3 p-5 transition hover:border-[#7d5232] hover:bg-[rgba(22,16,12,0.86)]')
+    return picoSoft('group grid gap-3 p-5 transition hover:border-[color:var(--pico-border-hover)] hover:bg-[rgba(22,16,12,0.86)]')
   }
 
-  return picoInset('group grid gap-3 p-5 transition hover:border-[#7d5232] hover:bg-[rgba(255,247,235,0.06)]')
+  return picoInset('group grid gap-3 p-5 transition hover:border-[color:var(--pico-border-hover)] hover:bg-[color:var(--pico-bg-surface-hover)]')
 }
 
 export function PicoSurfaceCompass({
@@ -40,6 +40,13 @@ export function PicoSurfaceCompass({
   items,
   aside,
 }: PicoSurfaceCompassProps) {
+  const itemGridClass = cn(
+    'mt-5 grid grid-flow-col auto-cols-[minmax(16rem,84vw)] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory md:grid-flow-row md:auto-cols-auto md:overflow-visible',
+    items.length === 2 && 'md:grid-cols-2',
+    items.length === 3 && 'md:grid-cols-3',
+    items.length >= 4 && 'md:grid-cols-2 2xl:grid-cols-4',
+  )
+
   return (
     <section className={picoPanel('p-5 sm:p-6')} data-testid="pico-surface-compass">
       <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr),22rem] lg:items-start">
@@ -48,10 +55,10 @@ export function PicoSurfaceCompass({
             <span className={picoClasses.label}>Surface compass</span>
             {status ? <span className={picoClasses.chip}>{status}</span> : null}
           </div>
-          <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6] sm:text-4xl">
+          <h2 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)] sm:text-4xl">
             {title}
           </h2>
-          <p className="mt-3 max-w-3xl text-sm leading-6 text-[#d5c0a8] sm:text-base sm:leading-7">
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-[color:var(--pico-text-secondary)] sm:text-base sm:leading-7">
             {body}
           </p>
         </div>
@@ -59,33 +66,30 @@ export function PicoSurfaceCompass({
         {aside ? (
           <div className={picoSoft('p-4 sm:p-5')}>
             <p className={picoClasses.label}>Operating rule</p>
-            <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">{aside}</p>
+            <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">{aside}</p>
           </div>
         ) : null}
       </div>
 
-      <div
-        className={cn(
-          'mt-5 grid gap-4',
-          items.length === 2 && 'md:grid-cols-2',
-          items.length === 3 && 'md:grid-cols-3',
-          items.length >= 4 && 'md:grid-cols-2 2xl:grid-cols-4',
-        )}
-      >
+      <div className={itemGridClass}>
         {items.map((item) => (
-          <Link key={`${item.href}-${item.label}`} href={item.href} className={itemClasses(item.tone)}>
+          <Link
+            key={`${item.href}-${item.label}`}
+            href={item.href}
+            className={cn(itemClasses(item.tone), 'snap-start')}
+          >
             <div className="flex items-start justify-between gap-3">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#b69067]">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--pico-text-muted)]">
                 {item.note}
               </span>
-              <span className="text-sm text-[#f0bb83] transition group-hover:translate-x-0.5">
+              <span className="text-sm text-[color:var(--pico-accent)] transition group-hover:translate-x-0.5">
                 →
               </span>
             </div>
-            <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[#fff4e6]">
+            <p className="font-[family:var(--font-site-display)] text-2xl tracking-[-0.05em] text-[color:var(--pico-text)]">
               {item.label}
             </p>
-            <p className="text-sm leading-6 text-[#d5c0a8]">{item.caption}</p>
+            <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">{item.caption}</p>
           </Link>
         ))}
       </div>

--- a/components/pico/PicoTutorPageClient.tsx
+++ b/components/pico/PicoTutorPageClient.tsx
@@ -164,6 +164,41 @@ export function PicoTutorPageClient() {
       ? (lessonSlug, workspace) => actions.setLessonWorkspace(lessonSlug, workspace)
       : undefined,
   })
+  const tutorMethod = [
+    {
+      label: '01 • Frame',
+      title: 'Bring one blocked step',
+      body: selectedLesson
+        ? `Tie the question to ${selectedLesson.title}. The desk works best when the lesson route is already attached.`
+        : 'Name the exact step, command, or approval state that broke. Broad anxiety is not enough.',
+    },
+    {
+      label: '02 • Evidence',
+      title: 'Bring what actually happened',
+      body: 'Paste the command, transcript, error, or runtime signal. This desk reviews evidence, not vibes.',
+    },
+    {
+      label: '03 • Exit',
+      title: 'Leave with one move',
+      body: 'A good tutor answer gives one next action, one verification line, and a clean handoff if the evidence stays thin.',
+    },
+  ]
+  const lessonReviewBoard = selectedLesson
+    ? [
+        {
+          label: 'Lesson brief',
+          value: selectedLesson.objective,
+        },
+        {
+          label: 'Deliverable',
+          value: selectedLesson.expectedResult,
+        },
+        {
+          label: 'Critique line',
+          value: selectedLesson.validation,
+        },
+      ]
+    : []
 
   useEffect(() => {
     setLessonSlug(defaultLessonSlug)
@@ -389,7 +424,7 @@ export function PicoTutorPageClient() {
         actions.setPlatform({ helpLaneOpen: !progress.platform.helpLaneOpen })
       }
       actions={
-        <div className="flex flex-wrap gap-3">
+        <div className="grid gap-3 sm:flex sm:flex-wrap">
           <Link
             href={selectedLesson ? toHref(`/academy/${selectedLesson.slug}`) : toHref('/academy')}
             className={picoClasses.secondaryButton}
@@ -446,18 +481,65 @@ export function PicoTutorPageClient() {
         ]}
       />
 
+      <section className={picoPanel('p-6 sm:p-7')} data-testid="pico-tutor-crit-desk">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.08fr),20rem]">
+          <div>
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className={picoClasses.label}>Crit desk method</p>
+                <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)]">
+                  Treat each question like a studio critique
+                </h2>
+              </div>
+              <span className={picoClasses.chip}>frame • evidence • exit</span>
+            </div>
+
+            <div className="mt-6 grid gap-4 xl:grid-cols-3">
+              {tutorMethod.map((item) => (
+                <article key={item.label} className={picoInset('flex h-full flex-col p-5')}>
+                  <p className={picoClasses.label}>{item.label}</p>
+                  <h3 className="mt-5 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
+                    {item.title}
+                  </h3>
+                  <p className="mt-4 text-sm leading-7 text-[color:var(--pico-text-secondary)]">
+                    {item.body}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-4">
+            <div className={picoEmber('p-5')}>
+              <p className={picoClasses.label}>Desk posture</p>
+              <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                The premium version of this page is not a friendly chatbot. It is a sharp review desk that narrows ambiguity into one next move.
+              </p>
+            </div>
+            <div className={picoInset('p-5')}>
+              <p className={picoClasses.label}>Attached lane</p>
+              <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                {selectedLesson
+                  ? `${selectedLesson.title} is attached, so the tutor can answer against the real lesson brief instead of guessing.`
+                  : 'No lesson is attached yet. Connect the blocked lesson if you want the tutor to stay grounded in the actual route.'}
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr),22rem]">
         <div className={picoPanel('overflow-hidden p-0')}>
-          <div className="grid gap-0 border-b border-[#3a291d] lg:grid-cols-[minmax(0,1fr),18rem]">
+          <div className="grid gap-0 border-b border-[color:var(--pico-border)] lg:grid-cols-[minmax(0,1fr),18rem]">
             <form onSubmit={submit} className="p-6 sm:p-7">
-              <p className={picoClasses.label}>Question desk</p>
-              <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[#fff4e6] sm:text-5xl">
-                Ground the next move before you escalate
+              <p className={picoClasses.label}>Crit desk</p>
+              <h2 className="mt-3 font-[family:var(--font-site-display)] text-4xl tracking-[-0.06em] text-[color:var(--pico-text)] sm:text-5xl">
+                Bring one blocker to the desk
               </h2>
-              <p className="mt-4 max-w-3xl text-sm leading-7 text-[#d5c0a8] sm:text-base">
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-[color:var(--pico-text-secondary)] sm:text-base">
                 Ask only when the lesson path is blocked. The answer should send you back into action, not into another loop of reading.
               </p>
-              <p className="mt-3 text-xs uppercase tracking-[0.18em] text-[#a8896e]">
+              <p className="mt-3 text-xs uppercase tracking-[0.18em] text-[color:var(--pico-text-muted)]">
                 {session.status === 'authenticated'
                   ? 'Hosted identity and runtime context attached'
                   : 'Read-only tutor mode. Hosted session context is missing until you sign in.'}
@@ -465,20 +547,30 @@ export function PicoTutorPageClient() {
 
               {selectedLesson ? (
                 <div className={picoEmber('mt-6 p-5')}>
-                  <p className="font-medium text-[#fff4e6]">Where you are</p>
+                  <p className="font-medium text-[color:var(--pico-text)]">Where you are</p>
                   <p className="mt-2 text-sm leading-6">
                     You are asking about {selectedLesson.title}. Keep the question tied to the step that is actually blocked.
                   </p>
+                  <div className="mt-4 grid gap-3 xl:grid-cols-5">
+                    {lessonReviewBoard.map((item) => (
+                      <div key={item.label} className={picoInset('p-4')}>
+                        <p className={picoClasses.label}>{item.label}</p>
+                        <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                          {item.value}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
                   <div className="mt-4 grid gap-3 sm:grid-cols-2">
                     <div className={picoInset('p-4')}>
-                      <p className="text-sm text-[#d6b695]">Lesson steps</p>
-                      <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                      <p className="text-sm text-[color:var(--pico-text-muted)]">Lesson steps</p>
+                      <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                         {lessonWorkspace.completedStepCount}/{selectedLesson.steps.length}
                       </p>
                     </div>
                     <div className={picoInset('p-4')}>
-                      <p className="text-sm text-[#d6b695]">Focused step</p>
-                      <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                      <p className="text-sm text-[color:var(--pico-text-muted)]">Focused step</p>
+                      <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                         {lessonWorkspace.workspace.activeStepIndex >= 0
                           ? selectedLesson.steps[lessonWorkspace.workspace.activeStepIndex]?.title ?? 'not set'
                           : 'not set'}
@@ -487,49 +579,60 @@ export function PicoTutorPageClient() {
                   </div>
                   <Link
                     href={toHref(`/academy/${selectedLesson.slug}`)}
-                    className="mt-4 inline-flex text-sm font-medium text-[#fff4e6] underline decoration-[#e2904f]/40 underline-offset-4"
+                    className="mt-4 inline-flex text-sm font-medium text-[color:var(--pico-text)] underline decoration-[color:rgba(var(--pico-accent-rgb),0.38)] underline-offset-4"
                   >
                     Back to lesson
                   </Link>
                 </div>
               ) : null}
 
-              <div className="mt-6 grid gap-4 md:grid-cols-2">
-                <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Current track</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                    {progress.selectedTrack ?? 'not chosen yet'}
-                  </p>
+              <div className={picoInset('mt-6 grid gap-4 p-5')}>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className={picoClasses.label}>Crit packet</p>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
+                      Bring just enough context for a sharp answer: route, failure, and exact expectation.
+                    </p>
+                  </div>
+                  <span className={picoClasses.chip}>route • failure • expectation</span>
                 </div>
-                <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Next lesson</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                    {derived.nextLesson?.title ?? 'none'}
-                  </p>
-                </div>
-                <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Hosted onboarding step</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                    {setup.onboarding?.current_step ?? 'session required'}
-                  </p>
-                </div>
-                <div className={picoInset('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Runtime status</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
-                    {setup.runtime?.status ?? 'not synced'}
-                  </p>
-                </div>
-              </div>
 
-              <div className={picoInset('mt-6 p-5')}>
-                <p className={picoClasses.label}>Question protocol</p>
-                <div className="mt-4 grid gap-3 md:grid-cols-3">
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                  <div className={picoSoft('p-4')}>
+                    <p className="text-sm text-[color:var(--pico-text-muted)]">Current track</p>
+                    <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                      {progress.selectedTrack ?? 'not chosen yet'}
+                    </p>
+                  </div>
+                  <div className={picoSoft('p-4')}>
+                    <p className="text-sm text-[color:var(--pico-text-muted)]">Next lesson</p>
+                    <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                      {derived.nextLesson?.title ?? 'none'}
+                    </p>
+                  </div>
+                  <div className={picoSoft('p-4')}>
+                    <p className="text-sm text-[color:var(--pico-text-muted)]">Hosted onboarding step</p>
+                    <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                      {setup.onboarding?.current_step ?? 'session required'}
+                    </p>
+                  </div>
+                  <div className={picoSoft('p-4')}>
+                    <p className="text-sm text-[color:var(--pico-text-muted)]">Runtime status</p>
+                    <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
+                      {setup.runtime?.status ?? 'not synced'}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 lg:grid-cols-3">
                   {questionProtocol.map((item, index) => (
                     <div key={item} className={picoSoft('p-4')}>
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#a8896e]">
-                        {String(index + 1).padStart(2, '0')}
-                      </p>
-                      <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">{item}</p>
+                      <div className="flex items-start gap-3">
+                        <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-[color:var(--pico-border)] bg-[rgba(var(--pico-accent-rgb),0.12)] text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-accent)]">
+                          {String(index + 1).padStart(2, '0')}
+                        </span>
+                        <p className="pt-1 text-sm leading-6 text-[color:var(--pico-text-secondary)]">{item}</p>
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -539,16 +642,16 @@ export function PicoTutorPageClient() {
                 value={question}
                 onChange={(event) => setQuestion(event.target.value)}
                 placeholder="Describe the blocker, the exact step, and what you expected to happen."
-                className="mt-6 min-h-[240px] w-full rounded-[28px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-5 py-5 text-sm leading-7 text-[#f6e7d4] outline-none placeholder:text-[#8f7157]"
+                className="mt-6 min-h-[240px] w-full rounded-[28px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-5 py-5 text-sm leading-7 text-[color:var(--pico-text-secondary)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
               />
 
               <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr),auto] lg:items-end">
-                <label className="block text-sm text-[#d5c0a8]">
+                <label className="block text-sm text-[color:var(--pico-text-secondary)]">
                   <span className={picoClasses.label}>Blocked lesson</span>
                   <select
                     value={lessonSlug}
                     onChange={(event) => setLessonSlug(event.target.value)}
-                    className="mt-3 w-full rounded-[22px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-3 text-sm text-[#f6e7d4] outline-none"
+                    className="mt-3 w-full rounded-[22px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-sm text-[color:var(--pico-text-secondary)] outline-none"
                   >
                     <option value="">No lesson selected</option>
                     {availableLessons.map((lesson) => (
@@ -563,7 +666,7 @@ export function PicoTutorPageClient() {
                 </button>
               </div>
 
-              <div className="mt-5 flex flex-wrap gap-2">
+              <div className="mt-5 grid gap-2 sm:flex sm:flex-wrap">
                 {examplePrompts.map((prompt) => (
                   <button
                     key={prompt}
@@ -577,16 +680,16 @@ export function PicoTutorPageClient() {
               </div>
             </form>
 
-            <div className="border-t border-[#3a291d] bg-[rgba(255,247,235,0.03)] p-6 lg:border-l lg:border-t-0">
+            <div className="border-t border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] p-6 lg:border-l lg:border-t-0">
               <p className={picoClasses.label}>Operator rail</p>
               <div className="mt-4 grid gap-3">
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Questions asked</p>
-                  <p className="mt-1 text-2xl font-semibold text-[#fff4e6]">{progress.tutorQuestions}</p>
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Questions asked</p>
+                  <p className="mt-1 text-2xl font-semibold text-[color:var(--pico-text)]">{progress.tutorQuestions}</p>
                 </div>
                 <div className={picoSoft('p-4')}>
-                  <p className="text-sm text-[#a8896e]">Live answer state</p>
-                  <p className="mt-1 text-lg font-medium text-[#fff4e6]">
+                  <p className="text-sm text-[color:var(--pico-text-muted)]">Live answer state</p>
+                  <p className="mt-1 text-lg font-medium text-[color:var(--pico-text)]">
                     {reply ? reply.confidence : loading ? 'thinking' : 'waiting'}
                   </p>
                 </div>
@@ -616,9 +719,9 @@ export function PicoTutorPageClient() {
               <div className={picoInset('mt-4 p-4')}>
                 <div data-testid="pico-openai-connect-panel">
                   <p className={picoClasses.label}>OpenAI connection</p>
-                  <div className="mt-3 rounded-[18px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] p-4">
+                  <div className="mt-3 rounded-[18px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] p-4">
                     <p
-                      className="text-sm leading-6 text-[#d5c0a8]"
+                      className="text-sm leading-6 text-[color:var(--pico-text-secondary)]"
                       data-testid="pico-openai-connect-status"
                     >
                       {session.status !== 'authenticated'
@@ -632,10 +735,10 @@ export function PicoTutorPageClient() {
                       <div className="mt-4 grid gap-3">
                         {openAIConnection?.status === 'connected' ? (
                           <div className={picoSoft('p-4')}>
-                            <p className="font-medium text-[#fff4e6]">
+                            <p className="font-medium text-[color:var(--pico-text)]">
                               Connected {openAIConnection.maskedKey ? `as ${openAIConnection.maskedKey}` : 'key'}
                             </p>
-                            <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">
+                            <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                               Live Tutor answers now prefer your own OpenAI access before any platform fallback.
                             </p>
                             <div className="mt-3 flex flex-wrap gap-2">
@@ -653,14 +756,14 @@ export function PicoTutorPageClient() {
                           </div>
                         ) : (
                           <>
-                            <label className="block text-sm text-[#d5c0a8]">
+                            <label className="block text-sm text-[color:var(--pico-text-secondary)]">
                               <span className={picoClasses.label}>Bring your own OpenAI key</span>
                               <input
                                 type="password"
                                 value={openAIApiKey}
                                 onChange={(event) => setOpenAIApiKey(event.target.value)}
                                 placeholder="sk-proj-..."
-                                className="mt-3 w-full rounded-[18px] border border-[#4a3423] bg-[rgba(255,247,235,0.03)] px-4 py-3 text-sm text-[#f6e7d4] outline-none placeholder:text-[#8f7157]"
+                                className="mt-3 w-full rounded-[18px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-sm text-[color:var(--pico-text-secondary)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
                               />
                             </label>
                             <button
@@ -674,7 +777,7 @@ export function PicoTutorPageClient() {
                           </>
                         )}
                         {openAIConnection?.status === 'platform' ? (
-                          <p className="text-xs leading-6 text-[#a8896e]">
+                          <p className="text-xs leading-6 text-[color:var(--pico-text-muted)]">
                             Platform access is already available. Connecting your own key simply overrides the Tutor model budget and ownership path for this account.
                           </p>
                         ) : null}
@@ -689,7 +792,7 @@ export function PicoTutorPageClient() {
 
               <div className={picoInset('mt-4 p-4')}>
                 <p className={picoClasses.label}>Escalation rule</p>
-                <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">
+                <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   If the answer still does not give you one concrete move, stop looping and open support with the lesson context attached.
                 </p>
                 <Link href={toHref('/support')} className={cn(picoClasses.secondaryButton, 'mt-4')}>
@@ -702,7 +805,7 @@ export function PicoTutorPageClient() {
 
         <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start">
           <section className={picoPanel('p-5')}>
-            <p className={picoClasses.label}>Answer</p>
+            <p className={picoClasses.label}>Studio critique</p>
             {error ? (
               <div className="mt-4 rounded-[24px] border border-rose-400/20 bg-rose-400/10 p-5 text-sm leading-6 text-rose-50">
                 {error}
@@ -720,24 +823,30 @@ export function PicoTutorPageClient() {
                     {reply.usedOfficialFallback ? <span className={picoClasses.chip}>official fallback</span> : null}
                     {reply.escalate ? <span className={picoClasses.chip}>human escalation likely</span> : null}
                   </div>
+                  <div className={picoInset('mt-4 p-4')}>
+                    <p className={picoClasses.label}>Single next move</p>
+                    <p className="mt-3 font-[family:var(--font-site-display)] text-2xl leading-8 tracking-[-0.05em] text-[color:var(--pico-text)]">
+                      {reply.structured.steps[0] ?? reply.title}
+                    </p>
+                  </div>
                   <div className="mt-4 grid gap-4">
                     <div>
                       <p className={picoClasses.label}>Situation</p>
-                      <p className="mt-2 text-sm leading-7 text-[#f0deca]">{reply.structured.situation}</p>
+                      <p className="mt-2 text-sm leading-7 text-[color:var(--pico-text-secondary)]">{reply.structured.situation}</p>
                     </div>
                     <div>
                       <p className={picoClasses.label}>Diagnosis</p>
-                      <p className="mt-2 text-sm leading-7 text-[#f0deca]">{reply.structured.diagnosis}</p>
+                      <p className="mt-2 text-sm leading-7 text-[color:var(--pico-text-secondary)]">{reply.structured.diagnosis}</p>
                     </div>
                   </div>
                 </div>
 
                 <div className={picoSoft('p-5')}>
-                  <p className="font-medium text-[#fff4e6]">Steps</p>
+                  <p className="font-medium text-[color:var(--pico-text)]">Steps</p>
                   <div className="mt-3 grid gap-3">
                     {reply.structured.steps.map((item, index) => (
-                      <div key={item} className={picoInset('px-4 py-3 text-sm leading-6 text-[#d5c0a8]')}>
-                        <span className="mr-3 text-[#f0bb83]">{String(index + 1).padStart(2, '0')}</span>
+                      <div key={item} className={picoInset('px-4 py-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]')}>
+                        <span className="mr-3 text-[color:var(--pico-accent)]">{String(index + 1).padStart(2, '0')}</span>
                         {item}
                       </div>
                     ))}
@@ -746,18 +855,18 @@ export function PicoTutorPageClient() {
 
                 {reply.structured.commands.length ? (
                   <div className={picoSoft('p-5')}>
-                    <p className="font-medium text-[#fff4e6]">Commands</p>
+                    <p className="font-medium text-[color:var(--pico-text)]">Operator commands</p>
                     <div className="mt-3 grid gap-3">
                       {reply.structured.commands.map((command) => (
                         <div key={`${command.label}-${command.code}`} className={picoInset('p-4')}>
-                          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#a8896e]">
+                          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-text-muted)]">
                             {command.label}
                           </p>
-                          <pre className="mt-3 overflow-x-auto rounded-[18px] border border-[#4a3423] bg-[#1f140d] p-4 text-xs leading-6 text-[#f6e7d4]">
+                          <pre className="mt-3 overflow-x-auto rounded-[18px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-input)] p-4 text-xs leading-6 text-[color:var(--pico-text-secondary)]">
                             <code>{command.code}</code>
                           </pre>
                           {command.note ? (
-                            <p className="mt-3 text-sm leading-6 text-[#d5c0a8]">{command.note}</p>
+                            <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">{command.note}</p>
                           ) : null}
                         </div>
                       ))}
@@ -767,10 +876,10 @@ export function PicoTutorPageClient() {
 
                 {reply.structured.verify.length ? (
                   <div className={picoSoft('p-5')}>
-                    <p className="font-medium text-[#fff4e6]">Verify</p>
+                    <p className="font-medium text-[color:var(--pico-text)]">Review line</p>
                     <div className="mt-3 grid gap-3">
                       {reply.structured.verify.map((item) => (
-                        <div key={item} className={picoInset('px-4 py-3 text-sm leading-6 text-[#d5c0a8]')}>
+                        <div key={item} className={picoInset('px-4 py-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]')}>
                           {item}
                         </div>
                       ))}
@@ -780,10 +889,10 @@ export function PicoTutorPageClient() {
 
                 {reply.structured.ifThisFails.length ? (
                   <div className={picoSoft('p-5')}>
-                    <p className="font-medium text-[#fff4e6]">If this fails</p>
+                    <p className="font-medium text-[color:var(--pico-text)]">Fallback route</p>
                     <div className="mt-3 grid gap-3">
                       {reply.structured.ifThisFails.map((item) => (
-                        <div key={item} className={picoInset('px-4 py-3 text-sm leading-6 text-[#d5c0a8]')}>
+                        <div key={item} className={picoInset('px-4 py-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]')}>
                           {item}
                         </div>
                       ))}
@@ -796,7 +905,7 @@ export function PicoTutorPageClient() {
                 <p className={picoClasses.body}>
                   Ask one blocker, not a whole story. Pico Tutor will ground the answer in lessons, the curated operator pack, and official docs when the question is version-sensitive.
                 </p>
-                <p className="mt-4 text-sm leading-6 text-[#d5c0a8]">
+                <p className="mt-4 text-sm leading-6 text-[color:var(--pico-text-secondary)]">
                   How this works: state the failing step, the expected result, and the exact failure. The answer should give you a concrete move, one verification step, and a clean escalation path if the evidence is still thin.
                 </p>
               </div>
@@ -813,7 +922,7 @@ export function PicoTutorPageClient() {
                     href={resolveTutorHref(toHref, lesson.href)}
                     className={cn(
                       picoInset('flex items-center justify-between gap-4 px-4 py-3 text-sm text-[#f2e0cb]'),
-                      index === 0 && 'border-[#7d5232] bg-[rgba(226,144,79,0.08)]',
+                      index === 0 && 'border-[color:var(--pico-border-hover)] bg-[rgba(var(--pico-accent-rgb),0.08)]',
                     )}
                   >
                     <span>{lesson.title}</span>
@@ -826,7 +935,7 @@ export function PicoTutorPageClient() {
 
           {reply?.structured.sources.length ? (
             <section className={picoPanel('p-5')}>
-              <p className={picoClasses.label}>Evidence rail</p>
+              <p className={picoClasses.label}>Critique evidence</p>
               <div className="mt-4 grid gap-3">
                 {reply.structured.sources.map((source) => (
                   <div
@@ -835,18 +944,18 @@ export function PicoTutorPageClient() {
                   >
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <span>{source.title}</span>
-                      <span className="text-xs uppercase tracking-[0.18em] text-[#a8896e]">
+                      <span className="text-xs uppercase tracking-[0.18em] text-[color:var(--pico-text-muted)]">
                         {source.kind.replace('_', ' ')}
                       </span>
                     </div>
                     <p className="mt-2 text-xs leading-6 text-[#bfa58c]">{source.sourcePath}</p>
                     {source.excerpt ? (
-                      <p className="mt-2 text-sm leading-6 text-[#d5c0a8]">{source.excerpt}</p>
+                      <p className="mt-2 text-sm leading-6 text-[color:var(--pico-text-secondary)]">{source.excerpt}</p>
                     ) : null}
                     {source.href ? (
                       <Link
                         href={resolveTutorHref(toHref, source.href)}
-                        className="mt-3 inline-flex text-sm font-medium text-[#fff4e6] underline decoration-[#e2904f]/40 underline-offset-4"
+                        className="mt-3 inline-flex text-sm font-medium text-[color:var(--pico-text)] underline decoration-[color:rgba(var(--pico-accent-rgb),0.38)] underline-offset-4"
                       >
                         Open source
                       </Link>
@@ -871,7 +980,7 @@ export function PicoTutorPageClient() {
                     )}
                   >
                     <span>{doc.label}</span>
-                    <span className="text-xs uppercase tracking-[0.18em] text-[#a8896e]">
+                    <span className="text-xs uppercase tracking-[0.18em] text-[color:var(--pico-text-muted)]">
                       {doc.sourcePath}
                     </span>
                   </Link>
@@ -881,7 +990,7 @@ export function PicoTutorPageClient() {
           ) : null}
 
           <section className={picoPanel('p-5')}>
-            <p className={picoClasses.label}>Route correction</p>
+            <p className={picoClasses.label}>Exit route</p>
             <div className="mt-4 grid gap-3">
               <Link
                 href={
@@ -929,7 +1038,7 @@ export function PicoTutorPageClient() {
 
           {reply?.structured.nextQuestion ? (
             <section className={picoPanel('p-5')}>
-              <p className={picoClasses.label}>Next question</p>
+              <p className={picoClasses.label}>If the answer is still fuzzy</p>
               <div className={picoSoft('mt-4 p-4')}>
                 <p className={picoClasses.body}>{reply.structured.nextQuestion}</p>
               </div>

--- a/components/pico/PicoWelcomeTour.tsx
+++ b/components/pico/PicoWelcomeTour.tsx
@@ -154,11 +154,11 @@ export function PicoWelcomeTour({
       data-testid="pico-welcome-tour"
     >
       <section className={picoCodexFrame('pointer-events-auto flex max-h-full w-full max-w-[26rem] flex-col overflow-hidden p-0')}>
-        <div className="border-b border-[#5d412d] px-5 py-4 sm:px-6">
+        <div className="border-b border-[color:var(--pico-border)] px-5 py-4 sm:px-6">
           <div className="flex items-start justify-between gap-4">
             <div>
               <p className={picoClasses.label}>Quick help</p>
-              <h2 className="mt-2 font-[family:var(--font-site-display)] text-3xl tracking-[-0.06em] text-[#fff4e6]">
+              <h2 className="mt-2 font-[family:var(--font-site-display)] text-3xl tracking-[-0.06em] text-[color:var(--pico-text)]">
                 Learn the codex once, then close it.
               </h2>
             </div>
@@ -176,17 +176,17 @@ export function PicoWelcomeTour({
         <div className="grid min-h-0 gap-5 overflow-y-auto px-5 py-5 sm:px-6 sm:py-6">
           <div className={picoCodexNote('p-4')}>
             <p className={picoClasses.label}>{step.eyebrow}</p>
-            <h3 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[#fff4e6]">
+            <h3 className="mt-3 font-[family:var(--font-site-display)] text-3xl tracking-[-0.05em] text-[color:var(--pico-text)]">
               {step.title}
             </h3>
-            <p className="mt-3 text-sm leading-6 text-[#f0deca]">{step.body}</p>
+            <p className="mt-3 text-sm leading-6 text-[color:var(--pico-text-secondary)]">{step.body}</p>
           </div>
 
           <div className="grid gap-3">
             {step.bullets.map((bullet) => (
               <div key={bullet} className={picoCodexInset('grid grid-cols-[0.8rem,1fr] items-start gap-3 px-4 py-4')}>
-                <span className="mt-1.5 h-2.5 w-2.5 rounded-full bg-[#e2904f]" />
-                <p className="text-sm leading-6 text-[#d5c0a8]">{bullet}</p>
+                <span className="mt-1.5 h-2.5 w-2.5 rounded-full bg-[color:var(--pico-accent)]" />
+                <p className="text-sm leading-6 text-[color:var(--pico-text-secondary)]">{bullet}</p>
               </div>
             ))}
           </div>
@@ -198,7 +198,9 @@ export function PicoWelcomeTour({
                   key={tourStep.eyebrow}
                   className={cn(
                     'h-2.5 rounded-full transition',
-                    stepIndex === index ? 'w-7 bg-[#e2904f]' : 'w-2.5 bg-[#5a3f2a]',
+                    stepIndex === index
+                      ? 'w-7 bg-[color:var(--pico-accent)]'
+                      : 'w-2.5 bg-[color:var(--pico-border)]',
                   )}
                 />
               ))}

--- a/components/pico/picoTheme.ts
+++ b/components/pico/picoTheme.ts
@@ -1,57 +1,61 @@
 import { cn } from '@/lib/utils'
 
 export const picoClasses = {
-  label: 'text-[11px] font-semibold uppercase tracking-[0.26em] text-[#b9976d]',
-  body: 'text-sm leading-6 text-[#d7c9b6]',
-  subdued: 'text-sm leading-6 text-[#bca990]',
-  title: 'font-[family:var(--font-site-display)] tracking-[-0.05em] text-[#fff4e6]',
+  label:
+    'text-[11px] font-semibold uppercase tracking-[0.26em] text-[color:var(--pico-text-muted)]',
+  body: 'text-sm leading-6 text-[color:var(--pico-text-secondary)]',
+  subdued: 'text-sm leading-6 text-[color:var(--pico-text-muted)]',
+  title:
+    'font-[family:var(--font-site-display)] tracking-[-0.05em] text-[color:var(--pico-text)]',
   panel:
-    'rounded-[30px] border border-[rgba(255,233,204,0.12)] bg-[radial-gradient(circle_at_top_right,rgba(212,171,115,0.1),transparent_24%),linear-gradient(180deg,rgba(24,22,29,0.96),rgba(10,10,13,0.98))] shadow-[0_28px_90px_rgba(2,2,5,0.34)]',
+    'rounded-[30px] border border-[color:var(--pico-border)] bg-[linear-gradient(180deg,rgba(9,17,11,0.94),rgba(4,9,6,0.98))] shadow-[var(--pico-shadow-panel)] backdrop-blur-xl',
   inset:
-    'rounded-[24px] border border-[rgba(255,233,204,0.1)] bg-[rgba(255,248,236,0.04)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]',
+    'rounded-[24px] border border-[color:var(--pico-border)] bg-[linear-gradient(180deg,rgba(255,255,255,0.02),rgba(255,255,255,0.008))] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]',
   soft:
-    'rounded-[24px] border border-[rgba(255,233,204,0.08)] bg-[rgba(14,13,18,0.78)] shadow-[0_18px_44px_rgba(2,2,5,0.24)]',
+    'rounded-[24px] border border-[color:rgba(255,255,255,0.05)] bg-[rgba(6,11,8,0.74)] shadow-[0_18px_44px_rgba(0,0,0,0.24)] backdrop-blur-xl',
   ember:
-    'rounded-[24px] border border-[rgba(212,171,115,0.26)] bg-[linear-gradient(180deg,rgba(212,171,115,0.16),rgba(41,32,25,0.28))] text-[#f4dfc6]',
+    'rounded-[24px] border border-[color:var(--pico-border-hover)] bg-[linear-gradient(180deg,rgba(var(--pico-accent-rgb),0.18),rgba(10,19,11,0.3))] text-[color:var(--pico-text)] shadow-[0_22px_60px_rgba(var(--pico-accent-rgb),0.08)]',
   primaryButton:
-    'inline-flex items-center justify-center gap-2 rounded-full border border-[rgba(212,171,115,0.28)] bg-[linear-gradient(135deg,#f2dfc4_0%,#c89b62_100%)] px-5 py-3 text-sm font-semibold text-[#0f0d11] transition hover:translate-y-[-1px] hover:bg-[linear-gradient(135deg,#f6e5ca_0%,#d2a469_100%)]',
+    'inline-flex w-full max-w-full items-center justify-center gap-2 rounded-full border border-[color:rgba(var(--pico-accent-rgb),0.28)] bg-[linear-gradient(135deg,var(--pico-accent-bright)_0%,var(--pico-accent)_42%,var(--pico-accent-deep)_100%)] px-5 py-3 text-center text-sm font-semibold text-[color:var(--pico-accent-contrast)] shadow-[0_16px_44px_rgba(var(--pico-accent-rgb),0.22)] transition duration-200 whitespace-normal sm:w-auto sm:whitespace-nowrap hover:translate-y-[-1px] hover:shadow-[0_20px_52px_rgba(var(--pico-accent-rgb),0.28)]',
   secondaryButton:
-    'inline-flex items-center justify-center gap-2 rounded-full border border-[rgba(255,233,204,0.12)] bg-[rgba(255,248,239,0.04)] px-5 py-3 text-sm font-medium text-[#f4e3cf] transition hover:border-[rgba(212,171,115,0.26)] hover:bg-[rgba(255,248,239,0.08)]',
+    'inline-flex w-full max-w-full items-center justify-center gap-2 rounded-full border border-[color:var(--pico-border)] bg-[rgba(255,255,255,0.02)] px-5 py-3 text-center text-sm font-medium text-[color:var(--pico-text)] transition duration-200 whitespace-normal sm:w-auto sm:whitespace-nowrap hover:border-[color:var(--pico-border-hover)] hover:bg-[color:var(--pico-bg-surface)]',
   tertiaryButton:
-    'inline-flex items-center justify-center gap-2 rounded-full border border-[rgba(255,233,204,0.12)] px-4 py-2 text-sm font-medium text-[#d9c1a4] transition hover:border-[rgba(212,171,115,0.26)] hover:text-[#fff4e6]',
+    'inline-flex w-full max-w-full items-center justify-center gap-2 rounded-full border border-[color:rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.01)] px-4 py-2 text-center text-sm font-medium text-[color:var(--pico-text-secondary)] transition duration-200 whitespace-normal sm:w-auto sm:whitespace-nowrap hover:border-[color:var(--pico-border-hover)] hover:bg-[rgba(255,255,255,0.03)] hover:text-[color:var(--pico-text)]',
   metric:
-    'rounded-[24px] border border-[rgba(255,233,204,0.1)] bg-[rgba(255,248,236,0.03)] p-5 shadow-[0_18px_44px_rgba(2,2,5,0.22)]',
-  metricValue: 'mt-3 font-[family:var(--font-site-display)] text-4xl leading-none tracking-[-0.06em] text-[#fff5e8]',
+    'rounded-[24px] border border-[color:var(--pico-border)] bg-[linear-gradient(180deg,rgba(255,255,255,0.016),rgba(255,255,255,0.008))] p-5 shadow-[0_18px_44px_rgba(0,0,0,0.22)]',
+  metricValue:
+    'mt-3 font-[family:var(--font-site-display)] text-4xl leading-none tracking-[-0.06em] text-[color:var(--pico-text)]',
   chip:
-    'inline-flex items-center rounded-full border border-[rgba(212,171,115,0.24)] bg-[rgba(212,171,115,0.08)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-[#d9b387]',
-  link: 'text-sm font-medium text-[#f0bb83] transition hover:text-[#ffd8ae]',
+    'inline-flex items-center rounded-full border border-[color:rgba(var(--pico-accent-rgb),0.22)] bg-[rgba(var(--pico-accent-rgb),0.08)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--pico-accent-bright)]',
+  link:
+    'text-sm font-medium text-[color:var(--pico-accent-bright)] transition duration-200 hover:text-[color:var(--pico-accent)]',
   plane:
-    'rounded-[32px] border border-[rgba(255,233,204,0.12)] bg-[radial-gradient(circle_at_top_right,rgba(212,171,115,0.08),transparent_24%),linear-gradient(180deg,rgba(24,21,28,0.96),rgba(10,10,13,0.98))] shadow-[0_34px_110px_rgba(2,2,5,0.3)]',
+    'rounded-[32px] border border-[color:var(--pico-border)] bg-[linear-gradient(180deg,rgba(8,15,10,0.96),rgba(4,8,5,0.99))] shadow-[var(--pico-shadow-frame)] backdrop-blur-xl',
   note:
-    'rounded-[22px] border border-[rgba(212,171,115,0.24)] bg-[linear-gradient(180deg,rgba(212,171,115,0.12),rgba(27,21,18,0.14))] px-4 py-4 text-sm leading-6 text-[#ebd7c1]',
+    'rounded-[22px] border border-[color:rgba(var(--pico-accent-rgb),0.24)] bg-[linear-gradient(180deg,rgba(var(--pico-accent-rgb),0.12),rgba(7,14,8,0.18))] px-4 py-4 text-sm leading-6 text-[color:var(--pico-text-secondary)]',
   monoLabel:
-    'font-[family:var(--font-mono)] text-[11px] uppercase tracking-[0.24em] text-[#c89a67]',
+    'font-[family:var(--font-mono)] text-[11px] uppercase tracking-[0.24em] text-[color:var(--pico-text-muted)]',
   ledger:
-    'rounded-[20px] border border-[rgba(255,233,204,0.1)] bg-[rgba(255,248,236,0.025)] px-4 py-3 text-sm text-[#ddc4a8]',
+    'rounded-[20px] border border-[color:var(--pico-border)] bg-[rgba(255,255,255,0.018)] px-4 py-3 text-sm text-[color:var(--pico-text-secondary)]',
 } as const
 
 export const picoCodex = {
   frame:
-    'rounded-[36px] border border-[rgba(255,233,204,0.12)] bg-[radial-gradient(circle_at_top_right,rgba(212,171,115,0.14),transparent_24%),linear-gradient(180deg,rgba(26,22,30,0.96),rgba(11,10,14,0.985))] shadow-[0_32px_90px_rgba(2,2,5,0.38)]',
+    'rounded-[36px] border border-[color:var(--pico-border)] bg-[linear-gradient(180deg,rgba(9,18,11,0.96),rgba(5,10,7,0.985))] shadow-[var(--pico-shadow-frame)] backdrop-blur-xl',
   spread:
-    'rounded-[34px] border border-[rgba(212,171,115,0.18)] bg-[radial-gradient(circle_at_top_right,rgba(212,171,115,0.14),transparent_24%),linear-gradient(180deg,rgba(30,24,31,0.97),rgba(12,11,15,0.99))] shadow-[0_30px_100px_rgba(2,2,5,0.32)]',
+    'rounded-[34px] border border-[color:var(--pico-border-hover)] bg-[linear-gradient(180deg,rgba(10,19,12,0.97),rgba(4,8,5,0.99))] shadow-[0_30px_100px_rgba(0,0,0,0.32)] backdrop-blur-xl',
   sheet:
-    'rounded-[30px] border border-[rgba(212,171,115,0.18)] bg-[linear-gradient(180deg,rgba(255,241,223,0.08),rgba(142,121,196,0.05))] shadow-[inset_0_1px_0_rgba(255,247,235,0.08),0_24px_70px_rgba(2,2,5,0.2)]',
+    'rounded-[30px] border border-[color:var(--pico-border-hover)] bg-[linear-gradient(180deg,rgba(var(--pico-accent-rgb),0.08),rgba(115,239,190,0.03))] shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_24px_70px_rgba(0,0,0,0.2)]',
   inset:
-    'rounded-[24px] border border-[rgba(255,233,204,0.1)] bg-[rgba(255,245,231,0.03)] shadow-[inset_0_1px_0_rgba(255,247,235,0.05)]',
+    'rounded-[24px] border border-[color:var(--pico-border)] bg-[rgba(255,255,255,0.018)] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]',
   note:
-    'rounded-[22px] border border-[rgba(212,171,115,0.24)] bg-[linear-gradient(180deg,rgba(212,171,115,0.16),rgba(33,25,21,0.18))] text-[#f2e1ce] shadow-[0_20px_60px_rgba(2,2,5,0.16)]',
+    'rounded-[22px] border border-[color:var(--pico-border-hover)] bg-[linear-gradient(180deg,rgba(var(--pico-accent-rgb),0.16),rgba(8,15,9,0.22))] text-[color:var(--pico-text)] shadow-[0_20px_60px_rgba(var(--pico-accent-rgb),0.08)]',
   stamp:
-    'inline-flex items-center rounded-full border border-[rgba(212,171,115,0.24)] bg-[rgba(212,171,115,0.08)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-[#f1bf86]',
-  rule: 'border-t border-[rgba(255,233,204,0.1)]',
-  ink: 'text-[#fff1e1]',
-  parchment: 'text-[#dbc6ae]',
-  muted: 'text-[#b99879]',
+    'inline-flex items-center rounded-full border border-[color:rgba(var(--pico-accent-rgb),0.24)] bg-[rgba(var(--pico-accent-rgb),0.08)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--pico-accent-bright)]',
+  rule: 'border-t border-[color:var(--pico-border)]',
+  ink: 'text-[color:var(--pico-text)]',
+  parchment: 'text-[color:var(--pico-text-secondary)]',
+  muted: 'text-[color:var(--pico-text-muted)]',
 } as const
 
 export function picoPanel(extra?: string) {


### PR DESCRIPTION
## Summary
- redesign the Pico surface around the new green premium studio language
- rewrite the long-scroll route composition on onboarding, academy, autopilot, tutor, and support
- upgrade the shared Pico shell, landing, footer, lesson, and support surfaces so every Pico path feels like one authored product

## Validation
- npm run build
- desktop standalone checks for /pico, /pico/onboarding, /pico/academy, /pico/academy/install-hermes-locally, /pico/autopilot, /pico/tutor, /pico/support
- mobile checks at 390x844 for the same Pico routes
