### PR TITLE
fix(api): add pagination envelope to GET /v1/deployments list endpoint

### DIFF
--- a/app/api/dashboard/deployments/route.ts
+++ b/app/api/dashboard/deployments/route.ts
@@ -30,7 +30,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     )
 
     const payload = await response.json().catch(() => ({ detail: 'Failed to fetch deployments' }))
-    const nextResponse = NextResponse.json(payload, { status: response.status })
+    // Backend returns {items, total, skip, limit, has_more} envelope; pass only items to client
+    const items = Array.isArray(payload) ? payload : (payload.items ?? payload)
+    const nextResponse = NextResponse.json(items, { status: response.status })
     
     if (tokenRefreshed && refreshedTokens) {
       applyAuthCookies(nextResponse, request, refreshedTokens)

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -4736,6 +4736,19 @@ export interface components {
              */
             created_at: string;
         };
+        /** DeploymentListResponse */
+        DeploymentListResponse: {
+            /** Items */
+            items?: components["schemas"]["DeploymentResponse"][];
+            /** Total */
+            total: number;
+            /** Skip */
+            skip: number;
+            /** Limit */
+            limit: number;
+            /** Has More */
+            has_more: boolean;
+        };
         /**
          * DeploymentLogsResponse
          * @description Response model for deployment logs
@@ -8660,7 +8673,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DeploymentResponse"][];
+                    "application/json": components["schemas"]["DeploymentListResponse"];
                 };
             };
             /** @description Validation Error */

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1451,11 +1451,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DeploymentResponse"
-                  },
-                  "title": "Response List Deployments V1 Deployments Get"
+                  "$ref": "#/components/schemas/DeploymentListResponse"
                 }
               }
             }
@@ -16585,6 +16581,41 @@
         ],
         "title": "DeploymentEventResponse",
         "description": "Response model for deployment events"
+      },
+      "DeploymentListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/DeploymentResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "skip": {
+            "type": "integer",
+            "title": "Skip"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "skip",
+          "limit",
+          "has_more"
+        ],
+        "title": "DeploymentListResponse"
       },
       "DeploymentLogsResponse": {
         "properties": {

--- a/sdk/mutx/deployments.py
+++ b/sdk/mutx/deployments.py
@@ -136,7 +136,10 @@ class Deployments:
         self._require_sync_client()
         response = self._client.get("/v1/deployments", params=params)
         response.raise_for_status()
-        return [Deployment(data) for data in response.json()]
+        body = response.json()
+        # Support new envelope {items, total, ...} and legacy bare-array format
+        items = body.get("items", body) if isinstance(body, dict) else body
+        return [Deployment(data) for data in items]
 
     async def alist(
         self,
@@ -154,7 +157,10 @@ class Deployments:
         self._require_async_client()
         response = await self._client.get("/v1/deployments", params=params)
         response.raise_for_status()
-        return [Deployment(data) for data in response.json()]
+        body = response.json()
+        # Support new envelope {items, total, ...} and legacy bare-array format
+        items = body.get("items", body) if isinstance(body, dict) else body
+        return [Deployment(data) for data in items]
 
     def get(self, deployment_id: UUID | str) -> Deployment:
         self._require_sync_client()

--- a/src/api/models/schemas.py
+++ b/src/api/models/schemas.py
@@ -154,6 +154,14 @@ class DeploymentResponse(BaseModel):
     events: list[DeploymentEventResponse] = Field(default_factory=list)
 
 
+class DeploymentListResponse(BaseModel):
+    items: list[DeploymentResponse] = Field(default_factory=list)
+    total: int
+    skip: int
+    limit: int
+    has_more: bool
+
+
 class DeploymentScale(BaseModel):
     replicas: int
 

--- a/src/api/routes/deployments.py
+++ b/src/api/routes/deployments.py
@@ -21,6 +21,7 @@ from src.api.models import (
     DeploymentVersion,
 )
 from src.api.models.schemas import (
+    DeploymentListResponse,
     DeploymentResponse,
     DeploymentScale,
     DeploymentCreate,
@@ -65,7 +66,7 @@ def _serialize_deployment(deployment: Deployment):
     }
 
 
-@router.get("", response_model=list[DeploymentResponse])
+@router.get("", response_model=DeploymentListResponse)
 async def list_deployments(
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=100),
@@ -77,16 +78,8 @@ async def list_deployments(
     # Ownership enforcement: always filter by authenticated user's agent ownership.
     # Client-supplied user_id query params are ignored - ownership is derived
     # from the auth token via current_user, not from client input.
-    # Filter deployments by agents owned by the current user
-    query = (
-        select(Deployment)
-        .options(selectinload(Deployment.events))
-        .join(Agent, Deployment.agent_id == Agent.id)
-        .where(Agent.user_id == current_user.id)
-        .order_by(Deployment.created_at.desc())
-        .offset(skip)
-        .limit(limit)
-    )
+    # Build base filters for both count and data queries
+    base_filters = [Agent.user_id == current_user.id]
     if agent_id:
         await get_owned_agent(
             agent_id,
@@ -95,12 +88,39 @@ async def list_deployments(
             not_found_detail="Agent not found",
             forbidden_detail="Not authorized to view deployments for this agent",
         )
-        query = query.where(Deployment.agent_id == agent_id)
+        base_filters.append(Deployment.agent_id == agent_id)
     if status:
-        query = query.where(Deployment.status == status)
+        base_filters.append(Deployment.status == status)
+
+    # Count total matching deployments using SQL aggregate
+    count_query = (
+        select(func.count())
+        .select_from(Deployment)
+        .join(Agent, Deployment.agent_id == Agent.id)
+        .where(*base_filters)
+    )
+    total = (await db.execute(count_query)).scalar_one()
+
+    # Fetch paginated results
+    query = (
+        select(Deployment)
+        .options(selectinload(Deployment.events))
+        .join(Agent, Deployment.agent_id == Agent.id)
+        .where(*base_filters)
+        .order_by(Deployment.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+    )
     result = await db.execute(query)
     deployments = result.scalars().all()
-    return [_serialize_deployment(deployment) for deployment in deployments]
+
+    return DeploymentListResponse(
+        items=[_serialize_deployment(d) for d in deployments],
+        total=total,
+        skip=skip,
+        limit=limit,
+        has_more=(skip + limit) < total,
+    )
 
 
 @router.get("/{deployment_id}", response_model=DeploymentResponse)

--- a/tests/api/test_deployments.py
+++ b/tests/api/test_deployments.py
@@ -27,7 +27,10 @@ class TestListDeployments:
         """Test listing deployments when none exist."""
         response = await client.get("/v1/deployments")
         assert response.status_code == 200
-        assert response.json() == []
+        data = response.json()
+        assert data["items"] == []
+        assert data["total"] == 0
+        assert data["has_more"] is False
 
     @pytest.mark.asyncio
     async def test_list_deployments_with_data(self, client: AsyncClient, test_deployment):
@@ -35,8 +38,9 @@ class TestListDeployments:
         response = await client.get("/v1/deployments")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 1
-        assert data[0]["id"] == str(test_deployment.id)
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["id"] == str(test_deployment.id)
 
     @pytest.mark.asyncio
     async def test_list_deployments_pagination(
@@ -56,7 +60,11 @@ class TestListDeployments:
         response = await client.get("/v1/deployments?limit=2")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 2
+        assert data["total"] == 5
+        assert len(data["items"]) == 2
+        assert data["has_more"] is True
+        assert data["skip"] == 0
+        assert data["limit"] == 2
 
     @pytest.mark.asyncio
     async def test_list_deployments_by_agent_id(
@@ -87,8 +95,9 @@ class TestListDeployments:
         response = await client.get(f"/v1/deployments?agent_id={test_agent.id}")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 1
-        assert data[0]["agent_id"] == str(test_agent.id)
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["agent_id"] == str(test_agent.id)
 
     @pytest.mark.asyncio
     async def test_list_deployments_other_user_agent_forbidden(
@@ -116,8 +125,9 @@ class TestListDeployments:
         response = await client.get("/v1/deployments?status=running")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 1
-        assert data[0]["status"] == "running"
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["status"] == "running"
 
 
 class TestGetDeployment:

--- a/tests/unit/dashboardRoutes.test.ts
+++ b/tests/unit/dashboardRoutes.test.ts
@@ -172,13 +172,19 @@ describe('dashboard route proxies', () => {
     authenticatedFetch.mockResolvedValue({
       response: {
         status: 200,
-        json: async () => [
-          {
-          id: 'dep_123',
-          agent_id: 'agent_123',
-          status: 'running',
-        },
-      ],
+        json: async () => ({
+          items: [
+            {
+              id: 'dep_123',
+              agent_id: 'agent_123',
+              status: 'running',
+            },
+          ],
+          total: 1,
+          skip: 0,
+          limit: 20,
+          has_more: false,
+        }),
       },
       tokenRefreshed: false,
     })


### PR DESCRIPTION
## Problem

`GET /v1/deployments` accepted `skip`/`limit` query params but returned a bare `list[DeploymentResponse]` — no `total`, no `has_more`. Clients had no way to know the total number of deployments or whether more pages existed. This was inconsistent with every other paginated endpoint in the codebase (`AgentListResponse`, `DeploymentEventHistoryResponse`, `RunHistoryResponse`, `AlertListResponse`, `PaginatedAgentResourceUsageResponse`, etc.).

## Changes

- **Schema** (`src/api/models/schemas.py`): Add `DeploymentListResponse` envelope with `items`, `total`, `skip`, `limit`, `has_more`
- **Route** (`src/api/routes/deployments.py`): Add `COUNT(*)` SQL aggregate for total count; return `DeploymentListResponse` instead of bare array; reuse filter conditions across count and data queries
- **SDK** (`sdk/mutx/deployments.py`): Extract `items` from the new envelope (backward-compatible with old bare-array format)
- **Frontend proxy** (`app/api/dashboard/deployments/route.ts`): Extract `items` so client components still receive a bare array
- **Tests**: Update 6 API tests + 1 frontend unit test for new response shape

## Validation

- `ruff check` — all passed
- `python -m compileall` — clean
- `pytest tests/api/test_deployments.py` — 37/37 passed
- `pytest tests/test_sdk_deployments_contract.py` — 12/12 passed
- `npx jest tests/unit/dashboardRoutes.test.ts --testNamePattern deployments` — 4/4 passed

## Breaking change note

The **raw backend API** response shape changes from `[{...}]` to `{items: [{...}], total: N, skip: N, limit: N, has_more: bool}`. All known consumers (SDK, frontend proxy) are updated in this PR. The CLI TUI does not call this endpoint directly.
