### PR TITLE
fix(docs): use openclaw type in agents config response example

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -98,8 +98,12 @@ Unknown keys are rejected for typed configs. Successful config patches increment
 ```json
 {
   "agent_id": "uuid",
-  "type": "openai",
+  "type": "openclaw",
   "config": {
+    "runtime": "personal_assistant",
+    "template": "personal_assistant",
+    "assistant_id": null,
+    "workspace": "default",
     "model": "openai/gpt-5",
     "safety_mode": "pairing",
     "version": 1
@@ -109,7 +113,7 @@ Unknown keys are rejected for typed configs. Successful config patches increment
 }
 ```
 
-The `type` field reflects the agent type (`openai`, `anthropic`, `langchain`, `custom`, or `openclaw`) and is always present regardless of how the agent was created.
+The config shape matches the agent's `type`. An `openclaw` config always includes `runtime`, `template`, `assistant_id`, `workspace`, `model`, and `safety_mode`.
 
 ## List And Inspect Agents
 


### PR DESCRIPTION
## Summary

The Config Response example in docs/api/agents.md still showed `type: "openai"` with an incomplete openai-only config after the merged PR that fixed the Create response example.

## What changed

docs/api/agents.md — Config Response section:
- Changed `type` from `openai` to `openclaw`
- Added missing openclaw-only fields: `runtime`, `template`, `assistant_id`, `workspace`
- Replaced generic `type` description with specific openclaw field list
- Config now matches the `OpenClawAgentConfig` schema (schemas.py line 70-82)

## Validation

Config Response example:
```json
{
  "agent_id": "uuid",
  "type": "openclaw",
  "config": {
    "runtime": "personal_assistant",
    "template": "personal_assistant",
    "assistant_id": null,
    "workspace": "default",
    "model": "openai/gpt-5",
    "safety_mode": "pairing",
    "version": 1
  },
  "config_version": 1,
  "updated_at": "2026-03-22T12:00:00Z"
}
```

## Files

- `docs/api/agents.md` — Config Response example corrected (+6, -2)