### PR TITLE
fix(api): use SELECT COUNT(*) instead of len(scalars().all()) in count_active_api_keys

### DIFF
--- a/src/api/routes/api_keys.py
+++ b/src/api/routes/api_keys.py
@@ -35,8 +35,10 @@ async def get_owned_api_key(
 
 
 async def count_active_api_keys(db: AsyncSession, user_id: uuid.UUID) -> int:
-    result = await db.execute(select(APIKey).where(APIKey.user_id == user_id, APIKey.is_active))
-    return len(result.scalars().all())
+    count_result = await db.execute(
+        select(func.count()).select_from(APIKey).where(APIKey.user_id == user_id, APIKey.is_active),
+    )
+    return count_result.scalar() or 0
 
 
 @router.get("", response_model=APIKeyHistoryResponse)


### PR DESCRIPTION
## Summary

count_active_api_keys() in api_keys.py had the same anti-pattern fixed in agents.py (PRs #3631, #3647):

- **Before**: `SELECT *` loads every active APIKey row into memory, then `len()` counts them
- **After**: `SELECT COUNT(*)` returns only the integer count from the DB

## Impact

For users with many active API keys, this reduces memory allocation and query result size. No functional change — the result is identical.

## Verification

- All 20 tests in `tests/api/test_api_keys.py` pass