### PR TITLE
test: fail closed against stale local Playwright servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ pytest                     # API tests
 npx playwright test        # e2e
 ```
 
+Playwright starts a fresh local standalone server by default so worktree runs fail closed instead of silently reusing a stale build. Set `PLAYWRIGHT_REUSE_EXISTING_SERVER=1` only when you intentionally want to target an already running local standalone server.
+
 ## Architecture
 
 ```

--- a/docs/troubleshooting/debugging.md
+++ b/docs/troubleshooting/debugging.md
@@ -90,9 +90,10 @@ Use `npm run test:app` for the current app-level Jest coverage under `tests/unit
 npm run build
 npx playwright test --list
 npx playwright test tests/website.spec.ts -g "no console errors or remote Guild asset requests"
+PLAYWRIGHT_REUSE_EXISTING_SERVER=1 npx playwright test tests/website.spec.ts -g "homepage"
 ```
 
-Current Playwright smoke coverage runs locally via the checked-in config. Build first when `.next/standalone` is missing, then use `npx playwright test --list` to confirm discovery and run the smallest matching spec or grep target.
+Current Playwright smoke coverage runs locally via the checked-in config. Build first when `.next/standalone` is missing, then use `npx playwright test --list` to confirm discovery and run the smallest matching spec or grep target. Local runs now start a fresh standalone server by default so the suite fails closed against stale worktree servers; only set `PLAYWRIGHT_REUSE_EXISTING_SERVER=1` when you intentionally want to reuse an already running standalone server.
 
 ## Trusted Validation Baseline
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,8 @@ import { defineConfig, devices } from '@playwright/test';
 const port = Number(process.env.PORT || '3000');
 const baseURL = process.env.BASE_URL || `http://127.0.0.1:${port}`;
 const isCI = !!process.env.CI;
+const reuseExistingServer =
+  !isCI && process.env.PLAYWRIGHT_REUSE_EXISTING_SERVER === '1';
 
 export default defineConfig({
   testDir: './tests',
@@ -27,7 +29,7 @@ export default defineConfig({
   webServer: {
     command: "sh -c 'npm run prepare:standalone && PORT=" + port + " HOSTNAME=127.0.0.1 node .next/standalone/server.js'",
     url: baseURL,
-    reuseExistingServer: !isCI,
+    reuseExistingServer,
     timeout: 120000,
     stdout: isCI ? 'pipe' : 'ignore',
     stderr: isCI ? 'pipe' : 'ignore',


### PR DESCRIPTION
## Summary
- make local Playwright runs start a fresh standalone server by default instead of silently reusing whatever is already on the port
- keep explicit local server reuse available behind \
- document the new local Playwright behavior in the repo validation and debugging notes

## Validation
- \
- \
> mutx@1.4.0 prebuild
> node -e "require('fs').rmSync('public/_next', { recursive: true, force: true })"


> mutx@1.4.0 build
> next build

▲ Next.js 16.2.3 (Turbopack)
- Environments: .env

  Creating an optimized production build ...
✓ Compiled successfully in 6.0s
  Running TypeScript ...
  Finished TypeScript in 8.8s ...
  Collecting page data using 9 workers ...
  Generating static pages using 9 workers (0/70) ...
  Generating static pages using 9 workers (17/70) 
  Generating static pages using 9 workers (34/70) 
  Generating static pages using 9 workers (52/70) 
✓ Generating static pages using 9 workers (70/70) in 939ms
  Finalizing page optimization ...

Route (app)                                                       Revalidate  Expire
┌ ○ /
├ ○ /_not-found
├ ○ /agents
├ ○ /ai-agent-approvals
├ ○ /ai-agent-audit-logs
├ ○ /ai-agent-control-plane
├ ○ /ai-agent-cost
├ ○ /ai-agent-deployment
├ ○ /ai-agent-governance
├ ○ /ai-agent-guardrails
├ ○ /ai-agent-infrastructure
├ ○ /ai-agent-monitoring
├ ○ /ai-agent-reliability
├ ƒ /api/agents
├ ƒ /api/agents/[id]
├ ƒ /api/agents/[id]/deploy
├ ƒ /api/agents/[id]/logs
├ ƒ /api/agents/[id]/stop
├ ƒ /api/api-keys
├ ƒ /api/api-keys/[id]
├ ƒ /api/api-keys/[id]/rotate
├ ƒ /api/auth/forgot-password
├ ƒ /api/auth/local-bootstrap
├ ƒ /api/auth/login
├ ƒ /api/auth/logout
├ ƒ /api/auth/me
├ ƒ /api/auth/oauth/[provider]/callback
├ ƒ /api/auth/oauth/[provider]/start
├ ƒ /api/auth/refresh
├ ƒ /api/auth/register
├ ƒ /api/auth/resend-verification
├ ƒ /api/auth/reset-password
├ ƒ /api/auth/verify-email
├ ƒ /api/contact
├ ƒ /api/dashboard/agents
├ ƒ /api/dashboard/agents/[agentId]
├ ƒ /api/dashboard/analytics/costs
├ ƒ /api/dashboard/analytics/summary
├ ƒ /api/dashboard/analytics/timeseries
├ ƒ /api/dashboard/assistant/[agentId]/channels
├ ƒ /api/dashboard/assistant/[agentId]/health
├ ƒ /api/dashboard/assistant/[agentId]/skills
├ ƒ /api/dashboard/assistant/[agentId]/skills/[skillId]
├ ƒ /api/dashboard/assistant/overview
├ ƒ /api/dashboard/autonomy
├ ƒ /api/dashboard/budgets
├ ƒ /api/dashboard/budgets/usage
├ ƒ /api/dashboard/clawhub/bundles
├ ƒ /api/dashboard/clawhub/install-bundle
├ ƒ /api/dashboard/clawhub/skills
├ ƒ /api/dashboard/deployments
├ ƒ /api/dashboard/deployments/[id]
├ ƒ /api/dashboard/documents/jobs
├ ƒ /api/dashboard/documents/jobs/[jobId]
├ ƒ /api/dashboard/documents/jobs/[jobId]/artifacts
├ ƒ /api/dashboard/documents/jobs/[jobId]/artifacts/[artifactId]
├ ƒ /api/dashboard/documents/jobs/[jobId]/dispatch
├ ƒ /api/dashboard/documents/templates
├ ƒ /api/dashboard/health
├ ƒ /api/dashboard/monitoring/alerts
├ ƒ /api/dashboard/observability
├ ƒ /api/dashboard/onboarding
├ ƒ /api/dashboard/overview
├ ƒ /api/dashboard/reasoning/jobs
├ ƒ /api/dashboard/reasoning/jobs/[jobId]
├ ƒ /api/dashboard/reasoning/jobs/[jobId]/artifacts
├ ƒ /api/dashboard/reasoning/jobs/[jobId]/artifacts/[artifactId]
├ ƒ /api/dashboard/reasoning/jobs/[jobId]/dispatch
├ ƒ /api/dashboard/reasoning/templates
├ ƒ /api/dashboard/runs
├ ƒ /api/dashboard/runs/[runId]
├ ƒ /api/dashboard/runs/[runId]/traces
├ ƒ /api/dashboard/runtime/providers/[provider]
├ ƒ /api/dashboard/sessions
├ ƒ /api/dashboard/swarms
├ ƒ /api/dashboard/swarms/[swarmId]
├ ƒ /api/dashboard/swarms/[swarmId]/scale
├ ƒ /api/dashboard/swarms/blueprints
├ ƒ /api/dashboard/templates
├ ƒ /api/dashboard/templates/[templateId]/clone
├ ƒ /api/dashboard/templates/[templateId]/deploy
├ ƒ /api/dashboard/templates/custom
├ ƒ /api/dashboard/templates/custom/[templateId]
├ ƒ /api/dashboard/templates/state
├ ƒ /api/dashboard/usage/events
├ ƒ /api/deployments
├ ƒ /api/deployments/[id]
├ ƒ /api/deployments/[id]/events
├ ƒ /api/deployments/[id]/logs
├ ƒ /api/deployments/[id]/metrics
├ ƒ /api/deployments/[id]/restart
├ ƒ /api/deployments/[id]/scale
├ ƒ /api/docs/events
├ ƒ /api/docs/sync
├ ƒ /api/leads
├ ƒ /api/newsletter
├ ƒ /api/og-image
├ ƒ /api/pico/approvals
├ ƒ /api/pico/approvals/[requestId]/approve
├ ƒ /api/pico/approvals/[requestId]/reject
├ ƒ /api/pico/onboarding
├ ƒ /api/pico/progress
├ ƒ /api/pico/runtime/[provider]
├ ƒ /api/pico/tutor
├ ƒ /api/pico/tutor/openai
├ ƒ /api/runs/[runId]/traces
├ ƒ /api/turnstile/site-key
├ ƒ /api/v1/leads
├ ƒ /api/webhooks
├ ƒ /api/webhooks/[id]
├ ƒ /api/webhooks/[id]/deliveries
├ ƒ /api/webhooks/[id]/test
├ ○ /contact
├ ƒ /control/[[...slug]]
├ ○ /dashboard
├ ○ /dashboard/agents
├ ƒ /dashboard/agents/[agentId]
├ ○ /dashboard/analytics
├ ○ /dashboard/api-keys
├ ○ /dashboard/autonomy
├ ○ /dashboard/budgets
├ ○ /dashboard/channels
├ ○ /dashboard/control
├ ○ /dashboard/deployments
├ ƒ /dashboard/deployments/[id]
├ ○ /dashboard/documents
├ ○ /dashboard/history
├ ○ /dashboard/logs
├ ○ /dashboard/memory
├ ○ /dashboard/monitoring
├ ○ /dashboard/observability
├ ○ /dashboard/orchestration
├ ○ /dashboard/runs
├ ○ /dashboard/security
├ ○ /dashboard/sessions
├ ○ /dashboard/skills
├ ○ /dashboard/spawn
├ ○ /dashboard/swarm
├ ○ /dashboard/templates
├ ○ /dashboard/traces
├ ○ /dashboard/webhooks
├ ƒ /docs/[[...slug]]
├ ○ /download                                                            15m      1y
├ ○ /download/macos                                                      15m      1y
├ ƒ /download/macos/arm64
├ ƒ /download/macos/intel
├ ƒ /download/macos/release-notes
├ ○ /forgot-password
├ ○ /infrastructure
├ ƒ /login
├ ○ /manifest.webmanifest
├ ○ /manifesto
├ ○ /onboarding
├ ○ /opengraph-image                                                      1h      1y
├ ƒ /pico
├ ƒ /pico/academy
├ ƒ /pico/academy/[slug]
├ ƒ /pico/autopilot
├ ƒ /pico/onboarding
├ ƒ /pico/support
├ ƒ /pico/tutor
├ ○ /privacy-policy
├ ƒ /register
├ ○ /releases                                                            15m      1y
├ ○ /reset-password
├ ○ /roadmap
├ ○ /robots.txt
├ ○ /sdk
├ ○ /security
├ ○ /sitemap.xml
├ ○ /support
├ ○ /twitter-image                                                        1h      1y
├ ○ /verify-email
└ ○ /whitepaper


ƒ Proxy (Middleware)

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand


> mutx@1.4.0 postbuild
> node scripts/fix-next-types.mjs
- \Error: Playwright Test did not expect test.describe() to be called here.
Most common reasons include:
- You are calling test.describe() in a configuration file.
- You are calling test.describe() in a file that is imported by the configuration file.
- You have two different versions of @playwright/test. This usually happens
  when one of the dependencies in your package.json depends on @playwright/test.

   at website.spec.ts:418

  416 | }
  417 |
> 418 | test.describe('mutx.dev QA', () => {
      |      ^
  419 |   test.beforeEach(async ({ page }) => {
  420 |     await page.route('https://challenges.cloudflare.com/**', async (route) => {
  421 |       await route.fulfill({
    at TestTypeImpl._currentSuite (/Users/fortune/MUTX/node_modules/@playwright/test/node_modules/playwright/lib/common/testType.js:75:13)
    at TestTypeImpl._describe (/Users/fortune/MUTX/node_modules/@playwright/test/node_modules/playwright/lib/common/testType.js:115:24)
    at Function.describe (/Users/fortune/MUTX/node_modules/@playwright/test/node_modules/playwright/lib/transform/transform.js:282:12)
    at Object.<anonymous> (/Users/fortune/MUTX/tests/website.spec.ts:418:6)
Error: No tests found.
Make sure that arguments are regular expressions matching test files.
You may need to escape symbols like "$" or "*" and quote the arguments.

Closes #3619