### PR TITLE
fix(ci): pass POSTGRES_PASSWORD and DATABASE_URL to compose-smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,12 @@ jobs:
       - python-validation
       - frontend-validation
 
+    env:
+      POSTGRES_USER: mutx
+      POSTGRES_DB: mutx
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      DATABASE_URL: postgresql://mutx:${{ secrets.POSTGRES_PASSWORD }}@postgres:5432/mutx
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

The `compose-smoke` job in CI runs `scripts/smoke-compose-prod.sh` which starts postgres/redis/migrate services via docker compose. The migrate service needs `DATABASE_URL` (which embeds `POSTGRES_PASSWORD`) to connect to postgres.

**Root cause:** Run 24428874650 on `main` failed with:
```
sqlalchemy.exc.OperationalError: password authentication failed for user "mutx"
```
The compose-smoke job had no `env` block, so `POSTGRES_PASSWORD` was empty/undefined in the docker compose environment, causing the migrate container to fail when trying to connect.

## Fix

Add an `env` block to the `compose-smoke` job providing:
- `POSTGRES_USER` = `mutx`
- `POSTGRES_DB` = `mutx`
- `POSTGRES_PASSWORD` = `${{ secrets.POSTGRES_PASSWORD }}`
- `DATABASE_URL` = constructed URL embedding the password

These are the same values the smoke script exports as defaults, but they need to be explicitly provided so docker compose can use them when spinning up the postgres container.

## Testing

- PR CI should show `Production Compose Smoke` passing.
- The `wait_for_postgres_auth` loop (which uses `PGPASSWORD`) and the migrate container (which uses `DATABASE_URL`) will both have the correct credentials.

## Notes

- `POSTGRES_PASSWORD` must be configured as a GitHub Actions secret on the repo.
- The fix follows the same pattern already used in `scripts/smoke-compose-prod.sh` defaults.
- `gh run 24428874650` — the red main push this fixes.
