### PR TITLE
fix(ci): use static test password for compose-smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,8 +184,8 @@ jobs:
     env:
       POSTGRES_USER: mutx
       POSTGRES_DB: mutx
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-      DATABASE_URL: postgresql://mutx:${{ secrets.POSTGRES_PASSWORD }}@postgres:5432/mutx
+      POSTGRES_PASSWORD: mutx-ci-test-password
+      DATABASE_URL: postgresql://mutx:mutx-ci-test-password@postgres:5432/mutx
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Problem
The compose-smoke CI job has been failing with `password authentication failed for user "mutx"`.

Root cause: the CI workflow references `${{ secrets.POSTGRES_PASSWORD }}` but this secret was never configured in the repo. The secret resolves to an empty string, which fails scram-sha-256 auth.

## Fix
Replace the missing secret with a static CI-only test password (`mutx-ci-test-password`). This is a smoke test running in CI, not production — a hardcoded test password is appropriate and standard practice.

## Testing
- This will be validated by the compose-smoke job on this PR.
- All other CI jobs (lint, typecheck, frontend tests, python validation) are unaffected.

Fixes the latest main branch CI red state.
