### PR TITLE
perf(api): replace scalars().all() + len() with SQL aggregates in analytics

### DIFF
--- a/src/api/routes/analytics.py
+++ b/src/api/routes/analytics.py
@@ -88,38 +88,50 @@ async def get_analytics_summary(
 ):
     period_start_dt, period_end_dt = _resolve_period(period_start, period_end)
 
-    agent_query = select(Agent).where(Agent.user_id == current_user.id)
+    agent_query = select(Agent.id, Agent.status).where(Agent.user_id == current_user.id)
     agent_result = await db.execute(agent_query)
-    user_agents = agent_result.scalars().all()
-    agent_ids = [a.id for a in user_agents]
+    agent_rows = agent_result.all()
+    agent_ids = [row.id for row in agent_rows]
 
-    total_agents = len(user_agents)
-    active_agents = sum(1 for a in user_agents if a.status == "running")
+    total_agents = len(agent_rows)
+    active_agents = sum(1 for row in agent_rows if row.status == "running")
 
     if agent_ids:
-        deploy_query = select(Deployment).where(Deployment.agent_id.in_(agent_ids))
-        deploy_result = await db.execute(deploy_query)
-        deployments = deploy_result.scalars().all()
-        total_deployments = len(deployments)
-        active_deployments = sum(
-            1 for d in deployments if d.status in ["running", "ready", "deploying"]
-        )
+        total_deployments = (
+            await db.execute(
+                select(func.count()).select_from(Deployment).where(
+                    Deployment.agent_id.in_(agent_ids)
+                )
+            )
+        ).scalar_one() or 0
+
+        active_deployments = (
+            await db.execute(
+                select(func.count()).select_from(Deployment).where(
+                    Deployment.agent_id.in_(agent_ids),
+                    Deployment.status.in_(["running", "ready", "deploying"]),
+                )
+            )
+        ).scalar_one() or 0
     else:
         total_deployments = active_deployments = 0
 
     if agent_ids:
-        runs_query = select(AgentRun).where(
-            and_(
-                AgentRun.agent_id.in_(agent_ids),
-                AgentRun.started_at >= period_start_dt,
-                AgentRun.started_at <= period_end_dt,
+        status_rows = (
+            await db.execute(
+                select(AgentRun.status, func.count().label("count")).where(
+                    and_(
+                        AgentRun.agent_id.in_(agent_ids),
+                        AgentRun.started_at >= period_start_dt,
+                        AgentRun.started_at <= period_end_dt,
+                    )
+                ).group_by(AgentRun.status)
             )
-        )
-        runs_result = await db.execute(runs_query)
-        runs = runs_result.scalars().all()
-        total_runs = len(runs)
-        successful_runs = sum(1 for r in runs if r.status == "completed")
-        failed_runs = sum(1 for r in runs if r.status == "failed")
+        ).all()
+        status_counts = {row.status: row.count for row in status_rows}
+        total_runs = sum(status_counts.values())
+        successful_runs = status_counts.get("completed", 0)
+        failed_runs = status_counts.get("failed", 0)
     else:
         total_runs = successful_runs = failed_runs = 0
 
@@ -192,49 +204,72 @@ async def get_agent_metrics_summary(
         period_start_dt = _parse_datetime(period_start) or (now - timedelta(days=30))
     period_end_dt = _parse_datetime(period_end) or now
 
-    runs_result = await db.execute(
-        select(AgentRun).where(
-            and_(
-                AgentRun.agent_id == agent_id,
-                AgentRun.started_at >= period_start_dt,
-                AgentRun.started_at <= period_end_dt,
-            )
+    run_status_rows = (
+        await db.execute(
+            select(AgentRun.status, func.count().label("count")).where(
+                and_(
+                    AgentRun.agent_id == agent_id,
+                    AgentRun.started_at >= period_start_dt,
+                    AgentRun.started_at <= period_end_dt,
+                )
+            ).group_by(AgentRun.status)
         )
-    )
-    runs = runs_result.scalars().all()
-    total_runs = len(runs)
-    successful_runs = sum(1 for r in runs if r.status == "completed")
-    failed_runs = sum(1 for r in runs if r.status == "failed")
+    ).all()
+    status_counts = {row.status: row.count for row in run_status_rows}
+    total_runs = sum(status_counts.values())
+    successful_runs = status_counts.get("completed", 0)
+    failed_runs = status_counts.get("failed", 0)
 
-    metrics_result = await db.execute(
-        select(AgentMetric).where(
-            and_(
-                AgentMetric.agent_id == agent_id,
-                AgentMetric.timestamp >= period_start_dt,
-                AgentMetric.timestamp <= period_end_dt,
+    avg_cpu_result = (
+        await db.execute(
+            select(func.avg(AgentMetric.cpu_usage)).where(
+                and_(
+                    AgentMetric.agent_id == agent_id,
+                    AgentMetric.timestamp >= period_start_dt,
+                    AgentMetric.timestamp <= period_end_dt,
+                )
             )
         )
-    )
-    metrics = metrics_result.scalars().all()
-    avg_cpu = sum(m.cpu_usage for m in metrics if m.cpu_usage) / len(metrics) if metrics else None
-    avg_memory = (
-        sum(m.memory_usage for m in metrics if m.memory_usage) / len(metrics) if metrics else None
-    )
+    ).scalar_one_or_none()
+    avg_cpu = round(avg_cpu_result, 2) if avg_cpu_result else None
 
-    sys_result = await db.execute(
-        select(Metrics).where(
-            and_(
-                Metrics.agent_id == agent_id,
-                Metrics.timestamp >= period_start_dt,
-                Metrics.timestamp <= period_end_dt,
+    avg_memory_result = (
+        await db.execute(
+            select(func.avg(AgentMetric.memory_usage)).where(
+                and_(
+                    AgentMetric.agent_id == agent_id,
+                    AgentMetric.timestamp >= period_start_dt,
+                    AgentMetric.timestamp <= period_end_dt,
+                )
             )
         )
-    )
-    sys_metrics = sys_result.scalars().all()
-    total_requests = sum(m.requests for m in sys_metrics)
-    avg_latency = (
-        sum(m.latency for m in sys_metrics if m.latency) / len(sys_metrics) if sys_metrics else None
-    )
+    ).scalar_one_or_none()
+    avg_memory = round(avg_memory_result, 2) if avg_memory_result else None
+
+    total_requests = (
+        await db.execute(
+            select(func.coalesce(func.sum(Metrics.requests), 0)).where(
+                and_(
+                    Metrics.agent_id == agent_id,
+                    Metrics.timestamp >= period_start_dt,
+                    Metrics.timestamp <= period_end_dt,
+                )
+            )
+        )
+    ).scalar_one()
+
+    avg_latency_result = (
+        await db.execute(
+            select(func.avg(Metrics.latency)).where(
+                and_(
+                    Metrics.agent_id == agent_id,
+                    Metrics.timestamp >= period_start_dt,
+                    Metrics.timestamp <= period_end_dt,
+                )
+            )
+        )
+    ).scalar_one_or_none()
+    avg_latency = round(avg_latency_result, 2) if avg_latency_result else None
 
     return AgentMetricsSummary(
         agent_id=agent_id,
@@ -242,10 +277,10 @@ async def get_agent_metrics_summary(
         total_runs=total_runs,
         successful_runs=successful_runs,
         failed_runs=failed_runs,
-        avg_cpu=round(avg_cpu, 2) if avg_cpu else None,
-        avg_memory=round(avg_memory, 2) if avg_memory else None,
+        avg_cpu=avg_cpu,
+        avg_memory=avg_memory,
         total_requests=total_requests,
-        avg_latency_ms=round(avg_latency, 2) if avg_latency else None,
+        avg_latency_ms=avg_latency,
         period_start=period_start_dt,
         period_end=period_end_dt,
     )


### PR DESCRIPTION
## Changes

Three analytics endpoints loaded full ORM object lists into Python memory just to call `len()` and `sum()`. This is the same class of performance bug fixed in PRs #3647, #3649, #3631 — but `analytics.py` was missed.

### Fix 1: `GET /v1/analytics/summary`
- Was: `select(Agent).where(...)` → `scalars().all()` → `len(user_agents)` and `sum(1 for a in ...)`
- Now: `select(Agent.id, Agent.status)` (lightweight row tuples) + `SELECT COUNT(*)` for deployments + `GROUP BY status` for runs
- **Impact**: Avoids loading all Agent/Deployment/AgentRun ORM objects into memory on every analytics dashboard load

### Fix 2: `GET /v1/analytics/agents/{id}/summary`
- Was: `select(AgentRun).where(...)` → `scalars().all()` → `len(runs)` and `sum(1 for r in ...)`
- Was: `select(AgentMetric).where(...)` → `scalars().all()` → Python avg computation
- Was: `select(Metrics).where(...)` → `scalars().all()` → Python sum/avg computation
- Now: `SELECT status, COUNT(*) GROUP BY status` for runs, `SELECT avg(cpu_usage)`, `SELECT avg(memory_usage)`, `SELECT sum(requests)`, `SELECT avg(latency)`
- **Impact**: Eliminates 3 full-table loads per agent metrics page view

### Left unchanged: `GET /v1/analytics/costs`
- The `_resolve_usage_agent_key()` function does per-event Python-level metadata parsing (`json.loads` + key resolution), so this cannot be pushed to SQL without a schema change. Lower priority since it is less frequently called.

## Validation
- `ruff check src/api/routes/analytics.py` — clean
- `python -m compileall` — clean
- `pytest tests/api/` — **618 passed, 0 failed**
- `npm run build` — clean (frontend unaffected)

## Files Changed
- `src/api/routes/analytics.py` — net +96/-61 (2 endpoints optimized)