### PR TITLE
fix(api): add pagination envelope to GET /v1/agents

### DIFF
--- a/app/api/dashboard/agents/route.ts
+++ b/app/api/dashboard/agents/route.ts
@@ -30,7 +30,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     )
 
     const payload = await response.json().catch(() => ({ detail: 'Failed to fetch agents' }))
-    const nextResponse = NextResponse.json(payload, { status: response.status })
+    // Backend returns { items, total, skip, limit, has_more } envelope.
+    // Extract items for backward-compatible client consumption.
+    const agents = Array.isArray(payload) ? payload : payload.items ?? payload
+    const nextResponse = NextResponse.json(agents, { status: response.status })
     
     if (tokenRefreshed && refreshedTokens) {
       applyAuthCookies(nextResponse, request, refreshedTokens)

--- a/cli/services/agents.py
+++ b/cli/services/agents.py
@@ -12,7 +12,9 @@ class AgentsService(APIService):
     def list_agents(self, *, limit: int = 50, skip: int = 0) -> list[AgentRecord]:
         response = self._request("get", "/v1/agents", params={"limit": limit, "skip": skip})
         self._expect_status(response, {200})
-        return [AgentRecord.from_payload(item) for item in response.json()]
+        payload = response.json()
+        items = payload.get("items", payload) if isinstance(payload, dict) else payload
+        return [AgentRecord.from_payload(item) for item in items]
 
     def get_agent(self, agent_id: str) -> AgentRecord:
         response = self._request("get", f"/v1/agents/{agent_id}")

--- a/src/api/models/schemas.py
+++ b/src/api/models/schemas.py
@@ -255,6 +255,16 @@ class AgentResponse(BaseModel):
     user_id: uuid.UUID
 
 
+class AgentListResponse(BaseModel):
+    """Paginated response for listing agents."""
+
+    items: list[AgentResponse]
+    total: int
+    skip: int
+    limit: int
+    has_more: bool
+
+
 class AgentDetailResponse(AgentResponse):
     deployments: list[DeploymentResponse] = Field(default_factory=list)
 

--- a/src/api/routes/agents.py
+++ b/src/api/routes/agents.py
@@ -35,6 +35,7 @@ from src.api.models.schemas import (
     AgentCreate,
     AgentDetailResponse,
     AgentResponse,
+    AgentListResponse,
     AnthropicAgentConfig,
     CustomAgentConfig,
     LangChainAgentConfig,
@@ -294,7 +295,7 @@ async def create_agent(
     return _serialize_agent(agent)
 
 
-@router.get("", response_model=list[AgentResponse])
+@router.get("", response_model=AgentListResponse)
 async def list_agents(
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=100),
@@ -304,11 +305,29 @@ async def list_agents(
     # Ownership enforcement: always filter by authenticated user's ID.
     # Client-supplied user_id query params are ignored - ownership is derived
     # from the auth token via current_user, not from client input.
-    query = select(Agent).order_by(Agent.created_at.desc()).offset(skip).limit(limit)
-    query = query.where(Agent.user_id == current_user.id)
+    base_filter = Agent.user_id == current_user.id
+
+    # Total count via SQL aggregate — avoids loading full rows just to count.
+    count_stmt = select(func.count()).select_from(Agent).where(base_filter)
+    total = (await db.execute(count_stmt)).scalar_one()
+
+    query = (
+        select(Agent)
+        .where(base_filter)
+        .order_by(Agent.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+    )
     result = await db.execute(query)
     agents = result.scalars().all()
-    return [_serialize_agent(agent) for agent in agents]
+
+    return AgentListResponse(
+        items=[_serialize_agent(agent) for agent in agents],
+        total=total,
+        skip=skip,
+        limit=limit,
+        has_more=(skip + limit) < total,
+    )
 
 
 @router.get("/{agent_id}", response_model=AgentDetailResponse)

--- a/tests/api/test_agents.py
+++ b/tests/api/test_agents.py
@@ -317,7 +317,10 @@ class TestListAgents:
         """Test listing agents when none exist."""
         response = await client.get("/v1/agents")
         assert response.status_code == 200
-        assert response.json() == []
+        data = response.json()
+        assert data["items"] == []
+        assert data["total"] == 0
+        assert data["has_more"] is False
 
     @pytest.mark.asyncio
     async def test_list_agents_with_data(self, client: AsyncClient, test_agent):
@@ -325,8 +328,10 @@ class TestListAgents:
         response = await client.get("/v1/agents")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 1
-        assert data[0]["id"] == str(test_agent.id)
+        assert len(data["items"]) == 1
+        assert data["items"][0]["id"] == str(test_agent.id)
+        assert data["total"] == 1
+        assert data["has_more"] is False
 
     @pytest.mark.asyncio
     async def test_list_agents_pagination(
@@ -348,7 +353,9 @@ class TestListAgents:
         response = await client.get("/v1/agents?limit=2")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 2
+        assert len(data["items"]) == 2
+        assert data["total"] == 5
+        assert data["has_more"] is True
 
     @pytest.mark.asyncio
     async def test_list_agents_scoped_to_authenticated_user(
@@ -357,16 +364,16 @@ class TestListAgents:
         """Test listing agents always uses the authenticated user scope."""
         # Test user can see their own agents
         response = await client.get("/v1/agents")
-        assert len(response.json()) == 1
+        assert len(response.json()["items"]) == 1
 
         # Other user sees empty list
         response = await other_user_client.get("/v1/agents")
-        assert len(response.json()) == 0
+        assert len(response.json()["items"]) == 0
 
         # Supplying user_id in query must not expand access scope
         response = await other_user_client.get(f"/v1/agents?user_id={test_agent.user_id}")
         assert response.status_code == 200
-        assert response.json() == []
+        assert response.json()["items"] == []
 
 
 class TestAgentAuthorization:

--- a/tests/unit/dashboardRoutes.test.ts
+++ b/tests/unit/dashboardRoutes.test.ts
@@ -90,13 +90,19 @@ describe('dashboard route proxies', () => {
     authenticatedFetch.mockResolvedValue({
       response: {
         status: 200,
-        json: async () => [
-          {
-          id: 'agent_123',
-          name: 'runtime-agent',
-          status: 'running',
-        },
-      ],
+        json: async () => ({
+          items: [
+            {
+              id: 'agent_123',
+              name: 'runtime-agent',
+              status: 'running',
+            },
+          ],
+          total: 1,
+          skip: 0,
+          limit: 20,
+          has_more: false,
+        }),
       },
       tokenRefreshed: false,
     })


### PR DESCRIPTION
## Problem

`GET /v1/agents` accepted `skip`/`limit` query params but returned a bare `list[AgentResponse]` — no `total`, no `has_more`. Clients had no way to know the total number of agents or whether more pages existed. This was inconsistent with every other paginated endpoint in the codebase (`AgentLogHistoryResponse`, `RunHistoryResponse`, `PaginatedAgentResourceUsageResponse`, etc.).

## Changes

- **Schema** (`src/api/models/schemas.py`): Add `AgentListResponse` envelope with `items`, `total`, `skip`, `limit`, `has_more`
- **Route** (`src/api/routes/agents.py`): Add `COUNT(*)` SQL aggregate for total count; return `AgentListResponse` instead of bare array
- **CLI** (`cli/services/agents.py`): Extract `items` from the new envelope (backward-compatible with old bare-array format)
- **Frontend proxy** (`app/api/dashboard/agents/route.ts`): Extract `items` so client components still receive a bare array
- **Tests**: Update 4 API tests + 1 frontend unit test for new response shape

## Validation

- `ruff check` — all passed
- `python -m compileall` — clean
- `pytest tests/api/test_agents.py::TestListAgents` — 4/4 passed
- `pytest tests/api/test_agents.py::TestAgentAuthorization` — 2/2 passed
- `npx jest tests/unit/dashboardRoutes.test.ts --testNamePattern agents` — 5/5 passed

## Breaking change note

The **raw backend API** response shape changes from `[{...}]` to `{items: [{...}], total: N, skip: N, limit: N, has_more: bool}`. All known consumers (CLI, frontend proxy) are updated in this PR. The SDK does not call this endpoint directly.