### PR TITLE
fix(api): add pagination envelope to GET /v1/webhooks and /{id}/deliveries

### DIFF
--- a/app/api/webhooks/[id]/deliveries/route.ts
+++ b/app/api/webhooks/[id]/deliveries/route.ts
@@ -42,7 +42,15 @@ export async function GET(
 
     const payload = await response.json().catch(() => ({}));
     const nextResponse = response.ok
-      ? NextResponse.json({ deliveries: payload }, { status: response.status })
+      ? NextResponse.json(
+          {
+            deliveries: Array.isArray(payload) ? payload : payload?.items ?? [],
+            total: payload?.total,
+            skip: payload?.skip,
+            limit: payload?.limit,
+          },
+          { status: response.status }
+        )
       : NextResponse.json(
           { error: payload.detail || "Failed to fetch webhook deliveries" },
           { status: response.status }

--- a/app/api/webhooks/route.ts
+++ b/app/api/webhooks/route.ts
@@ -29,7 +29,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const payload = await response.json().catch(() => ({}));
     const nextResponse = response.ok
       ? NextResponse.json({
-          webhooks: Array.isArray(payload) ? payload : payload?.webhooks ?? [],
+          webhooks: Array.isArray(payload) ? payload : payload?.items ?? [],
+          total: payload?.total,
+          skip: payload?.skip,
+          limit: payload?.limit,
         })
       : NextResponse.json(
           { error: payload.detail || "Failed to fetch webhooks" },

--- a/sdk/mutx/webhooks.py
+++ b/sdk/mutx/webhooks.py
@@ -118,7 +118,9 @@ class Webhooks:
             params={"skip": skip, "limit": limit},
         )
         response.raise_for_status()
-        return [Webhook(data) for data in response.json()]
+        body = response.json()
+        items = body.get("items", body) if isinstance(body, dict) else body
+        return [Webhook(data) for data in items]
 
     async def alist(
         self,
@@ -131,7 +133,9 @@ class Webhooks:
             params={"skip": skip, "limit": limit},
         )
         response.raise_for_status()
-        return [Webhook(data) for data in response.json()]
+        body = response.json()
+        items = body.get("items", body) if isinstance(body, dict) else body
+        return [Webhook(data) for data in items]
 
     def get(self, webhook_id: UUID | str) -> Webhook:
         self._require_sync_client()
@@ -175,7 +179,9 @@ class Webhooks:
             params=params,
         )
         response.raise_for_status()
-        return [WebhookDelivery(data) for data in response.json()]
+        body = response.json()
+        items = body.get("items", body) if isinstance(body, dict) else body
+        return [WebhookDelivery(data) for data in items]
 
     async def aget_deliveries(
         self,
@@ -197,7 +203,9 @@ class Webhooks:
             params=params,
         )
         response.raise_for_status()
-        return [WebhookDelivery(data) for data in response.json()]
+        body = response.json()
+        items = body.get("items", body) if isinstance(body, dict) else body
+        return [WebhookDelivery(data) for data in items]
 
     def update(
         self,

--- a/src/api/models/schemas.py
+++ b/src/api/models/schemas.py
@@ -1023,6 +1023,27 @@ class WebhookDelivery(BaseModel):
     delivered_at: Optional[datetime]
 
 
+class WebhookListResponse(BaseModel):
+    """Paginated response for listing webhooks."""
+
+    items: list[WebhookResponse] = Field(default_factory=list)
+    total: int
+    skip: int
+    limit: int
+
+
+class WebhookDeliveryListResponse(BaseModel):
+    """Paginated response for listing webhook deliveries."""
+
+    webhook_id: uuid.UUID
+    items: list[WebhookDelivery] = Field(default_factory=list)
+    total: int
+    skip: int
+    limit: int
+    event: Optional[str] = None
+    success: Optional[bool] = None
+
+
 class WaitlistSignupCreate(BaseModel):
     email: EmailStr
     source: Optional[str] = None

--- a/src/api/routes/webhooks.py
+++ b/src/api/routes/webhooks.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Header, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import func, select
 import uuid
 import logging
 from typing import Optional
@@ -12,7 +12,8 @@ from src.api.models.schemas import (
     WebhookCreate,
     WebhookUpdate,
     WebhookResponse,
-    WebhookDelivery,
+    WebhookListResponse,
+    WebhookDeliveryListResponse,
 )
 from src.api.middleware.auth import get_current_user_or_api_key
 from src.api.security import encrypt_secret_value
@@ -132,7 +133,7 @@ async def create_webhook(
     return _serialize_webhook(webhook)
 
 
-@router.get("/", response_model=list[WebhookResponse])
+@router.get("/", response_model=WebhookListResponse)
 async def list_webhooks(
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
@@ -140,11 +141,21 @@ async def list_webhooks(
     current_user: User = Depends(get_webhook_auth),
 ):
     """List all webhooks registered by the authenticated user."""
+    filters = [Webhook.user_id == current_user.id]
+
+    total_stmt = select(func.count()).select_from(Webhook).where(*filters)
+    total = (await db.execute(total_stmt)).scalar_one()
+
     result = await db.execute(
-        select(Webhook).where(Webhook.user_id == current_user.id).offset(skip).limit(limit)
+        select(Webhook).where(*filters).offset(skip).limit(limit)
     )
     webhooks = result.scalars().all()
-    return [_serialize_webhook(webhook) for webhook in webhooks]
+    return WebhookListResponse(
+        items=[_serialize_webhook(w) for w in webhooks],
+        total=total,
+        skip=skip,
+        limit=limit,
+    )
 
 
 @router.get("/{webhook_id}", response_model=WebhookResponse)
@@ -234,7 +245,7 @@ async def test_webhook(
         )
 
 
-@router.get("/{webhook_id}/deliveries", response_model=list[WebhookDelivery])
+@router.get("/{webhook_id}/deliveries", response_model=WebhookDeliveryListResponse)
 async def list_webhook_deliveries(
     webhook_id: uuid.UUID,
     event: Optional[str] = Query(None),
@@ -247,17 +258,31 @@ async def list_webhook_deliveries(
     """List delivery attempts for a webhook owned by the authenticated user."""
     webhook = await _get_owned_webhook(webhook_id, db, current_user)
 
+    filters = [WebhookDeliveryLog.webhook_id == webhook.id]
+    if event is not None:
+        filters.append(WebhookDeliveryLog.event == event)
+    if success is not None:
+        filters.append(WebhookDeliveryLog.success == success)
+
+    total_stmt = select(func.count()).select_from(WebhookDeliveryLog).where(*filters)
+    total = (await db.execute(total_stmt)).scalar_one()
+
     query = (
         select(WebhookDeliveryLog)
-        .where(WebhookDeliveryLog.webhook_id == webhook.id)
+        .where(*filters)
         .order_by(WebhookDeliveryLog.created_at.desc())
         .offset(skip)
         .limit(limit)
     )
-    if event is not None:
-        query = query.where(WebhookDeliveryLog.event == event)
-    if success is not None:
-        query = query.where(WebhookDeliveryLog.success == success)
 
     result = await db.execute(query)
-    return result.scalars().all()
+    deliveries = result.scalars().all()
+    return WebhookDeliveryListResponse(
+        webhook_id=webhook.id,
+        items=deliveries,
+        total=total,
+        skip=skip,
+        limit=limit,
+        event=event,
+        success=success,
+    )

--- a/tests/unit/webhooksRoutes.test.ts
+++ b/tests/unit/webhooksRoutes.test.ts
@@ -43,15 +43,20 @@ describe('Webhooks route proxies', () => {
       expect(authenticatedFetch).not.toHaveBeenCalled()
     })
 
-    it('wraps array responses into a webhooks collection payload', async () => {
+    it('wraps paginated responses into a webhooks collection payload', async () => {
       hasAuthSession.mockReturnValue(true)
       authenticatedFetch.mockResolvedValue({
         response: {
           ok: true,
           status: 200,
-          json: async () => [
-            { id: 'wh_456', name: 'another-webhook', url: 'https://example.com/hook', events: ['agent.stopped'], active: false },
-          ],
+          json: async () => ({
+            items: [
+              { id: 'wh_456', name: 'another-webhook', url: 'https://example.com/hook', events: ['agent.stopped'], active: false },
+            ],
+            total: 1,
+            skip: 0,
+            limit: 50,
+          }),
         },
         tokenRefreshed: false,
       })
@@ -71,6 +76,9 @@ describe('Webhooks route proxies', () => {
         webhooks: [
           { id: 'wh_456', name: 'another-webhook', url: 'https://example.com/hook', events: ['agent.stopped'], active: false },
         ],
+        total: 1,
+        skip: 0,
+        limit: 50,
       })
     })
 


### PR DESCRIPTION
## Problem

`GET /v1/webhooks` and `GET /v1/webhooks/{id}/deliveries` accepted `skip`/`limit` query params but returned bare `list[...]` responses — no `total`, no `has_more`. Clients had no way to know the total count or whether more pages existed. This was inconsistent with every other paginated endpoint in the codebase (`RunHistoryResponse`, `AgentLogHistoryResponse`, `APIKeyHistoryResponse`, etc.).

## Changes

- **Schema** (`src/api/models/schemas.py`): Add `WebhookListResponse` and `WebhookDeliveryListResponse` pagination envelopes
- **Route** (`src/api/routes/webhooks.py`): Both `list_webhooks` and `list_webhook_deliveries` now return proper `{items, total, skip, limit}` envelopes using `SELECT COUNT(*)` for the total
- **SDK** (`sdk/mutx/webhooks.py`): Unwrap the new envelope in `list()`, `alist()`, `get_deliveries()`, `aget_deliveries()` — backward-compatible with bare array responses for older backends
- **Frontend proxies** (`app/api/webhooks/route.ts`, `app/api/webhooks/[id]/deliveries/route.ts`): Pass pagination metadata through to the client
- **Test** (`tests/unit/webhooksRoutes.test.ts`): Updated to match new response shape

## Validation

- ✅ `ruff check` — all passed
- ✅ `npm run build` — clean
- ✅ Jest: 8/8 webhooks route tests pass
- ✅ Pytest: 5/5 SDK webhooks contract tests pass
- ✅ `python -m compileall` — clean