### PR TITLE
fix(api): add pagination (total/has_more) to GET /v1/agents/{id}/resource-usage

### DIFF
--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -6344,6 +6344,22 @@ export interface components {
             /** Label */
             label?: string | null;
         };
+        /**
+         * PaginatedAgentResourceUsageResponse
+         * @description Paginated response for agent resource usage records.
+         */
+        PaginatedAgentResourceUsageResponse: {
+            /** Items */
+            items: components["schemas"]["AgentResourceUsageResponse"][];
+            /** Total */
+            total: number;
+            /** Skip */
+            skip: number;
+            /** Limit */
+            limit: number;
+            /** Has More */
+            has_more: boolean;
+        };
         /** PicoProgressPayload */
         PicoProgressPayload: Record<string, never>;
         /** PicoTutorCommand */
@@ -8305,7 +8321,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AgentResourceUsageResponse"][];
+                    "application/json": components["schemas"]["PaginatedAgentResourceUsageResponse"];
                 };
             };
             /** @description Validation Error */

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -826,11 +826,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AgentResourceUsageResponse"
-                  },
-                  "title": "Response List Agent Resource Usage V1 Agents  Agent Id  Resource Usage Get"
+                  "$ref": "#/components/schemas/PaginatedAgentResourceUsageResponse"
                 }
               }
             }
@@ -20643,6 +20639,43 @@
         "additionalProperties": false,
         "type": "object",
         "title": "OpenClawWakeupConfig"
+      },
+      "PaginatedAgentResourceUsageResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AgentResourceUsageResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "skip": {
+            "type": "integer",
+            "title": "Skip"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "skip",
+          "limit",
+          "has_more"
+        ],
+        "title": "PaginatedAgentResourceUsageResponse",
+        "description": "Paginated response for agent resource usage records."
       },
       "PicoProgressPayload": {
         "properties": {},

--- a/sdk/mutx/agents.py
+++ b/sdk/mutx/agents.py
@@ -563,13 +563,16 @@ class Agents:
         agent_id: UUID | str,
         skip: int = 0,
         limit: int = 50,
-    ) -> list[AgentResourceUsage]:
+    ) -> dict[str, Any]:
         """List recorded resource usage for an agent.
 
         Args:
             agent_id: The agent UUID
             skip: Number of records to skip (for pagination)
             limit: Maximum number of records to return (default 50, max 100)
+
+        Returns:
+            dict with items (list of AgentResourceUsage), total, has_more, skip, and limit
         """
         self._require_sync_client()
         response = self._client.get(
@@ -577,20 +580,35 @@ class Agents:
             params={"skip": skip, "limit": limit},
         )
         response.raise_for_status()
-        return [AgentResourceUsage(r) for r in response.json()]
+        result = response.json()
+        # Normalise: newer servers return {items,total,has_more,...}, older returned a raw list
+        if isinstance(result, list):
+            result = {
+                "items": result,
+                "total": len(result),
+                "skip": skip,
+                "limit": limit,
+                "has_more": False,
+            }
+        else:
+            result.setdefault("has_more", False)
+        return result
 
     async def alist_resource_usage(
         self,
         agent_id: UUID | str,
         skip: int = 0,
         limit: int = 50,
-    ) -> list[AgentResourceUsage]:
+    ) -> dict[str, Any]:
         """List recorded resource usage for an agent (async).
 
         Args:
             agent_id: The agent UUID
             skip: Number of records to skip (for pagination)
             limit: Maximum number of records to return (default 50, max 100)
+
+        Returns:
+            dict with items (list of AgentResourceUsage), total, has_more, skip, and limit
         """
         self._require_async_client()
         response = await self._client.get(
@@ -598,7 +616,19 @@ class Agents:
             params={"skip": skip, "limit": limit},
         )
         response.raise_for_status()
-        return [AgentResourceUsage(r) for r in response.json()]
+        result = response.json()
+        # Normalise: newer servers return {items,total,has_more,...}, older returned a raw list
+        if isinstance(result, list):
+            result = {
+                "items": result,
+                "total": len(result),
+                "skip": skip,
+                "limit": limit,
+                "has_more": False,
+            }
+        else:
+            result.setdefault("has_more", False)
+        return result
 
     def stream_logs(
         self,

--- a/src/api/models/schemas.py
+++ b/src/api/models/schemas.py
@@ -323,6 +323,16 @@ class AgentResourceUsageResponse(BaseModel):
     created_at: datetime
 
 
+class PaginatedAgentResourceUsageResponse(BaseModel):
+    """Paginated response for agent resource usage records."""
+
+    items: list[AgentResourceUsageResponse]
+    total: int
+    skip: int
+    limit: int
+    has_more: bool
+
+
 class AgentResourceUsageCreate(BaseModel):
     """Request schema for creating agent resource usage record."""
 

--- a/src/api/routes/agents.py
+++ b/src/api/routes/agents.py
@@ -30,6 +30,7 @@ from src.api.models.schemas import (
     AgentLogHistoryResponse,
     AgentMetricHistoryResponse,
     AgentResourceUsageCreate,
+    PaginatedAgentResourceUsageResponse,
     AgentResourceUsageResponse,
     AgentCreate,
     AgentDetailResponse,
@@ -539,7 +540,9 @@ async def get_agent_metrics(
         forbidden_detail="Not authorized to access this agent's metrics",
     )
 
-    count_query = select(func.count()).select_from(AgentMetric).where(AgentMetric.agent_id == agent_id)
+    count_query = (
+        select(func.count()).select_from(AgentMetric).where(AgentMetric.agent_id == agent_id)
+    )
     count_result = await db.execute(count_query)
     total = count_result.scalar() or 0
 
@@ -603,7 +606,7 @@ async def create_agent_resource_usage(
 
 @router.get(
     "/{agent_id}/resource-usage",
-    response_model=list[AgentResourceUsageResponse],
+    response_model=PaginatedAgentResourceUsageResponse,
 )
 async def list_agent_resource_usage(
     agent_id: uuid.UUID,
@@ -620,6 +623,14 @@ async def list_agent_resource_usage(
         forbidden_detail="Not authorized to access this agent's resource usage",
     )
 
+    # Total count
+    count_stmt = (
+        select(func.count())
+        .select_from(AgentResourceUsage)
+        .where(AgentResourceUsage.agent_id == agent_id)
+    )
+    total = (await db.execute(count_stmt)).scalar_one()
+
     query = (
         select(AgentResourceUsage)
         .where(AgentResourceUsage.agent_id == agent_id)
@@ -629,4 +640,11 @@ async def list_agent_resource_usage(
     )
     result = await db.execute(query)
     usages = result.scalars().all()
-    return [_to_agent_resource_usage_response(usage) for usage in usages]
+
+    return PaginatedAgentResourceUsageResponse(
+        items=[_to_agent_resource_usage_response(usage) for usage in usages],
+        total=total,
+        skip=skip,
+        limit=limit,
+        has_more=(skip + limit) < total,
+    )


### PR DESCRIPTION
Adds total and has_more pagination fields to GET /v1/agents/{id}/resource-usage response, matching SDK pagination parity.