### PR TITLE
fix(homepage): re-cut landing polish on current main

### DIFF
--- a/components/site/marketing/MarketingCore.module.css
+++ b/components/site/marketing/MarketingCore.module.css
@@ -12,8 +12,8 @@
   --marketing-border: rgba(255, 233, 204, 0.11);
   --marketing-border-strong: rgba(212, 171, 115, 0.22);
   --marketing-border-reverse: rgba(255, 241, 223, 0.14);
-  --marketing-accent: #d4ab73;
-  --marketing-accent-soft: #f0d0a1;
+  --marketing-accent: #3b82f6;
+  --marketing-accent-soft: #60a5fa;
   --marketing-shadow: 0 28px 80px rgba(2, 2, 5, 0.28);
   position: relative;
   min-height: 100vh;
@@ -427,18 +427,18 @@
 }
 
 .buttonPrimary {
-  background: linear-gradient(135deg, #edc492 0%, var(--marketing-accent) 100%);
-  color: #24160f;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.4) 0%, var(--marketing-accent) 100%);
+  color: #eff6ff;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.24),
-    0 18px 42px rgba(85, 44, 21, 0.18);
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    0 18px 42px rgba(30, 64, 175, 0.25);
 }
 
 .buttonPrimary:hover {
-  background: linear-gradient(135deg, #f2d6af 0%, #d2683d 100%);
+  background: linear-gradient(135deg, rgba(147, 197, 253, 0.5) 0%, #2563eb 100%);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.24),
-    0 24px 50px rgba(85, 44, 21, 0.22);
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    0 24px 50px rgba(30, 64, 175, 0.3);
 }
 
 .buttonSecondary {

--- a/components/site/marketing/MarketingHome.module.css
+++ b/components/site/marketing/MarketingHome.module.css
@@ -926,7 +926,8 @@
   display: flex;
   align-items: center;
   min-height: 3.25rem;
-  padding: 0 0.1rem;
+  padding: 0.15rem 0.1rem 0.85rem;
+  border-bottom: 1px solid rgba(255, 227, 193, 0.08);
 }
 
 .proofLane:first-child {

--- a/components/site/marketing/MarketingLoader.tsx
+++ b/components/site/marketing/MarketingLoader.tsx
@@ -400,7 +400,6 @@ export function MarketingLoader() {
             className={styles.loaderMarkVideo}
             muted
             playsInline
-            autoPlay
             preload="auto"
           >
             <source src={LOADER_VIDEO_WEBM_SRC} type="video/webm" />


### PR DESCRIPTION
## Summary
- re-cut the stranded landing-page polish from #3614 on top of current `main`
- remove autoplay from the loader video so the homepage does not self-start playback
- switch the shared homepage primary CTA accent from warm gold to MUTX blue
- tighten the current proof-card header treatment with separator/padding on the live proof section

## Validation
- `npx jest --runInBand tests/unit/marketingContent.test.ts`
- `npm run build`
- attempted `PORT=3120 npx playwright test tests/website.spec.ts -g "homepage" --workers=1`, but the existing standalone/worktree Playwright harness failed before test execution
