### PR TITLE
fix(api): add has_more to MutxRunHistoryResponse for SDK pagination parity

### DIFF
--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -5888,6 +5888,8 @@ export interface components {
             skip: number;
             /** Limit */
             limit: number;
+            /** Has More */
+            has_more: boolean;
             /** Agent Id */
             agent_id?: string | null;
             /** Status */

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -19434,6 +19434,10 @@
             "type": "integer",
             "title": "Limit"
           },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
+          },
           "agent_id": {
             "anyOf": [
               {
@@ -19462,7 +19466,8 @@
           "items",
           "total",
           "skip",
-          "limit"
+          "limit",
+          "has_more"
         ],
         "title": "MutxRunHistoryResponse",
         "description": "Paginated list of runs."

--- a/sdk/mutx/observability.py
+++ b/sdk/mutx/observability.py
@@ -110,7 +110,7 @@ class Observability:
             trigger: Filter by trigger (manual, cron, webhook, agent, pipeline, queue)
 
         Returns:
-            dict with items (list), total, skip, limit, and filter values
+            dict with items (list), total, has_more, skip, limit, and filter values
         """
         self._require_sync_client()
         params = {"skip": skip, "limit": limit}
@@ -125,7 +125,10 @@ class Observability:
 
         response = self._client.get("/v1/observability/runs", params=params)
         response.raise_for_status()
-        return response.json()
+        result = response.json()
+        # Backwards-compat: older servers may not include has_more
+        result.setdefault("has_more", False)
+        return result
 
     async def alist_runs(
         self,
@@ -152,7 +155,10 @@ class Observability:
 
         response = await self._client.get("/v1/observability/runs", params=params)
         response.raise_for_status()
-        return response.json()
+        result = response.json()
+        # Backwards-compat: older servers may not include has_more
+        result.setdefault("has_more", False)
+        return result
 
     def get_run(self, run_id: str) -> dict:
         """

--- a/src/api/models/observability.py
+++ b/src/api/models/observability.py
@@ -461,6 +461,7 @@ class MutxRunHistoryResponse(BaseModel):
     total: int
     skip: int
     limit: int
+    has_more: bool
     agent_id: Optional[str] = None
     status: Optional[str] = None
 

--- a/src/api/routes/observability.py
+++ b/src/api/routes/observability.py
@@ -377,6 +377,7 @@ async def list_runs(
         total=total,
         skip=skip,
         limit=limit,
+        has_more=total > skip + len(runs),
         agent_id=agent_id,
         status=status_filter,
     )

--- a/tests/api/test_observability.py
+++ b/tests/api/test_observability.py
@@ -37,6 +37,7 @@ async def test_list_observability_runs(client):
     assert response.status_code == 200
     payload = response.json()
     assert "items" in payload
+    assert "has_more" in payload
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

MutxRunHistoryResponse was missing the `has_more` field that AgentLogHistoryResponse and AgentMetricHistoryResponse both include, breaking SDK pagination for `list_runs()`.

## Changes

- **src/api/models/observability.py**: Added `has_more: bool` to `MutxRunHistoryResponse` schema
- **src/api/routes/observability.py**: Compute `has_more=total > skip + len(runs)` in `list_runs` endpoint
- **sdk/mutx/observability.py**: Added backwards-compatible `setdefault('has_more', False)` in sync+async `list_runs` methods so older servers still work
- **tests/api/test_observability.py**: Added `assert 'has_more' in payload` to `test_list_observability_runs`

## Validation

- `ruff check src/api cli sdk` → All checks passed
- `pytest tests/api/test_observability.py` → 9 passed