### PR TITLE
fix(frontend): use normalizeCollection for API envelope extraction in 3 components

### DIFF
--- a/components/app/activity-feed.tsx
+++ b/components/app/activity-feed.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { EmptyState } from '@/components/dashboard'
+import { normalizeCollection } from '@/components/app/http'
 import { cn } from '@/lib/utils'
 
 interface ActivityEvent {
@@ -155,13 +156,13 @@ export function ActivityFeed({
 
       if (agentsRes?.ok) {
         const data = await agentsRes.json()
-        agentsData = Array.isArray(data) ? data : (data.agents || [])
+        agentsData = normalizeCollection<Agent>(data, ['items', 'agents', 'data'])
         setAgents(agentsData)
       }
 
       if (deploymentsRes?.ok) {
         const data = await deploymentsRes.json()
-        deploymentsData = Array.isArray(data) ? data : (data.deployments || [])
+        deploymentsData = normalizeCollection<Deployment>(data, ['items', 'deployments', 'data'])
         setDeployments(deploymentsData)
       }
 

--- a/components/app/log-viewer.tsx
+++ b/components/app/log-viewer.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { EmptyState } from '@/components/dashboard'
+import { normalizeCollection } from '@/components/app/http'
 import { cn } from '@/lib/utils'
 
 interface LogEntry {
@@ -83,7 +84,7 @@ export function LogViewer({ className, deploymentId }: LogViewerProps) {
       const res = await fetch('/api/dashboard/deployments')
       if (!res.ok) return
       const data = await res.json()
-      const deps = Array.isArray(data) ? data : (data.deployments || [])
+      const deps = normalizeCollection<Deployment>(data, ['items', 'deployments', 'data'])
       setDeployments(deps)
     } catch {
       // silent

--- a/components/app/task-board.tsx
+++ b/components/app/task-board.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { EmptyState } from '@/components/dashboard'
+import { normalizeCollection } from '@/components/app/http'
 import { cn } from '@/lib/utils'
 
 interface Task {
@@ -154,13 +155,13 @@ export function TaskBoard({ className, initialTasks = [] }: TaskBoardProps) {
 
       if (agentsRes?.ok) {
         const data = await agentsRes.json()
-        agentsData = Array.isArray(data) ? data : (data.agents || [])
+        agentsData = normalizeCollection<Agent>(data, ['items', 'agents', 'data'])
         setAgents(agentsData)
       }
 
       if (deploymentsRes?.ok) {
         const data = await deploymentsRes.json()
-        deploymentsData = Array.isArray(data) ? data : (data.deployments || [])
+        deploymentsData = normalizeCollection<Deployment>(data, ['items', 'deployments', 'data'])
         setDeployments(deploymentsData)
       }
 


### PR DESCRIPTION
## Problem

Three components (`log-viewer.tsx`, `task-board.tsx`, `activity-feed.tsx`) use inline envelope extraction:

```ts
Array.isArray(data) ? data : (data.deployments || [])
```

This pattern doesn't handle the `{items, total, skip, limit}` pagination envelope introduced by PRs #3654, #3658, #3656, #3662. When those PRs merge, these components will silently receive empty arrays instead of actual data.

## Fix

Replace inline extraction with `normalizeCollection()` from `@/components/app/http`, which checks for `items` as the first key — matching the new pagination envelope shape while remaining backward-compatible with raw array responses.

## Files changed

- `components/app/log-viewer.tsx` — deployments fetch
- `components/app/task-board.tsx` — agents + deployments fetch
- `components/app/activity-feed.tsx` — agents + deployments fetch

## Validation

- `npx tsc --noEmit` ✅ clean
- `npm run build` ✅ clean
- `npx eslint` on all 3 files ✅ clean