### PR TITLE
docs: refresh validation commands and agent config response

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ npm run dev                                    # frontend only
 ### Validation
 
 ```bash
-./scripts/test.sh          # full suite
-npm run build              # frontend build
-npm run typecheck          # TS gate
-ruff check src/api cli sdk # Python lint
-pytest                     # API tests
-npx playwright test        # e2e
+./scripts/test.sh                        # full suite
+npm run build                            # frontend build
+npm run typecheck                        # TS gate
+npm run test:app                         # frontend unit tests
+ruff check src/api cli sdk src/security  # Python lint
+.venv/bin/python -m pytest               # API tests (from repo venv)
+npx playwright test                       # e2e
 ```
 
 Playwright starts a fresh local standalone server by default so worktree runs fail closed instead of silently reusing a stale build. Set `PLAYWRIGHT_REUSE_EXISTING_SERVER=1` only when you intentionally want to target an already running local standalone server.

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -99,6 +99,26 @@ Current typed config families:
 
 Unknown keys are rejected for typed configs. Successful config patches increment `config_version`.
 
+## Config Response
+
+`GET /v1/agents/{agent_id}/config` returns the agent's normalized config with its current version:
+
+```json
+{
+  "agent_id": "uuid",
+  "type": "openai",
+  "config": {
+    "model": "openai/gpt-5",
+    "safety_mode": "pairing",
+    "version": 1
+  },
+  "config_version": 1,
+  "updated_at": "2026-03-22T12:00:00Z"
+}
+```
+
+The `type` field reflects the agent type (`openai`, `anthropic`, `langchain`, `custom`, or `openclaw`) and is always present regardless of how the agent was created.
+
 ## List And Inspect Agents
 
 ```bash


### PR DESCRIPTION
## Summary
- refresh the root validation block so it matches the current repo-native commands
- document the normalized response shape for `GET /v1/agents/{agent_id}/config`

## Validation
- `git diff --check`
- `npm run build`
