### PR TITLE
fix(ci): verify password auth in postgres healthcheck to fix compose-smoke flake

### DIFF
--- a/infrastructure/docker/docker-compose.prod.yml
+++ b/infrastructure/docker/docker-compose.prod.yml
@@ -21,7 +21,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-mutx} -d ${POSTGRES_DB:-mutx}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-mutx} -d ${POSTGRES_DB:-mutx} && PGPASSWORD=${POSTGRES_PASSWORD} psql -U ${POSTGRES_USER:-mutx} -d ${POSTGRES_DB:-mutx} -c 'SELECT 1'"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
The compose-smoke job has been flaking repeatedly (PRs #3640, #3642, #3634, #3636, #3629, eb2acdb6). The root cause: `pg_isready` only checks TCP availability, not password auth. The migrate container races ahead and gets `FATAL: password authentication failed`.

**Fix**: Add `psql -c 'SELECT 1'` with password to the postgres healthcheck. Now the healthcheck only passes when postgres actually accepts the configured credentials.

Previous attempts only added volume cleanup or retry loops — they treat the symptom, not the cause.