### PR TITLE
docs(api): add complete route inventory to reference.md

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -39,6 +39,47 @@ jq -r '.paths | keys[]' docs/api/openapi.json | sort
 - Operator app: `https://app.mutx.dev`
 - Direct API base: `https://api.mutx.dev`
 
+## Route Inventory
+
+All public routes mount under `/v1/*` via `PUBLIC_ROUTE_REGISTRATIONS` in `src/api/main.py`.
+The private `audit` route also mounts at `/v1/audit` but requires internal credentials.
+
+| Route Group | Prefix | Has Docs? |
+| --- | --- | --- |
+| `agents` | `/v1/agents` | [agents.md](./agents.md) |
+| `agent_runtime` | `/v1/agents` (runtime sub-paths) | — |
+| `assistant` | `/v1/assistant` | — |
+| `deployments` | `/v1/deployments` | [deployments.md](./deployments.md) |
+| `templates` | `/v1/templates` | — |
+| `webhooks` | `/v1/webhooks` | [webhooks.md](./webhooks.md) |
+| `ingest` | `/v1/ingest` | (see webhooks.md) |
+| `auth` | `/v1/auth` | [authentication.md](./authentication.md) |
+| `clawhub` | `/v1/clawhub` | — |
+| `api_keys` | `/v1/api-keys` | [api-keys.md](./api-keys.md) |
+| `leads` | `/v1/leads` | [leads.md](./leads.md) |
+| `runs` | `/v1/runs` | — |
+| `documents` | `/v1/documents` | — |
+| `reasoning` | `/v1/reasoning` | — |
+| `observability` | `/v1/observability` | — |
+| `security` | `/v1/security` | — |
+| `rag` | `/v1/rag` | — |
+| `usage` | `/v1/usage` | — |
+| `analytics` | `/v1/analytics` | [analytics.md](./analytics.md) |
+| `monitoring` | `/v1/monitoring` | — |
+| `onboarding` | `/v1/onboarding` | — |
+| `pico` | `/v1/pico` | — |
+| `runtime` | `/v1/runtime` | — |
+| `scheduler` | `/v1/scheduler` | — |
+| `sessions` | `/v1/sessions` | — |
+| `swarms` | `/v1/swarms` | — |
+| `telemetry` | `/v1/telemetry` | — |
+| `budgets` | `/v1/budgets` | — |
+| `governance_credentials` | `/v1/governance/credentials` | — |
+| `governance_supervision` | `/v1/governance/supervision` | — |
+| `policies` | `/v1/policies` | — |
+| `approvals` | `/v1/approvals` | — |
+| `audit` (private) | `/v1/audit` | — |
+
 ## Reference Artifacts
 
 - API overview: [index.md](./index.md)


### PR DESCRIPTION
The reference docs only listed 8 of 33+ registered route groups in the Reference Artifacts section.

This adds a Route Inventory table mapping every PUBLIC_ROUTE_REGISTRATIONS entry to its /v1/* prefix with links to existing docs where available.

**Drift found**: 25 route groups had no mention in the docs index. No code changes.