### PR TITLE
fix(api): add pagination envelope to GET /v1/leads and /contacts list endpoints

### DIFF
--- a/sdk/mutx/leads.py
+++ b/sdk/mutx/leads.py
@@ -94,13 +94,17 @@ class Leads:
         self._require_sync_client()
         response = self._client.get("/v1/leads", params={"skip": skip, "limit": limit})
         response.raise_for_status()
-        return [Lead(data) for data in response.json()]
+        data = response.json()
+        items = data.get("items", data) if isinstance(data, dict) else data
+        return [Lead(item) for item in items]
 
     async def alist(self, skip: int = 0, limit: int = 50) -> list[Lead]:
         self._require_async_client()
         response = await self._client.get("/v1/leads", params={"skip": skip, "limit": limit})
         response.raise_for_status()
-        return [Lead(data) for data in response.json()]
+        data = response.json()
+        items = data.get("items", data) if isinstance(data, dict) else data
+        return [Lead(item) for item in items]
 
     def get(self, lead_id: UUID | str) -> Lead:
         self._require_sync_client()
@@ -222,7 +226,9 @@ class Contacts(Leads):
         self._require_sync_client()
         response = self._client.get("/v1/leads/contacts", params={"skip": skip, "limit": limit})
         response.raise_for_status()
-        return [Lead(data) for data in response.json()]
+        data = response.json()
+        items = data.get("items", data) if isinstance(data, dict) else data
+        return [Lead(item) for item in items]
 
     async def alist(self, skip: int = 0, limit: int = 50) -> list[Lead]:
         self._require_async_client()
@@ -230,7 +236,9 @@ class Contacts(Leads):
             "/v1/leads/contacts", params={"skip": skip, "limit": limit}
         )
         response.raise_for_status()
-        return [Lead(data) for data in response.json()]
+        data = response.json()
+        items = data.get("items", data) if isinstance(data, dict) else data
+        return [Lead(item) for item in items]
 
     def get(self, contact_id: UUID | str) -> Lead:
         self._require_sync_client()

--- a/src/api/models/schemas.py
+++ b/src/api/models/schemas.py
@@ -1067,6 +1067,16 @@ class LeadResponse(BaseModel):
     created_at: datetime
 
 
+class LeadListResponse(BaseModel):
+    """Paginated response for listing leads."""
+
+    items: list[LeadResponse] = Field(default_factory=list)
+    total: int
+    skip: int
+    limit: int
+    has_more: bool
+
+
 class APIKeyHistoryResponse(BaseModel):
     """Paginated response for listing API keys."""
 

--- a/src/api/routes/leads.py
+++ b/src/api/routes/leads.py
@@ -1,15 +1,14 @@
 import asyncio
 import uuid
-from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.database import get_db
 from src.api.middleware.auth import assert_internal_user, get_current_user
 from src.api.models.models import Lead, User
-from src.api.models.schemas import LeadCreate, LeadResponse, LeadUpdate
+from src.api.models.schemas import LeadCreate, LeadListResponse, LeadResponse, LeadUpdate
 
 router = APIRouter(prefix="/leads", tags=["leads"])
 contacts_router = APIRouter(prefix="/contacts", tags=["contacts"])
@@ -65,8 +64,8 @@ async def capture_lead(
     return lead
 
 
-@router.get("", response_model=List[LeadResponse])
-@contacts_router.get("", response_model=List[LeadResponse])
+@router.get("", response_model=LeadListResponse)
+@contacts_router.get("", response_model=LeadListResponse)
 async def list_leads(
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=100),
@@ -78,11 +77,21 @@ async def list_leads(
     Restricted to internal/admin users.
     """
     _assert_internal_user(current_user)
-    result = await db.execute(
-        select(Lead).order_by(Lead.created_at.desc()).offset(skip).limit(limit)
-    )
+
+    base_query = select(Lead)
+    count_result = await db.execute(select(func.count()).select_from(base_query.subquery()))
+    total = count_result.scalar_one()
+
+    result = await db.execute(base_query.order_by(Lead.created_at.desc()).offset(skip).limit(limit))
     leads = result.scalars().all()
-    return leads
+
+    return LeadListResponse(
+        items=leads,
+        total=total,
+        skip=skip,
+        limit=limit,
+        has_more=(skip + len(leads)) < total,
+    )
 
 
 @router.get("/{lead_id}", response_model=LeadResponse)

--- a/tests/api/test_leads.py
+++ b/tests/api/test_leads.py
@@ -64,7 +64,11 @@ async def test_list_leads_internal_user(client: AsyncClient, test_user):
     """Test listing leads for an internal user."""
     response = await client.get("/v1/leads")
     assert response.status_code == 200
-    assert isinstance(response.json(), list)
+    data = response.json()
+    assert "items" in data
+    assert "total" in data
+    assert "has_more" in data
+    assert isinstance(data["items"], list)
 
 
 @pytest.mark.asyncio
@@ -72,7 +76,9 @@ async def test_list_contacts_alias_internal_user(client: AsyncClient):
     """Test /contacts alias for listing."""
     response = await client.get("/v1/leads/contacts")
     assert response.status_code == 200
-    assert isinstance(response.json(), list)
+    data = response.json()
+    assert "items" in data
+    assert isinstance(data["items"], list)
 
 
 @pytest.mark.asyncio

--- a/tests/test_sdk_leads_contract.py
+++ b/tests/test_sdk_leads_contract.py
@@ -155,7 +155,16 @@ def test_leads_list_hits_contract_route() -> None:
         captured["path"] = request.url.path
         captured["method"] = request.method
         captured["params"] = dict(request.url.params)
-        return httpx.Response(200, json=[_lead_payload(), _lead_payload(id=str(uuid.uuid4()))])
+        return httpx.Response(
+            200,
+            json={
+                "items": [_lead_payload(), _lead_payload(id=str(uuid.uuid4()))],
+                "total": 2,
+                "skip": 0,
+                "limit": 50,
+                "has_more": False,
+            },
+        )
 
     client = httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler))
     leads = Leads(client)
@@ -170,7 +179,16 @@ def test_leads_list_hits_contract_route() -> None:
 
 def test_leads_list_returns_list_of_leads() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json=[_lead_payload(), _lead_payload(id=str(uuid.uuid4()))])
+        return httpx.Response(
+            200,
+            json={
+                "items": [_lead_payload(), _lead_payload(id=str(uuid.uuid4()))],
+                "total": 2,
+                "skip": 0,
+                "limit": 50,
+                "has_more": False,
+            },
+        )
 
     client = httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler))
     leads = Leads(client)
@@ -189,7 +207,10 @@ def test_leads_alist_hits_contract_route() -> None:
         captured["path"] = request.url.path
         captured["method"] = request.method
         captured["params"] = dict(request.url.params)
-        return httpx.Response(200, json=[])
+        return httpx.Response(
+            200,
+            json={"items": [], "total": 0, "skip": 0, "limit": 50, "has_more": False},
+        )
 
     client = httpx.AsyncClient(base_url="https://api.test", transport=httpx.MockTransport(handler))
     leads = Leads(client)
@@ -204,7 +225,16 @@ def test_leads_alist_hits_contract_route() -> None:
 
 def test_leads_alist_returns_list_of_leads() -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json=[_lead_payload()])
+        return httpx.Response(
+            200,
+            json={
+                "items": [_lead_payload()],
+                "total": 1,
+                "skip": 0,
+                "limit": 50,
+                "has_more": False,
+            },
+        )
 
     client = httpx.AsyncClient(base_url="https://api.test", transport=httpx.MockTransport(handler))
     leads = Leads(client)
@@ -478,7 +508,10 @@ def test_contacts_list_hits_contacts_route() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         captured["path"] = request.url.path
         captured["method"] = request.method
-        return httpx.Response(200, json=[])
+        return httpx.Response(
+            200,
+            json={"items": [], "total": 0, "skip": 0, "limit": 50, "has_more": False},
+        )
 
     client = httpx.Client(base_url="https://api.test", transport=httpx.MockTransport(handler))
     contacts = Contacts(client)
@@ -495,7 +528,10 @@ def test_contacts_alist_hits_contacts_route() -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
         captured["path"] = request.url.path
         captured["method"] = request.method
-        return httpx.Response(200, json=[])
+        return httpx.Response(
+            200,
+            json={"items": [], "total": 0, "skip": 0, "limit": 50, "has_more": False},
+        )
 
     client = httpx.AsyncClient(base_url="https://api.test", transport=httpx.MockTransport(handler))
     contacts = Contacts(client)


### PR DESCRIPTION
## Summary
Adds pagination envelope (`items/total/skip/limit/has_more`) to `GET /v1/leads` and `GET /v1/leads/contacts` list endpoints, consistent with the ongoing pagination standardization sweep (see #3654, #3656, #3658).

## Changes
- **`src/api/models/schemas.py`**: Add `LeadListResponse` paginated response schema
- **`src/api/routes/leads.py`**: Update `list_leads` to return paginated envelope with `SELECT COUNT(*)` for total
- **`sdk/mutx/leads.py`**: Update `Leads.list/alist` and `Contacts.list/alist` to unwrap the new envelope (backward-compatible with old list format)
- **`tests/api/test_leads.py`**: Update assertions for new response shape
- **`tests/test_sdk_leads_contract.py`**: Update mock responses to use new envelope format

## Validation
- `ruff check`: All checks passed
- `ruff format --check`: All formatted
- `pytest tests/api/test_leads.py`: 17 passed
- `pytest tests/test_sdk_leads_contract.py`: 32 passed