### PR TITLE
fix(ci): split compose smoke into two phases to fix postgres auth race

### DIFF
--- a/scripts/smoke-compose-prod.sh
+++ b/scripts/smoke-compose-prod.sh
@@ -133,16 +133,21 @@ trap cleanup EXIT
 echo "Starting production compose smoke core services..."
 # Clean named volumes before starting to prevent auth failures from stale postgres state.
 docker compose -f "$COMPOSE_FILE" down -v --remove-orphans >/dev/null 2>&1 || true
-docker compose -f "$COMPOSE_FILE" up -d --build postgres redis migrate api monitor
 
-# Wait for postgres to fully initialize — pg_isready in the healthcheck confirms
-# TCP availability but does NOT verify that init scripts have created the mutx user.
-# Without this wait, the migrate container races ahead and hits auth failure.
+# Phase 1: Start only postgres and redis so we can verify auth before starting
+# services that depend on the database. The compose healthcheck uses pg_isready
+# which only confirms TCP availability — the initdb scripts that create the user
+# may not have finished yet. Starting migrate before auth is ready causes a race.
+docker compose -f "$COMPOSE_FILE" up -d --build postgres redis
+
 wait_for_postgres_auth \
   "postgres" \
   "${POSTGRES_USER:-mutx}" \
   "${POSTGRES_DB:-mutx}" \
   "${POSTGRES_PASSWORD}"
+
+# Phase 2: Now that postgres auth is confirmed, start migrate + api + monitor.
+docker compose -f "$COMPOSE_FILE" up -d --build migrate api monitor
 
 wait_for_command \
   "API health endpoint" \


### PR DESCRIPTION
## Problem

The Production Compose Smoke test has been failing on main with:

```
sqlalchemy.exc.OperationalError: (psycopg.OperationalError) connection failed:
FATAL: password authentication failed for user mutx
```

This was masked until now because earlier pushes to main had Python Validation failures, which caused the compose-smoke job to be skipped (it depends on both python-validation and frontend-validation passing).

## Root Cause

The smoke script started all services in one shot:
```bash
docker compose up -d --build postgres redis migrate api monitor
```

Although `migrate` has `depends_on: postgres: condition: service_healthy`, the postgres healthcheck (using `pg_isready`) can report healthy before the initdb scripts finish creating the user with the correct password. The migrate container then immediately tries to connect with password auth and fails.

## Fix

Split the startup into two phases:
1. **Phase 1**: Start only `postgres` and `redis`, then explicitly verify password auth works via `psql -h localhost` inside the container
2. **Phase 2**: Once auth is confirmed, start `migrate`, `api`, and `monitor`

This eliminates the race condition by ensuring password auth is verified before any service tries to connect.

## Testing

- This is a CI-only change. The smoke test itself validates the fix.
- No code changes outside the smoke script.

## Files Changed

- `scripts/smoke-compose-prod.sh`: Two-phase startup with auth gate between them