### PR TITLE
fix(api): add pagination to deployment logs/metrics and use COUNT(*) for versions

### DIFF
--- a/src/api/models/schemas.py
+++ b/src/api/models/schemas.py
@@ -197,6 +197,27 @@ class DeploymentVersionResponse(BaseModel):
     rolled_back_at: Optional[datetime] = None
 
 
+class DeploymentLogsHistoryResponse(BaseModel):
+    """Paginated response for deployment logs"""
+
+    deployment_id: uuid.UUID
+    items: list[DeploymentLogsResponse]
+    total: int
+    skip: int
+    limit: int
+    level: Optional[str] = None
+
+
+class DeploymentMetricsHistoryResponse(BaseModel):
+    """Paginated response for deployment metrics"""
+
+    deployment_id: uuid.UUID
+    items: list[DeploymentMetricsResponse]
+    total: int
+    skip: int
+    limit: int
+
+
 class DeploymentVersionHistoryResponse(BaseModel):
     """Response model for deployment version history"""
 

--- a/src/api/routes/deployments.py
+++ b/src/api/routes/deployments.py
@@ -25,8 +25,8 @@ from src.api.models.schemas import (
     DeploymentScale,
     DeploymentCreate,
     DeploymentEventHistoryResponse,
-    DeploymentLogsResponse,
-    DeploymentMetricsResponse,
+    DeploymentLogsHistoryResponse,
+    DeploymentMetricsHistoryResponse,
     DeploymentVersionHistoryResponse,
     DeploymentRollbackRequest,
 )
@@ -349,7 +349,7 @@ async def restart_deployment(
     return _serialize_deployment(deployment)
 
 
-@router.get("/{deployment_id}/logs", response_model=list[DeploymentLogsResponse])
+@router.get("/{deployment_id}/logs", response_model=DeploymentLogsHistoryResponse)
 async def get_deployment_logs(
     deployment_id: uuid.UUID,
     skip: int = Query(0, ge=0),
@@ -358,23 +358,37 @@ async def get_deployment_logs(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Get logs for a specific deployment."""
+    """Get paginated logs for a specific deployment."""
     deployment = await get_owned_deployment(deployment_id, db, current_user)
 
-    # Query logs for the deployment's agent
-    query = (
-        select(AgentLog).where(AgentLog.agent_id == deployment.agent_id).offset(skip).limit(limit)
-    )
+    filters = [AgentLog.agent_id == deployment.agent_id]
     if level:
-        query = query.where(AgentLog.level == level)
-    query = query.order_by(AgentLog.timestamp.desc())
+        filters.append(AgentLog.level == level)
+
+    total_stmt = select(func.count()).select_from(AgentLog).where(*filters)
+    total = (await db.execute(total_stmt)).scalar_one()
+
+    query = (
+        select(AgentLog)
+        .where(*filters)
+        .order_by(AgentLog.timestamp.desc())
+        .offset(skip)
+        .limit(limit)
+    )
 
     result = await db.execute(query)
     logs = result.scalars().all()
-    return logs
+    return DeploymentLogsHistoryResponse(
+        deployment_id=deployment.id,
+        items=logs,
+        total=total,
+        skip=skip,
+        limit=limit,
+        level=level,
+    )
 
 
-@router.get("/{deployment_id}/metrics", response_model=list[DeploymentMetricsResponse])
+@router.get("/{deployment_id}/metrics", response_model=DeploymentMetricsHistoryResponse)
 async def get_deployment_metrics(
     deployment_id: uuid.UUID,
     skip: int = Query(0, ge=0),
@@ -382,13 +396,17 @@ async def get_deployment_metrics(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Get metrics for a specific deployment."""
+    """Get paginated metrics for a specific deployment."""
     deployment = await get_owned_deployment(deployment_id, db, current_user)
 
-    # Query metrics for the deployment's agent
+    filters = [AgentMetric.agent_id == deployment.agent_id]
+
+    total_stmt = select(func.count()).select_from(AgentMetric).where(*filters)
+    total = (await db.execute(total_stmt)).scalar_one()
+
     query = (
         select(AgentMetric)
-        .where(AgentMetric.agent_id == deployment.agent_id)
+        .where(*filters)
         .offset(skip)
         .limit(limit)
         .order_by(AgentMetric.timestamp.desc())
@@ -396,7 +414,13 @@ async def get_deployment_metrics(
 
     result = await db.execute(query)
     metrics = result.scalars().all()
-    return metrics
+    return DeploymentMetricsHistoryResponse(
+        deployment_id=deployment.id,
+        items=metrics,
+        total=total,
+        skip=skip,
+        limit=limit,
+    )
 
 
 @router.get("/{deployment_id}/versions", response_model=DeploymentVersionHistoryResponse)
@@ -408,6 +432,11 @@ async def get_deployment_versions(
     """Get version history for a specific deployment."""
     deployment = await get_owned_deployment(deployment_id, db, current_user)
 
+    count_stmt = select(func.count()).select_from(DeploymentVersion).where(
+        DeploymentVersion.deployment_id == deployment.id
+    )
+    total = (await db.execute(count_stmt)).scalar_one()
+
     query = (
         select(DeploymentVersion)
         .where(DeploymentVersion.deployment_id == deployment.id)
@@ -417,11 +446,11 @@ async def get_deployment_versions(
     result = await db.execute(query)
     versions = result.scalars().all()
 
-    return {
-        "deployment_id": deployment.id,
-        "items": versions,
-        "total": len(versions),
-    }
+    return DeploymentVersionHistoryResponse(
+        deployment_id=deployment.id,
+        items=versions,
+        total=total,
+    )
 
 
 @router.post("/{deployment_id}/rollback", response_model=DeploymentResponse)

--- a/tests/api/test_deployments.py
+++ b/tests/api/test_deployments.py
@@ -354,10 +354,11 @@ class TestDeploymentLogs:
         assert response.status_code == 200
 
         data = response.json()
-        assert len(data) == 1
-        assert data[0]["agent_id"] == str(test_deployment.agent_id)
-        assert data[0]["level"] == "ERROR"
-        assert data[0]["message"] == "probe failed"
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["agent_id"] == str(test_deployment.agent_id)
+        assert data["items"][0]["level"] == "ERROR"
+        assert data["items"][0]["message"] == "probe failed"
 
     @pytest.mark.asyncio
     async def test_get_deployment_logs_other_user_forbidden(
@@ -396,10 +397,11 @@ class TestDeploymentMetrics:
         assert response.status_code == 200
 
         data = response.json()
-        assert len(data) == 2
-        assert data[0]["agent_id"] == str(test_deployment.agent_id)
-        assert data[0]["cpu_usage"] == 0.85
-        assert data[1]["cpu_usage"] == 0.22
+        assert data["total"] == 2
+        assert len(data["items"]) == 2
+        assert data["items"][0]["agent_id"] == str(test_deployment.agent_id)
+        assert data["items"][0]["cpu_usage"] == 0.85
+        assert data["items"][1]["cpu_usage"] == 0.22
 
     @pytest.mark.asyncio
     async def test_get_deployment_metrics_other_user_forbidden(


### PR DESCRIPTION
## Changes

Three deployment list endpoints accepted `skip`/`limit` pagination params but returned bare `list[...]` — clients had no way to know total record count. One endpoint used `len(results)` (loading all rows into memory) instead of `SELECT COUNT(*)`.

### Fix 1: `GET /v1/deployments/{id}/logs` — add pagination envelope
- Was: `response_model=list[DeploymentLogsResponse]`
- Now: `response_model=DeploymentLogsHistoryResponse` with `deployment_id`, `items`, `total`, `skip`, `limit`, `level`
- Uses `SELECT COUNT(*)` for total count

### Fix 2: `GET /v1/deployments/{id}/metrics` — add pagination envelope
- Was: `response_model=list[DeploymentMetricsResponse]`
- Now: `response_model=DeploymentMetricsHistoryResponse` with `deployment_id`, `items`, `total`, `skip`, `limit`
- Uses `SELECT COUNT(*)` for total count

### Fix 3: `GET /v1/deployments/{id}/versions` — use COUNT(*) instead of len()
- Was: `len(versions)` (loads all `DeploymentVersion` rows into memory to count them)
- Now: `SELECT COUNT(*)` query + return typed `DeploymentVersionHistoryResponse`

Follows the same pagination pattern as `RunHistoryResponse`, `RunTraceHistoryResponse`, and `DeploymentEventHistoryResponse`.

## Validation
- `ruff check` — clean
- `python -m compileall` — clean
- `pytest tests/api/` — **618 passed, 0 failed**
- `npm run build` — clean (frontend unaffected)

## Files Changed
- `src/api/models/schemas.py` — +21 lines (2 new pagination response schemas)
- `src/api/routes/deployments.py` — net +41/-28 (3 endpoints updated)
- `tests/api/test_deployments.py` — updated assertions for new response shape