### PR TITLE
fix(ci): pass POSTGRES_PASSWORD and DATABASE_URL to compose-smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,12 @@ jobs:
       - python-validation
       - frontend-validation
 
+    env:
+      POSTGRES_USER: mutx
+      POSTGRES_DB: mutx
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      DATABASE_URL: postgresql://mutx:${{ secrets.POSTGRES_PASSWORD }}@postgres:5432/mutx
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v5


### PR DESCRIPTION
The compose-smoke job runs scripts/smoke-compose-prod.sh which starts postgres/redis/migrate services via docker compose. The migrate service needs DATABASE_URL (which embeds POSTGRES_PASSWORD) to connect to postgres. Without this, the migrate container fails with: .