### PR TITLE
fix(api): graceful OTel tracer shutdown to prevent closed-file errors on exit

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -325,6 +325,15 @@ def _build_lifespan(
 
             await dispose_engine()
 
+            # Shutdown OpenTelemetry to flush pending spans before process exit
+            try:
+                from src.api.telemetry.telemetry import shutdown_telemetry
+
+                shutdown_telemetry()
+                logger.info("OpenTelemetry shutdown complete")
+            except Exception as e:
+                logger.warning(f"Error shutting down telemetry: {e}")
+
     return lifespan
 
 

--- a/src/api/telemetry/telemetry.py
+++ b/src/api/telemetry/telemetry.py
@@ -112,8 +112,10 @@ def setup_telemetry(service_name: str | None = None) -> trace.Tracer:
         # If exporter fails, continue without it
         pass
 
-    # Set global tracer provider
+    # Set global tracer provider and keep a reference for shutdown
+    global _tracer_provider
     trace.set_tracer_provider(provider)
+    _tracer_provider = provider
 
     # Return configured tracer
     return trace.get_tracer(name)
@@ -157,8 +159,9 @@ class Spans:
     AGENT_RESPONSE = "agent.response"
 
 
-# Pre-configured tracer (initialized on first use)
+# Pre-configured tracer and provider (initialized on first use)
 _tracer: trace.Tracer | None = None
+_tracer_provider: trace.TracerProvider | None = None
 
 
 def get_tracer() -> trace.Tracer:
@@ -167,3 +170,19 @@ def get_tracer() -> trace.Tracer:
     if _tracer is None:
         _tracer = setup_telemetry()
     return _tracer
+
+
+def shutdown_telemetry() -> None:
+    """Gracefully shut down the tracer provider and flush pending spans.
+
+    Call this during application shutdown to prevent the OTel
+    BatchSpanProcessor background thread from writing to a closed
+    logging stream (ValueError: I/O operation on closed file).
+    """
+    global _tracer_provider
+    if _tracer_provider is not None:
+        try:
+            _tracer_provider.shutdown(timeout=5.0)
+        except Exception:
+            pass
+        _tracer_provider = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -294,3 +294,22 @@ async def test_deployment(db_session: AsyncSession, test_agent):
     db_session.add(deployment)
     await db_session.commit()
     return deployment
+
+
+@pytest.fixture(scope="session", autouse=True)
+def shutdown_telemetry_after_tests() -> None:
+    """Gracefully shut down OpenTelemetry after all tests complete.
+
+    This prevents the BatchSpanProcessor background thread from writing
+    to pytest's closed stdout/stderr (ValueError: I/O operation on closed file).
+    Must run after all tests and at all process exits — including forked workers.
+    """
+    yield
+    # Runs after the session ends but before the process exits.
+    # We need to be defensive since the telemetry module may not have been imported.
+    try:
+        from src.api.telemetry.telemetry import shutdown_telemetry
+
+        shutdown_telemetry()
+    except Exception:
+        pass  # telemetry may not be imported in this test run


### PR DESCRIPTION
Implements graceful OpenTelemetry tracer shutdown to prevent "closed file" errors when the API process exits.