### PR TITLE
fix(api): add missing authZ check to GET /profiles in governance supervision

### DIFF
--- a/src/api/routes/governance_supervision.py
+++ b/src/api/routes/governance_supervision.py
@@ -68,6 +68,7 @@ async def list_supervised_launch_profiles(
     current_user: User = Depends(get_current_user),
 ):
     """List configured launch profiles for supervised agents."""
+    _assert_internal_user(current_user)
     supervisor = get_faramesh_supervisor()
     return [
         SupervisedLaunchProfileResponse(

--- a/tests/api/test_governance_supervision_extended.py
+++ b/tests/api/test_governance_supervision_extended.py
@@ -117,6 +117,24 @@ async def test_list_supervised_launch_profiles_returns_profiles(client: AsyncCli
 
 
 @pytest.mark.asyncio
+async def test_list_supervised_launch_profiles_forbidden_for_non_internal_user(
+    other_user_client: AsyncClient,
+    monkeypatch,
+):
+    from src.api.routes import governance_supervision
+
+    monkeypatch.setattr(
+        governance_supervision,
+        'get_faramesh_supervisor',
+        lambda: _MockSupervisor(),
+    )
+
+    response = await other_user_client.get('/v1/runtime/governance/supervised/profiles')
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_get_supervised_agent_returns_404_for_unknown_agent(client: AsyncClient, monkeypatch):
     from src.api.routes import governance_supervision
 


### PR DESCRIPTION
## Summary

The `GET /v1/runtime/governance/supervised/profiles` endpoint was **the only route** in `governance_supervision.py` that did not call `_assert_internal_user()`. This allowed any authenticated user to view supervised launch profiles (commands, env keys, faramesh policies) regardless of email domain verification.

Every other endpoint in the same router (`list_supervised_agents`, `get_supervised_agent`, `start_supervised_agent`, `stop_supervised_agent`, `restart_supervised_agent`) correctly calls `_assert_internal_user()`.

## Changes

- Added `_assert_internal_user(current_user)` call to `list_supervised_launch_profiles()` in `src/api/routes/governance_supervision.py`
- Added regression test: `test_list_supervised_launch_profiles_forbidden_for_non_internal_user`

## Validation

- `ruff check` — clean
- `python -m compileall` — clean
- `pytest tests/api/test_governance_supervision.py tests/api/test_governance_supervision_extended.py` — **10/10 passed**

## Security Impact

Before: any authenticated user could enumerate supervised launch profile details.  
After: only verified internal-domain users can access this endpoint (consistent with all other governance supervision routes).