### PR TITLE
fix(ci): remove duplicate env block in compose-smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,12 +187,6 @@ jobs:
       POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       DATABASE_URL: postgresql://mutx:${{ secrets.POSTGRES_PASSWORD }}@postgres:5432/mutx
 
-    env:
-      POSTGRES_USER: mutx
-      POSTGRES_DB: mutx
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-      DATABASE_URL: postgresql://mutx:${{ secrets.POSTGRES_PASSWORD }}@postgres:5432/mutx
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v5


### PR DESCRIPTION
The compose-smoke job had a duplicate env block (lines 190-195), causing GitHub Actions to fail with a workflow file error. This removes the duplicate block.

Before: Two identical env blocks on lines 184 and 190.
After: Single env block with correct spacing before steps.

Fixes the CI failure on fix/agents-list-pagination-envelope and prevents the same error on main pushes that trigger compose-smoke.