### PR TITLE
fix(ci): run compose-smoke on PRs that change scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       frontend: ${{ steps.filter.outputs.frontend }}
       container: ${{ steps.filter.outputs.container }}
+      scripts: ${{ steps.filter.outputs.scripts }}
 
     steps:
       - name: Check out repository
@@ -67,6 +68,8 @@ jobs:
               - 'next.config.mjs'
               - 'docs/api/openapi.json'
               - 'scripts/verify-generated-artifacts.sh'
+            scripts:
+              - 'scripts/**'
             container:
               - 'requirements.txt'
               - 'pyproject.toml'
@@ -171,11 +174,12 @@ jobs:
 
   compose-smoke:
     name: Production Compose Smoke
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
       - python-validation
       - frontend-validation
+    # Run on main pushes and on PRs that change scripts (scripts/**, .github/workflows/ci.yml)
+    if: github.event_name == 'push' || needs.changes.outputs.scripts == 'true'
 
     env:
       POSTGRES_USER: mutx


### PR DESCRIPTION
Ensures the compose-smoke job also runs when scripts/ or .github/workflows/ci.yml are changed in a PR, not just on main push.