### PR TITLE
fix(autonomy): remove /usr/bin/python3 fallback causing daemon slots crash

### DIFF
--- a/scripts/autonomy/python_runtime.py
+++ b/scripts/autonomy/python_runtime.py
@@ -52,7 +52,6 @@ def _candidate_bins() -> Iterable[str]:
         resolved = shutil.which(name)
         if resolved:
             yield resolved
-    yield '/usr/bin/python3'
 
 
 def resolve_python(min_version: Tuple[int, int] = MIN_VERSION) -> Tuple[str, Tuple[int, int, int]]:


### PR DESCRIPTION
## Summary

_candidate_bins() in python_runtime.py had a hardcoded fallback to /usr/bin/python3 (3.9.6) at the end of the candidate chain. On this machine, Python 3.9 does not support dataclass(slots=True), causing daemon_main.py to crash on import immediately after the watchdog spawned it.

The watchdog has been failing every ~5 min for ~11 hours (since 2026-04-14T20:54).

## Fix

Remove the /usr/bin/python3 hardcoded fallback. The shutil.which(python) lookup already surfaces a Python 3.11 from the hermes-agent venv, which satisfies MIN_VERSION = (3, 10) and supports dataclass(slots=True).

## Verification

- Before: python_runtime.py --print-version -> 3.9.6 -> daemon crashes with TypeError: dataclass() got an unexpected keyword argument slots
- After: python_runtime.py --print-version -> 3.11.15 -> daemon running, heartbeat active

## Daemon status after restart

status: idle, heartbeat_at: 2026-04-15T06:10:08.110045Z, cycle_count: 1