### PR TITLE
fix: deduplicate agent version schemas and fix governance_status 200-on-error

### DIFF
--- a/src/api/routes/agent_runtime.py
+++ b/src/api/routes/agent_runtime.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -35,7 +35,7 @@ from src.api.models import (
     DeploymentEvent as DeploymentEventModel,
     User,
 )
-from src.api.models.schemas import AgentResponse
+from src.api.models.schemas import AgentResponse, AgentRollbackRequest, AgentVersionHistoryResponse
 from src.api.services.user_service import hash_api_key
 from src.api.services.webhook_service import trigger_deployment_event, trigger_webhook_event
 from src.api.time_utils import as_utc, as_utc_naive
@@ -115,27 +115,6 @@ class AgentStatusResponse(BaseModel):
     status: str
     last_heartbeat: Optional[str]
     uptime_seconds: float
-
-
-class AgentVersionItem(BaseModel):
-    id: str
-    agent_id: str
-    version: int
-    config_snapshot: str
-    status: str
-    created_at: str
-
-
-class AgentVersionHistoryResponse(BaseModel):
-    agent_id: str
-    items: list[AgentVersionItem]
-    total: int
-
-
-class AgentRollbackRequest(BaseModel):
-    """Request model for rolling back an agent to a specific version."""
-
-    version: int = Field(..., description="The version number to rollback to")
 
 
 # --- Routes ---
@@ -536,18 +515,8 @@ async def get_agent_versions(
     versions = result.scalars().all()
 
     return AgentVersionHistoryResponse(
-        agent_id=str(agent.id),
-        items=[
-            AgentVersionItem(
-                id=str(v.id),
-                agent_id=str(v.agent_id),
-                version=v.version,
-                config_snapshot=v.config_snapshot,
-                status=v.status,
-                created_at=v.created_at.isoformat(),
-            )
-            for v in versions
-        ],
+        agent_id=agent.id,
+        items=list(versions),
         total=total,
         has_more=(skip + limit) < total,
     )

--- a/src/api/routes/runtime.py
+++ b/src/api/routes/runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, Depends, Response
+from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.database import get_db
@@ -91,4 +92,7 @@ async def governance_status(
         }
     except Exception:
         logger.exception("Failed to collect governance status")
-        return {"error": "Failed to collect governance status"}
+        return JSONResponse(
+            status_code=500,
+            content={"error": "Failed to collect governance status"},
+        )


### PR DESCRIPTION
## Changes

### Fix 1: Deduplicate agent version Pydantic models (`agent_runtime.py`)

Removed 3 duplicate Pydantic models (`AgentVersionItem`, `AgentVersionHistoryResponse`, `AgentRollbackRequest`) that diverged from canonical definitions in `schemas.py`:

- **Type mismatch**: Local copies used `str` for `agent_id` vs `uuid.UUID` in canonical — causes OpenAPI spec drift
- **Missing field**: Local `AgentVersionHistoryResponse` lacked `has_more: bool` — the route passed it but Pydantic silently dropped it, so consumers never got pagination info
- **Missing validation**: Local `AgentRollbackRequest.version` lacked `gt=0` constraint that the canonical model has

Now imports canonical models from `schemas.py` and leverages `from_attributes=True` on `AgentVersionResponse` for cleaner ORM→response mapping.

### Fix 2: governance_status returns HTTP 500 on error (`runtime.py`)

The `/runtime/governance/status` endpoint was returning `{"error": "..."}` with HTTP 200 when governance data collection failed. Callers checking only status code would think everything was fine. Now returns proper HTTP 500 via `JSONResponse`.

## Validation
- `ruff check` — clean
- `python -m compileall` — clean
- `pytest tests/api/` — **618 passed, 0 failed**
- `npm run build` — clean (frontend unaffected)

## Files Changed
- `src/api/routes/agent_runtime.py` — -27 lines (removed duplicates, added imports, simplified route code)
- `src/api/routes/runtime.py` — +3 lines (proper 500 error response)