### PR TITLE
fix(api): add has_more to 3 inline paginated schemas (usage, monitoring, swarms)

### DIFF
--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -3410,9 +3410,7 @@ export interface components {
              * Tool Args
              * @description Tool arguments
              */
-            tool_args?: {
-                [key: string]: unknown;
-            };
+            tool_args?: Record<string, never>;
             /**
              * Agent Id
              * @description Agent ID
@@ -3473,9 +3471,7 @@ export interface components {
             agent_id: string;
             type: components["schemas"]["AgentType"];
             /** Config */
-            config: components["schemas"]["OpenAIAgentConfig"] | components["schemas"]["AnthropicAgentConfig"] | components["schemas"]["LangChainAgentConfig"] | components["schemas"]["CustomAgentConfig"] | components["schemas"]["OpenClawAgentConfig"] | {
-                [key: string]: unknown;
-            };
+            config: components["schemas"]["OpenAIAgentConfig"] | components["schemas"]["AnthropicAgentConfig"] | components["schemas"]["LangChainAgentConfig"] | components["schemas"]["CustomAgentConfig"] | components["schemas"]["OpenClawAgentConfig"] | Record<string, never>;
             /** Config Version */
             config_version: number;
             /**
@@ -3490,9 +3486,7 @@ export interface components {
              * Config
              * @description Updated agent configuration payload. Can be a JSON object or JSON string.
              */
-            config: {
-                [key: string]: unknown;
-            } | string;
+            config: Record<string, never> | string;
         };
         /** AgentCreate */
         AgentCreate: {
@@ -3503,9 +3497,7 @@ export interface components {
             /** @default openai */
             type: components["schemas"]["AgentType"];
             /** Config */
-            config?: {
-                [key: string]: unknown;
-            } | string | null;
+            config?: Record<string, never> | string | null;
         };
         /** AgentDetailResponse */
         AgentDetailResponse: {
@@ -3522,9 +3514,7 @@ export interface components {
             /** Status */
             status: string;
             /** Config */
-            config: components["schemas"]["OpenAIAgentConfig"] | components["schemas"]["AnthropicAgentConfig"] | components["schemas"]["LangChainAgentConfig"] | components["schemas"]["CustomAgentConfig"] | components["schemas"]["OpenClawAgentConfig"] | {
-                [key: string]: unknown;
-            } | null;
+            config: components["schemas"]["OpenAIAgentConfig"] | components["schemas"]["AnthropicAgentConfig"] | components["schemas"]["LangChainAgentConfig"] | components["schemas"]["CustomAgentConfig"] | components["schemas"]["OpenClawAgentConfig"] | Record<string, never> | null;
             /**
              * Config Version
              * @default 1
@@ -3691,9 +3681,7 @@ export interface components {
              * Metadata
              * @default {}
              */
-            metadata: {
-                [key: string]: unknown;
-            };
+            metadata: Record<string, never>;
             /**
              * Capabilities
              * @default []
@@ -3744,9 +3732,7 @@ export interface components {
             /** Model */
             model?: string | null;
             /** Extra Metadata */
-            extra_metadata?: {
-                [key: string]: unknown;
-            } | null;
+            extra_metadata?: Record<string, never> | null;
             /**
              * Period Start
              * Format: date-time
@@ -3795,9 +3781,7 @@ export interface components {
             /** Model */
             model?: string | null;
             /** Extra Metadata */
-            extra_metadata?: {
-                [key: string]: unknown;
-            } | null;
+            extra_metadata?: Record<string, never> | null;
             /**
              * Period Start
              * Format: date-time
@@ -3826,9 +3810,7 @@ export interface components {
             /** Status */
             status: string;
             /** Config */
-            config: components["schemas"]["OpenAIAgentConfig"] | components["schemas"]["AnthropicAgentConfig"] | components["schemas"]["LangChainAgentConfig"] | components["schemas"]["CustomAgentConfig"] | components["schemas"]["OpenClawAgentConfig"] | {
-                [key: string]: unknown;
-            } | null;
+            config: components["schemas"]["OpenAIAgentConfig"] | components["schemas"]["AnthropicAgentConfig"] | components["schemas"]["LangChainAgentConfig"] | components["schemas"]["CustomAgentConfig"] | components["schemas"]["OpenClawAgentConfig"] | Record<string, never> | null;
             /**
              * Config Version
              * @default 1
@@ -4115,9 +4097,7 @@ export interface components {
              * Payload
              * @default {}
              */
-            payload: {
-                [key: string]: unknown;
-            };
+            payload: Record<string, never>;
         };
         /**
          * ApprovalRequest
@@ -4136,9 +4116,7 @@ export interface components {
             /** Action Type */
             action_type: string;
             /** Payload */
-            payload?: {
-                [key: string]: unknown;
-            };
+            payload?: Record<string, never>;
             /** @default PENDING */
             status: components["schemas"]["ApprovalStatus"];
             /** Requester */
@@ -4169,9 +4147,7 @@ export interface components {
              * Tool Args
              * @description Tool arguments
              */
-            tool_args?: {
-                [key: string]: unknown;
-            };
+            tool_args?: Record<string, never>;
             /**
              * Agent Id
              * @description Agent ID
@@ -4326,9 +4302,7 @@ export interface components {
             /** Deployments */
             deployments?: components["schemas"]["DeploymentResponse"][];
             /** Config */
-            config: components["schemas"]["OpenClawAgentConfig"] | {
-                [key: string]: unknown;
-            };
+            config: components["schemas"]["OpenClawAgentConfig"] | Record<string, never>;
         };
         /** AssistantSessionResponse */
         AssistantSessionResponse: {
@@ -4417,9 +4391,7 @@ export interface components {
             /** Starter Prompt */
             starter_prompt: string;
             /** Default Config */
-            default_config: components["schemas"]["OpenClawAgentConfig"] | {
-                [key: string]: unknown;
-            };
+            default_config: components["schemas"]["OpenClawAgentConfig"] | Record<string, never>;
             /** Category */
             category?: string | null;
             /** Tags */
@@ -4467,9 +4439,7 @@ export interface components {
             /** Event Type */
             event_type: string;
             /** Payload */
-            payload: {
-                [key: string]: unknown;
-            };
+            payload: Record<string, never>;
             /**
              * Timestamp
              * Format: date-time
@@ -4602,9 +4572,7 @@ export interface components {
             /** Success */
             success: boolean;
             /** Result */
-            result?: {
-                [key: string]: unknown;
-            } | null;
+            result?: Record<string, never> | null;
             /** Error */
             error?: string | null;
             /** Completed At */
@@ -4617,9 +4585,7 @@ export interface components {
             /** Action */
             action: string;
             /** Parameters */
-            parameters: {
-                [key: string]: unknown;
-            };
+            parameters: Record<string, never>;
             /** Received At */
             received_at: string;
         };
@@ -4640,13 +4606,9 @@ export interface components {
             /** Checked At */
             checked_at: string;
             /** Summary */
-            summary: {
-                [key: string]: unknown;
-            };
+            summary: Record<string, never>;
             /** Results */
-            results: {
-                [key: string]: unknown;
-            }[];
+            results: Record<string, never>[];
         };
         /** CostSummaryResponse */
         CostSummaryResponse: {
@@ -4689,9 +4651,7 @@ export interface components {
              */
             ttl: number | null;
             /** Config */
-            config?: {
-                [key: string]: unknown;
-            };
+            config?: Record<string, never>;
         };
         /** CredentialResponse */
         CredentialResponse: {
@@ -4711,9 +4671,7 @@ export interface components {
             /** Expires At */
             expires_at?: string | null;
             /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            };
+            metadata?: Record<string, never>;
         };
         /** CustomAgentConfig */
         CustomAgentConfig: {
@@ -5047,9 +5005,7 @@ export interface components {
             /** Sha256 */
             sha256?: string | null;
             /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            };
+            metadata?: Record<string, never>;
             /**
              * Created At
              * Format: date-time
@@ -5071,9 +5027,7 @@ export interface components {
              */
             execution_mode: string;
             /** Parameters */
-            parameters?: {
-                [key: string]: unknown;
-            };
+            parameters?: Record<string, never>;
         };
         /** DocumentJobDispatchRequest */
         DocumentJobDispatchRequest: {
@@ -5090,9 +5044,7 @@ export interface components {
             /** Message */
             message?: string | null;
             /** Payload */
-            payload?: {
-                [key: string]: unknown;
-            };
+            payload?: Record<string, never>;
             /** Status */
             status?: string | null;
             /** Output Text */
@@ -5100,9 +5052,7 @@ export interface components {
             /** Error Message */
             error_message?: string | null;
             /** Result Summary */
-            result_summary?: {
-                [key: string]: unknown;
-            } | null;
+            result_summary?: Record<string, never> | null;
             /** Timestamp */
             timestamp?: string | null;
         };
@@ -5138,9 +5088,7 @@ export interface components {
             /** Execution Mode */
             execution_mode: string;
             /** Manifest */
-            manifest?: {
-                [key: string]: unknown;
-            };
+            manifest?: Record<string, never>;
             /** Artifacts */
             artifacts?: components["schemas"]["DocumentArtifactResponse"][];
         };
@@ -5163,13 +5111,9 @@ export interface components {
             /** Status */
             status: string;
             /** Parameters */
-            parameters?: {
-                [key: string]: unknown;
-            };
+            parameters?: Record<string, never>;
             /** Result Summary */
-            result_summary?: {
-                [key: string]: unknown;
-            };
+            result_summary?: Record<string, never>;
             /** Error Message */
             error_message?: string | null;
             /** Claimed By */
@@ -5315,9 +5259,7 @@ export interface components {
             uptime_seconds?: number | null;
             /** Components */
             components?: {
-                [key: string]: {
-                    [key: string]: unknown;
-                };
+                [key: string]: Record<string, never>;
             };
             /** Schema Repairs Applied */
             schema_repairs_applied?: string[];
@@ -5374,9 +5316,7 @@ export interface components {
              */
             model: string;
             /** Metadatas */
-            metadatas?: {
-                [key: string]: unknown;
-            }[] | null;
+            metadatas?: Record<string, never>[] | null;
             /** Ids */
             ids?: string[] | null;
         };
@@ -5426,9 +5366,7 @@ export interface components {
             /** Chain Id */
             chain_id: string;
             /** Parameters */
-            parameters?: {
-                [key: string]: unknown;
-            };
+            parameters?: Record<string, never>;
         };
         /** LeadCreate */
         LeadCreate: {
@@ -5521,9 +5459,7 @@ export interface components {
              * Metadata
              * @default {}
              */
-            metadata: {
-                [key: string]: unknown;
-            };
+            metadata: Record<string, never>;
             /** Timestamp */
             timestamp: string;
         };
@@ -5601,9 +5537,7 @@ export interface components {
              * Custom
              * @default {}
              */
-            custom: {
-                [key: string]: unknown;
-            };
+            custom: Record<string, never>;
             /** Timestamp */
             timestamp: string;
         };
@@ -5975,9 +5909,7 @@ export interface components {
              * Run Metadata
              * @description Additional metadata
              */
-            run_metadata?: {
-                [key: string]: unknown;
-            };
+            run_metadata?: Record<string, never>;
         };
         /**
          * MutxRunDetailResponse
@@ -6044,9 +5976,7 @@ export interface components {
              * Run Metadata
              * @default {}
              */
-            run_metadata: {
-                [key: string]: unknown;
-            };
+            run_metadata: Record<string, never>;
             /**
              * Created At
              * Format: date-time
@@ -6143,9 +6073,7 @@ export interface components {
              * Run Metadata
              * @default {}
              */
-            run_metadata: {
-                [key: string]: unknown;
-            };
+            run_metadata: Record<string, never>;
             /**
              * Created At
              * Format: date-time
@@ -6233,9 +6161,7 @@ export interface components {
              * Step Metadata
              * @description Extension point for step-specific data
              */
-            step_metadata?: {
-                [key: string]: unknown;
-            };
+            step_metadata?: Record<string, never>;
         };
         /**
          * MutxStepBatchResponse
@@ -6319,9 +6245,7 @@ export interface components {
              * Step Metadata
              * @description Additional metadata
              */
-            step_metadata?: {
-                [key: string]: unknown;
-            };
+            step_metadata?: Record<string, never>;
         };
         /**
          * MutxStepType
@@ -6358,9 +6282,7 @@ export interface components {
             /** Action Type */
             action_type?: string | null;
             /** Import Source */
-            import_source?: {
-                [key: string]: unknown;
-            };
+            import_source?: Record<string, never>;
             /** Current Step */
             current_step: string;
             /** Completed Steps */
@@ -6413,9 +6335,7 @@ export interface components {
             /** Step */
             step?: string | null;
             /** Payload */
-            payload?: {
-                [key: string]: unknown;
-            };
+            payload?: Record<string, never>;
         };
         /** OpenAIAgentConfig */
         OpenAIAgentConfig: {
@@ -6488,9 +6408,7 @@ export interface components {
             /** Wakeups */
             wakeups?: components["schemas"]["OpenClawWakeupConfig"][];
             /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            };
+            metadata?: Record<string, never>;
             gateway?: components["schemas"]["OpenClawGatewayConfig"];
         };
         /** OpenClawChannelConfig */
@@ -6556,9 +6474,7 @@ export interface components {
             has_more: boolean;
         };
         /** PicoProgressPayload */
-        PicoProgressPayload: {
-            [key: string]: unknown;
-        };
+        PicoProgressPayload: Record<string, never>;
         /** PicoTutorCommand */
         PicoTutorCommand: {
             /** Label */
@@ -6633,9 +6549,7 @@ export interface components {
             /** Lessonslug */
             lessonSlug?: string | null;
             /** Progress */
-            progress?: {
-                [key: string]: unknown;
-            } | null;
+            progress?: Record<string, never> | null;
             setupContext?: components["schemas"]["PicoTutorSetupContext"] | null;
         };
         /** PicoTutorResponse */
@@ -6686,17 +6600,11 @@ export interface components {
         /** PicoTutorSetupContext */
         PicoTutorSetupContext: {
             /** Onboarding */
-            onboarding?: {
-                [key: string]: unknown;
-            } | null;
+            onboarding?: Record<string, never> | null;
             /** Runtime */
-            runtime?: {
-                [key: string]: unknown;
-            } | null;
+            runtime?: Record<string, never> | null;
             /** Currentsurface */
             currentSurface?: string | null;
-        } & {
-            [key: string]: unknown;
         };
         /** PicoTutorSource */
         PicoTutorSource: {
@@ -6802,9 +6710,7 @@ export interface components {
             /** Sha256 */
             sha256?: string | null;
             /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            };
+            metadata?: Record<string, never>;
             /**
              * Created At
              * Format: date-time
@@ -6826,9 +6732,7 @@ export interface components {
              */
             execution_mode: string;
             /** Parameters */
-            parameters?: {
-                [key: string]: unknown;
-            };
+            parameters?: Record<string, never>;
         };
         /** ReasoningJobDispatchRequest */
         ReasoningJobDispatchRequest: {
@@ -6845,9 +6749,7 @@ export interface components {
             /** Message */
             message?: string | null;
             /** Payload */
-            payload?: {
-                [key: string]: unknown;
-            };
+            payload?: Record<string, never>;
             /** Status */
             status?: string | null;
             /** Output Text */
@@ -6855,9 +6757,7 @@ export interface components {
             /** Error Message */
             error_message?: string | null;
             /** Result Summary */
-            result_summary?: {
-                [key: string]: unknown;
-            } | null;
+            result_summary?: Record<string, never> | null;
             /** Timestamp */
             timestamp?: string | null;
         };
@@ -6893,9 +6793,7 @@ export interface components {
             /** Execution Mode */
             execution_mode: string;
             /** Manifest */
-            manifest?: {
-                [key: string]: unknown;
-            };
+            manifest?: Record<string, never>;
             /** Artifacts */
             artifacts?: components["schemas"]["ReasoningArtifactResponse"][];
         };
@@ -6918,13 +6816,9 @@ export interface components {
             /** Status */
             status: string;
             /** Parameters */
-            parameters?: {
-                [key: string]: unknown;
-            };
+            parameters?: Record<string, never>;
             /** Result Summary */
-            result_summary?: {
-                [key: string]: unknown;
-            };
+            result_summary?: Record<string, never>;
             /** Error Message */
             error_message?: string | null;
             /** Claimed By */
@@ -7107,9 +7001,7 @@ export interface components {
             /** Error Message */
             error_message?: string | null;
             /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            };
+            metadata?: Record<string, never>;
             /** Started At */
             started_at?: string | null;
             /** Completed At */
@@ -7135,9 +7027,7 @@ export interface components {
             /** Error Message */
             error_message: string | null;
             /** Metadata */
-            metadata: {
-                [key: string]: unknown;
-            };
+            metadata: Record<string, never>;
             /**
              * Started At
              * Format: date-time
@@ -7201,9 +7091,7 @@ export interface components {
             /** Error Message */
             error_message: string | null;
             /** Metadata */
-            metadata: {
-                [key: string]: unknown;
-            };
+            metadata: Record<string, never>;
             /**
              * Started At
              * Format: date-time
@@ -7239,9 +7127,7 @@ export interface components {
             /** Message */
             message?: string | null;
             /** Payload */
-            payload?: {
-                [key: string]: unknown;
-            };
+            payload?: Record<string, never>;
             /** Timestamp */
             timestamp?: string | null;
         };
@@ -7280,9 +7166,7 @@ export interface components {
             /** Message */
             message: string | null;
             /** Payload */
-            payload: {
-                [key: string]: unknown;
-            };
+            payload: Record<string, never>;
             /** Sequence */
             sequence: number;
             /**
@@ -7357,9 +7241,7 @@ export interface components {
             /** Last Action Type */
             last_action_type?: string | null;
             /** Import Source */
-            import_source?: {
-                [key: string]: unknown;
-            };
+            import_source?: Record<string, never>;
             /** Version */
             version?: string | null;
             /**
@@ -7368,9 +7250,7 @@ export interface components {
              */
             status: string;
             /** Gateway */
-            gateway?: {
-                [key: string]: unknown;
-            };
+            gateway?: Record<string, never>;
             /** Gateway Url */
             gateway_url?: string | null;
             /** Gateway Port */
@@ -7385,13 +7265,9 @@ export interface components {
              */
             binding_count: number;
             /** Current Binding */
-            current_binding?: {
-                [key: string]: unknown;
-            } | null;
+            current_binding?: Record<string, never> | null;
             /** Bindings */
-            bindings?: {
-                [key: string]: unknown;
-            }[];
+            bindings?: Record<string, never>[];
             /**
              * Observed Source
              * @default local
@@ -7474,9 +7350,7 @@ export interface components {
             /** Last Action Type */
             last_action_type?: string | null;
             /** Import Source */
-            import_source?: {
-                [key: string]: unknown;
-            };
+            import_source?: Record<string, never>;
             /** Version */
             version?: string | null;
             /**
@@ -7485,9 +7359,7 @@ export interface components {
              */
             status: string;
             /** Gateway */
-            gateway?: {
-                [key: string]: unknown;
-            };
+            gateway?: Record<string, never>;
             /** Gateway Url */
             gateway_url?: string | null;
             /** Gateway Port */
@@ -7502,13 +7374,9 @@ export interface components {
              */
             binding_count: number;
             /** Current Binding */
-            current_binding?: {
-                [key: string]: unknown;
-            } | null;
+            current_binding?: Record<string, never> | null;
             /** Bindings */
-            bindings?: {
-                [key: string]: unknown;
-            }[];
+            bindings?: Record<string, never>[];
             /**
              * Observed Source
              * @default local
@@ -7561,9 +7429,7 @@ export interface components {
              */
             task_type: string;
             /** Payload */
-            payload?: {
-                [key: string]: unknown;
-            };
+            payload?: Record<string, never>;
         };
         /** SchedulerTaskResponse */
         SchedulerTaskResponse: {
@@ -7582,9 +7448,7 @@ export interface components {
             /** Task Type */
             task_type: string;
             /** Payload */
-            payload: {
-                [key: string]: unknown;
-            };
+            payload: Record<string, never>;
             /** Last Run */
             last_run: number | null;
             /** Next Run */
@@ -7611,9 +7475,7 @@ export interface components {
             /** Task Type */
             task_type?: string | null;
             /** Payload */
-            payload?: {
-                [key: string]: unknown;
-            } | null;
+            payload?: Record<string, never> | null;
         };
         /**
          * SearchRequest
@@ -7666,9 +7528,7 @@ export interface components {
         /** SessionListResponse */
         SessionListResponse: {
             /** Sessions */
-            sessions: {
-                [key: string]: unknown;
-            }[];
+            sessions: Record<string, never>[];
         };
         /** StarterDeploymentCreate */
         StarterDeploymentCreate: {
@@ -7697,9 +7557,7 @@ export interface components {
                 [key: string]: components["schemas"]["OpenClawChannelConfig"];
             };
             /** Runtime Metadata */
-            runtime_metadata?: {
-                [key: string]: unknown;
-            };
+            runtime_metadata?: Record<string, never>;
         };
         /** StarterDeploymentResponse */
         StarterDeploymentResponse: {
@@ -7991,9 +7849,7 @@ export interface components {
              * Metadata
              * @description Additional event metadata
              */
-            metadata?: {
-                [key: string]: unknown;
-            } | null;
+            metadata?: Record<string, never> | null;
         };
         /**
          * UsageEventListResponse
@@ -8045,9 +7901,7 @@ export interface components {
              * Metadata
              * @description Deserialize event_metadata JSON string to dict
              */
-            readonly metadata: {
-                [key: string]: unknown;
-            } | null;
+            readonly metadata: Record<string, never> | null;
         };
         /** UserResponse */
         UserResponse: {
@@ -8483,9 +8337,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -8518,9 +8370,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -12241,9 +12091,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
+                "application/json": Record<string, never>;
             };
         };
         responses: {
@@ -13370,9 +13218,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -13407,9 +13253,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -13704,9 +13548,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -3410,7 +3410,9 @@ export interface components {
              * Tool Args
              * @description Tool arguments
              */
-            tool_args?: Record<string, never>;
+            tool_args?: {
+                [key: string]: unknown;
+            };
             /**
              * Agent Id
              * @description Agent ID
@@ -3471,7 +3473,9 @@ export interface components {
             agent_id: string;
             type: components["schemas"]["AgentType"];
             /** Config */
-            config: components["schemas"]["OpenAIAgentConfig"] | components["schemas"]["AnthropicAgentConfig"] | components["schemas"]["LangChainAgentConfig"] | components["schemas"]["CustomAgentConfig"] | components["schemas"]["OpenClawAgentConfig"] | Record<string, never>;
+            config: components["schemas"]["OpenAIAgentConfig"] | components["schemas"]["AnthropicAgentConfig"] | components["schemas"]["LangChainAgentConfig"] | components["schemas"]["CustomAgentConfig"] | components["schemas"]["OpenClawAgentConfig"] | {
+                [key: string]: unknown;
+            };
             /** Config Version */
             config_version: number;
             /**
@@ -3486,7 +3490,9 @@ export interface components {
              * Config
              * @description Updated agent configuration payload. Can be a JSON object or JSON string.
              */
-            config: Record<string, never> | string;
+            config: {
+                [key: string]: unknown;
+            } | string;
         };
         /** AgentCreate */
         AgentCreate: {
@@ -3497,7 +3503,9 @@ export interface components {
             /** @default openai */
             type: components["schemas"]["AgentType"];
             /** Config */
-            config?: Record<string, never> | string | null;
+            config?: {
+                [key: string]: unknown;
+            } | string | null;
         };
         /** AgentDetailResponse */
         AgentDetailResponse: {
@@ -3514,7 +3522,9 @@ export interface components {
             /** Status */
             status: string;
             /** Config */
-            config: components["schemas"]["OpenAIAgentConfig"] | components["schemas"]["AnthropicAgentConfig"] | components["schemas"]["LangChainAgentConfig"] | components["schemas"]["CustomAgentConfig"] | components["schemas"]["OpenClawAgentConfig"] | Record<string, never> | null;
+            config: components["schemas"]["OpenAIAgentConfig"] | components["schemas"]["AnthropicAgentConfig"] | components["schemas"]["LangChainAgentConfig"] | components["schemas"]["CustomAgentConfig"] | components["schemas"]["OpenClawAgentConfig"] | {
+                [key: string]: unknown;
+            } | null;
             /**
              * Config Version
              * @default 1
@@ -3681,7 +3691,9 @@ export interface components {
              * Metadata
              * @default {}
              */
-            metadata: Record<string, never>;
+            metadata: {
+                [key: string]: unknown;
+            };
             /**
              * Capabilities
              * @default []
@@ -3732,7 +3744,9 @@ export interface components {
             /** Model */
             model?: string | null;
             /** Extra Metadata */
-            extra_metadata?: Record<string, never> | null;
+            extra_metadata?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Period Start
              * Format: date-time
@@ -3781,7 +3795,9 @@ export interface components {
             /** Model */
             model?: string | null;
             /** Extra Metadata */
-            extra_metadata?: Record<string, never> | null;
+            extra_metadata?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Period Start
              * Format: date-time
@@ -3810,7 +3826,9 @@ export interface components {
             /** Status */
             status: string;
             /** Config */
-            config: components["schemas"]["OpenAIAgentConfig"] | components["schemas"]["AnthropicAgentConfig"] | components["schemas"]["LangChainAgentConfig"] | components["schemas"]["CustomAgentConfig"] | components["schemas"]["OpenClawAgentConfig"] | Record<string, never> | null;
+            config: components["schemas"]["OpenAIAgentConfig"] | components["schemas"]["AnthropicAgentConfig"] | components["schemas"]["LangChainAgentConfig"] | components["schemas"]["CustomAgentConfig"] | components["schemas"]["OpenClawAgentConfig"] | {
+                [key: string]: unknown;
+            } | null;
             /**
              * Config Version
              * @default 1
@@ -3931,6 +3949,12 @@ export interface components {
             total: number;
             /** Unresolved Count */
             unresolved_count: number;
+            /** Skip */
+            skip: number;
+            /** Limit */
+            limit: number;
+            /** Has More */
+            has_more: boolean;
         };
         /** AlertResolveRequest */
         AlertResolveRequest: {
@@ -4091,7 +4115,9 @@ export interface components {
              * Payload
              * @default {}
              */
-            payload: Record<string, never>;
+            payload: {
+                [key: string]: unknown;
+            };
         };
         /**
          * ApprovalRequest
@@ -4110,7 +4136,9 @@ export interface components {
             /** Action Type */
             action_type: string;
             /** Payload */
-            payload?: Record<string, never>;
+            payload?: {
+                [key: string]: unknown;
+            };
             /** @default PENDING */
             status: components["schemas"]["ApprovalStatus"];
             /** Requester */
@@ -4141,7 +4169,9 @@ export interface components {
              * Tool Args
              * @description Tool arguments
              */
-            tool_args?: Record<string, never>;
+            tool_args?: {
+                [key: string]: unknown;
+            };
             /**
              * Agent Id
              * @description Agent ID
@@ -4296,7 +4326,9 @@ export interface components {
             /** Deployments */
             deployments?: components["schemas"]["DeploymentResponse"][];
             /** Config */
-            config: components["schemas"]["OpenClawAgentConfig"] | Record<string, never>;
+            config: components["schemas"]["OpenClawAgentConfig"] | {
+                [key: string]: unknown;
+            };
         };
         /** AssistantSessionResponse */
         AssistantSessionResponse: {
@@ -4385,7 +4417,9 @@ export interface components {
             /** Starter Prompt */
             starter_prompt: string;
             /** Default Config */
-            default_config: components["schemas"]["OpenClawAgentConfig"] | Record<string, never>;
+            default_config: components["schemas"]["OpenClawAgentConfig"] | {
+                [key: string]: unknown;
+            };
             /** Category */
             category?: string | null;
             /** Tags */
@@ -4433,7 +4467,9 @@ export interface components {
             /** Event Type */
             event_type: string;
             /** Payload */
-            payload: Record<string, never>;
+            payload: {
+                [key: string]: unknown;
+            };
             /**
              * Timestamp
              * Format: date-time
@@ -4566,7 +4602,9 @@ export interface components {
             /** Success */
             success: boolean;
             /** Result */
-            result?: Record<string, never> | null;
+            result?: {
+                [key: string]: unknown;
+            } | null;
             /** Error */
             error?: string | null;
             /** Completed At */
@@ -4579,7 +4617,9 @@ export interface components {
             /** Action */
             action: string;
             /** Parameters */
-            parameters: Record<string, never>;
+            parameters: {
+                [key: string]: unknown;
+            };
             /** Received At */
             received_at: string;
         };
@@ -4600,9 +4640,13 @@ export interface components {
             /** Checked At */
             checked_at: string;
             /** Summary */
-            summary: Record<string, never>;
+            summary: {
+                [key: string]: unknown;
+            };
             /** Results */
-            results: Record<string, never>[];
+            results: {
+                [key: string]: unknown;
+            }[];
         };
         /** CostSummaryResponse */
         CostSummaryResponse: {
@@ -4645,7 +4689,9 @@ export interface components {
              */
             ttl: number | null;
             /** Config */
-            config?: Record<string, never>;
+            config?: {
+                [key: string]: unknown;
+            };
         };
         /** CredentialResponse */
         CredentialResponse: {
@@ -4665,7 +4711,9 @@ export interface components {
             /** Expires At */
             expires_at?: string | null;
             /** Metadata */
-            metadata?: Record<string, never>;
+            metadata?: {
+                [key: string]: unknown;
+            };
         };
         /** CustomAgentConfig */
         CustomAgentConfig: {
@@ -4999,7 +5047,9 @@ export interface components {
             /** Sha256 */
             sha256?: string | null;
             /** Metadata */
-            metadata?: Record<string, never>;
+            metadata?: {
+                [key: string]: unknown;
+            };
             /**
              * Created At
              * Format: date-time
@@ -5021,7 +5071,9 @@ export interface components {
              */
             execution_mode: string;
             /** Parameters */
-            parameters?: Record<string, never>;
+            parameters?: {
+                [key: string]: unknown;
+            };
         };
         /** DocumentJobDispatchRequest */
         DocumentJobDispatchRequest: {
@@ -5038,7 +5090,9 @@ export interface components {
             /** Message */
             message?: string | null;
             /** Payload */
-            payload?: Record<string, never>;
+            payload?: {
+                [key: string]: unknown;
+            };
             /** Status */
             status?: string | null;
             /** Output Text */
@@ -5046,7 +5100,9 @@ export interface components {
             /** Error Message */
             error_message?: string | null;
             /** Result Summary */
-            result_summary?: Record<string, never> | null;
+            result_summary?: {
+                [key: string]: unknown;
+            } | null;
             /** Timestamp */
             timestamp?: string | null;
         };
@@ -5082,7 +5138,9 @@ export interface components {
             /** Execution Mode */
             execution_mode: string;
             /** Manifest */
-            manifest?: Record<string, never>;
+            manifest?: {
+                [key: string]: unknown;
+            };
             /** Artifacts */
             artifacts?: components["schemas"]["DocumentArtifactResponse"][];
         };
@@ -5105,9 +5163,13 @@ export interface components {
             /** Status */
             status: string;
             /** Parameters */
-            parameters?: Record<string, never>;
+            parameters?: {
+                [key: string]: unknown;
+            };
             /** Result Summary */
-            result_summary?: Record<string, never>;
+            result_summary?: {
+                [key: string]: unknown;
+            };
             /** Error Message */
             error_message?: string | null;
             /** Claimed By */
@@ -5253,7 +5315,9 @@ export interface components {
             uptime_seconds?: number | null;
             /** Components */
             components?: {
-                [key: string]: Record<string, never>;
+                [key: string]: {
+                    [key: string]: unknown;
+                };
             };
             /** Schema Repairs Applied */
             schema_repairs_applied?: string[];
@@ -5310,7 +5374,9 @@ export interface components {
              */
             model: string;
             /** Metadatas */
-            metadatas?: Record<string, never>[] | null;
+            metadatas?: {
+                [key: string]: unknown;
+            }[] | null;
             /** Ids */
             ids?: string[] | null;
         };
@@ -5360,7 +5426,9 @@ export interface components {
             /** Chain Id */
             chain_id: string;
             /** Parameters */
-            parameters?: Record<string, never>;
+            parameters?: {
+                [key: string]: unknown;
+            };
         };
         /** LeadCreate */
         LeadCreate: {
@@ -5453,7 +5521,9 @@ export interface components {
              * Metadata
              * @default {}
              */
-            metadata: Record<string, never>;
+            metadata: {
+                [key: string]: unknown;
+            };
             /** Timestamp */
             timestamp: string;
         };
@@ -5531,7 +5601,9 @@ export interface components {
              * Custom
              * @default {}
              */
-            custom: Record<string, never>;
+            custom: {
+                [key: string]: unknown;
+            };
             /** Timestamp */
             timestamp: string;
         };
@@ -5903,7 +5975,9 @@ export interface components {
              * Run Metadata
              * @description Additional metadata
              */
-            run_metadata?: Record<string, never>;
+            run_metadata?: {
+                [key: string]: unknown;
+            };
         };
         /**
          * MutxRunDetailResponse
@@ -5970,7 +6044,9 @@ export interface components {
              * Run Metadata
              * @default {}
              */
-            run_metadata: Record<string, never>;
+            run_metadata: {
+                [key: string]: unknown;
+            };
             /**
              * Created At
              * Format: date-time
@@ -6067,7 +6143,9 @@ export interface components {
              * Run Metadata
              * @default {}
              */
-            run_metadata: Record<string, never>;
+            run_metadata: {
+                [key: string]: unknown;
+            };
             /**
              * Created At
              * Format: date-time
@@ -6155,7 +6233,9 @@ export interface components {
              * Step Metadata
              * @description Extension point for step-specific data
              */
-            step_metadata?: Record<string, never>;
+            step_metadata?: {
+                [key: string]: unknown;
+            };
         };
         /**
          * MutxStepBatchResponse
@@ -6239,7 +6319,9 @@ export interface components {
              * Step Metadata
              * @description Additional metadata
              */
-            step_metadata?: Record<string, never>;
+            step_metadata?: {
+                [key: string]: unknown;
+            };
         };
         /**
          * MutxStepType
@@ -6276,7 +6358,9 @@ export interface components {
             /** Action Type */
             action_type?: string | null;
             /** Import Source */
-            import_source?: Record<string, never>;
+            import_source?: {
+                [key: string]: unknown;
+            };
             /** Current Step */
             current_step: string;
             /** Completed Steps */
@@ -6329,7 +6413,9 @@ export interface components {
             /** Step */
             step?: string | null;
             /** Payload */
-            payload?: Record<string, never>;
+            payload?: {
+                [key: string]: unknown;
+            };
         };
         /** OpenAIAgentConfig */
         OpenAIAgentConfig: {
@@ -6402,7 +6488,9 @@ export interface components {
             /** Wakeups */
             wakeups?: components["schemas"]["OpenClawWakeupConfig"][];
             /** Metadata */
-            metadata?: Record<string, never>;
+            metadata?: {
+                [key: string]: unknown;
+            };
             gateway?: components["schemas"]["OpenClawGatewayConfig"];
         };
         /** OpenClawChannelConfig */
@@ -6468,7 +6556,9 @@ export interface components {
             has_more: boolean;
         };
         /** PicoProgressPayload */
-        PicoProgressPayload: Record<string, never>;
+        PicoProgressPayload: {
+            [key: string]: unknown;
+        };
         /** PicoTutorCommand */
         PicoTutorCommand: {
             /** Label */
@@ -6543,7 +6633,9 @@ export interface components {
             /** Lessonslug */
             lessonSlug?: string | null;
             /** Progress */
-            progress?: Record<string, never> | null;
+            progress?: {
+                [key: string]: unknown;
+            } | null;
             setupContext?: components["schemas"]["PicoTutorSetupContext"] | null;
         };
         /** PicoTutorResponse */
@@ -6594,11 +6686,17 @@ export interface components {
         /** PicoTutorSetupContext */
         PicoTutorSetupContext: {
             /** Onboarding */
-            onboarding?: Record<string, never> | null;
+            onboarding?: {
+                [key: string]: unknown;
+            } | null;
             /** Runtime */
-            runtime?: Record<string, never> | null;
+            runtime?: {
+                [key: string]: unknown;
+            } | null;
             /** Currentsurface */
             currentSurface?: string | null;
+        } & {
+            [key: string]: unknown;
         };
         /** PicoTutorSource */
         PicoTutorSource: {
@@ -6704,7 +6802,9 @@ export interface components {
             /** Sha256 */
             sha256?: string | null;
             /** Metadata */
-            metadata?: Record<string, never>;
+            metadata?: {
+                [key: string]: unknown;
+            };
             /**
              * Created At
              * Format: date-time
@@ -6726,7 +6826,9 @@ export interface components {
              */
             execution_mode: string;
             /** Parameters */
-            parameters?: Record<string, never>;
+            parameters?: {
+                [key: string]: unknown;
+            };
         };
         /** ReasoningJobDispatchRequest */
         ReasoningJobDispatchRequest: {
@@ -6743,7 +6845,9 @@ export interface components {
             /** Message */
             message?: string | null;
             /** Payload */
-            payload?: Record<string, never>;
+            payload?: {
+                [key: string]: unknown;
+            };
             /** Status */
             status?: string | null;
             /** Output Text */
@@ -6751,7 +6855,9 @@ export interface components {
             /** Error Message */
             error_message?: string | null;
             /** Result Summary */
-            result_summary?: Record<string, never> | null;
+            result_summary?: {
+                [key: string]: unknown;
+            } | null;
             /** Timestamp */
             timestamp?: string | null;
         };
@@ -6787,7 +6893,9 @@ export interface components {
             /** Execution Mode */
             execution_mode: string;
             /** Manifest */
-            manifest?: Record<string, never>;
+            manifest?: {
+                [key: string]: unknown;
+            };
             /** Artifacts */
             artifacts?: components["schemas"]["ReasoningArtifactResponse"][];
         };
@@ -6810,9 +6918,13 @@ export interface components {
             /** Status */
             status: string;
             /** Parameters */
-            parameters?: Record<string, never>;
+            parameters?: {
+                [key: string]: unknown;
+            };
             /** Result Summary */
-            result_summary?: Record<string, never>;
+            result_summary?: {
+                [key: string]: unknown;
+            };
             /** Error Message */
             error_message?: string | null;
             /** Claimed By */
@@ -6995,7 +7107,9 @@ export interface components {
             /** Error Message */
             error_message?: string | null;
             /** Metadata */
-            metadata?: Record<string, never>;
+            metadata?: {
+                [key: string]: unknown;
+            };
             /** Started At */
             started_at?: string | null;
             /** Completed At */
@@ -7021,7 +7135,9 @@ export interface components {
             /** Error Message */
             error_message: string | null;
             /** Metadata */
-            metadata: Record<string, never>;
+            metadata: {
+                [key: string]: unknown;
+            };
             /**
              * Started At
              * Format: date-time
@@ -7085,7 +7201,9 @@ export interface components {
             /** Error Message */
             error_message: string | null;
             /** Metadata */
-            metadata: Record<string, never>;
+            metadata: {
+                [key: string]: unknown;
+            };
             /**
              * Started At
              * Format: date-time
@@ -7121,7 +7239,9 @@ export interface components {
             /** Message */
             message?: string | null;
             /** Payload */
-            payload?: Record<string, never>;
+            payload?: {
+                [key: string]: unknown;
+            };
             /** Timestamp */
             timestamp?: string | null;
         };
@@ -7160,7 +7280,9 @@ export interface components {
             /** Message */
             message: string | null;
             /** Payload */
-            payload: Record<string, never>;
+            payload: {
+                [key: string]: unknown;
+            };
             /** Sequence */
             sequence: number;
             /**
@@ -7235,7 +7357,9 @@ export interface components {
             /** Last Action Type */
             last_action_type?: string | null;
             /** Import Source */
-            import_source?: Record<string, never>;
+            import_source?: {
+                [key: string]: unknown;
+            };
             /** Version */
             version?: string | null;
             /**
@@ -7244,7 +7368,9 @@ export interface components {
              */
             status: string;
             /** Gateway */
-            gateway?: Record<string, never>;
+            gateway?: {
+                [key: string]: unknown;
+            };
             /** Gateway Url */
             gateway_url?: string | null;
             /** Gateway Port */
@@ -7259,9 +7385,13 @@ export interface components {
              */
             binding_count: number;
             /** Current Binding */
-            current_binding?: Record<string, never> | null;
+            current_binding?: {
+                [key: string]: unknown;
+            } | null;
             /** Bindings */
-            bindings?: Record<string, never>[];
+            bindings?: {
+                [key: string]: unknown;
+            }[];
             /**
              * Observed Source
              * @default local
@@ -7344,7 +7474,9 @@ export interface components {
             /** Last Action Type */
             last_action_type?: string | null;
             /** Import Source */
-            import_source?: Record<string, never>;
+            import_source?: {
+                [key: string]: unknown;
+            };
             /** Version */
             version?: string | null;
             /**
@@ -7353,7 +7485,9 @@ export interface components {
              */
             status: string;
             /** Gateway */
-            gateway?: Record<string, never>;
+            gateway?: {
+                [key: string]: unknown;
+            };
             /** Gateway Url */
             gateway_url?: string | null;
             /** Gateway Port */
@@ -7368,9 +7502,13 @@ export interface components {
              */
             binding_count: number;
             /** Current Binding */
-            current_binding?: Record<string, never> | null;
+            current_binding?: {
+                [key: string]: unknown;
+            } | null;
             /** Bindings */
-            bindings?: Record<string, never>[];
+            bindings?: {
+                [key: string]: unknown;
+            }[];
             /**
              * Observed Source
              * @default local
@@ -7423,7 +7561,9 @@ export interface components {
              */
             task_type: string;
             /** Payload */
-            payload?: Record<string, never>;
+            payload?: {
+                [key: string]: unknown;
+            };
         };
         /** SchedulerTaskResponse */
         SchedulerTaskResponse: {
@@ -7442,7 +7582,9 @@ export interface components {
             /** Task Type */
             task_type: string;
             /** Payload */
-            payload: Record<string, never>;
+            payload: {
+                [key: string]: unknown;
+            };
             /** Last Run */
             last_run: number | null;
             /** Next Run */
@@ -7469,7 +7611,9 @@ export interface components {
             /** Task Type */
             task_type?: string | null;
             /** Payload */
-            payload?: Record<string, never> | null;
+            payload?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * SearchRequest
@@ -7522,7 +7666,9 @@ export interface components {
         /** SessionListResponse */
         SessionListResponse: {
             /** Sessions */
-            sessions: Record<string, never>[];
+            sessions: {
+                [key: string]: unknown;
+            }[];
         };
         /** StarterDeploymentCreate */
         StarterDeploymentCreate: {
@@ -7551,7 +7697,9 @@ export interface components {
                 [key: string]: components["schemas"]["OpenClawChannelConfig"];
             };
             /** Runtime Metadata */
-            runtime_metadata?: Record<string, never>;
+            runtime_metadata?: {
+                [key: string]: unknown;
+            };
         };
         /** StarterDeploymentResponse */
         StarterDeploymentResponse: {
@@ -7671,6 +7819,12 @@ export interface components {
             items: components["schemas"]["SwarmResponse"][];
             /** Total */
             total: number;
+            /** Skip */
+            skip: number;
+            /** Limit */
+            limit: number;
+            /** Has More */
+            has_more: boolean;
         };
         /** SwarmResponse */
         SwarmResponse: {
@@ -7837,7 +7991,9 @@ export interface components {
              * Metadata
              * @description Additional event metadata
              */
-            metadata?: Record<string, never> | null;
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * UsageEventListResponse
@@ -7852,6 +8008,8 @@ export interface components {
             skip: number;
             /** Limit */
             limit: number;
+            /** Has More */
+            has_more: boolean;
         };
         /**
          * UsageEventResponse
@@ -7887,7 +8045,9 @@ export interface components {
              * Metadata
              * @description Deserialize event_metadata JSON string to dict
              */
-            readonly metadata: Record<string, never> | null;
+            readonly metadata: {
+                [key: string]: unknown;
+            } | null;
         };
         /** UserResponse */
         UserResponse: {
@@ -8323,7 +8483,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -8356,7 +8518,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -12077,7 +12241,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -13204,7 +13370,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -13239,7 +13407,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -13534,7 +13704,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2,6 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "mutx.dev API",
+    "description": "API for the mutx platform",
     "version": "1.0.0"
   },
   "paths": {
@@ -22,8 +23,7 @@
               }
             }
           }
-        },
-        "security": []
+        }
       }
     },
     "/v1/agents": {
@@ -432,6 +432,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Deploy Agent V1 Agents  Agent Id  Deploy Post"
                 }
               }
@@ -492,6 +493,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Stop Agent V1 Agents  Agent Id  Stop Post"
                 }
               }
@@ -2942,8 +2944,7 @@
               }
             }
           }
-        },
-        "security": []
+        }
       }
     },
     "/v1/auth/login": {
@@ -2984,8 +2985,7 @@
               }
             }
           }
-        },
-        "security": []
+        }
       }
     },
     "/v1/auth/local-bootstrap": {
@@ -3222,8 +3222,7 @@
               }
             }
           }
-        },
-        "security": []
+        }
       }
     },
     "/v1/auth/reset-password": {
@@ -3265,8 +3264,7 @@
               }
             }
           }
-        },
-        "security": []
+        }
       }
     },
     "/v1/auth/verify-email": {
@@ -3308,8 +3306,7 @@
               }
             }
           }
-        },
-        "security": []
+        }
       }
     },
     "/v1/auth/resend-verification": {
@@ -3351,8 +3348,7 @@
               }
             }
           }
-        },
-        "security": []
+        }
       }
     },
     "/v1/auth/oauth/{provider}/authorize": {
@@ -7680,6 +7676,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "additionalProperties": true,
                 "title": "Status Update"
               }
             }
@@ -9870,6 +9867,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Pico Progress V1 Pico Progress Get"
                 }
               }
@@ -9928,6 +9926,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Pico Progress Update V1 Pico Progress Post"
                 }
               }
@@ -10409,6 +10408,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Get Scheduler V1 Scheduler Get"
                 }
               }
@@ -13164,8 +13164,7 @@
               }
             }
           }
-        },
-        "security": []
+        }
       }
     },
     "/ready": {
@@ -13181,8 +13180,7 @@
               }
             }
           }
-        },
-        "security": []
+        }
       }
     },
     "/": {
@@ -13369,6 +13367,7 @@
             "description": "Name of the tool"
           },
           "tool_args": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Tool Args",
             "description": "Tool arguments"
@@ -13501,6 +13500,7 @@
                 "$ref": "#/components/schemas/OpenClawAgentConfig"
               },
               {
+                "additionalProperties": true,
                 "type": "object"
               }
             ],
@@ -13532,6 +13532,7 @@
           "config": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -13575,6 +13576,7 @@
           "config": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -13640,6 +13642,7 @@
                 "$ref": "#/components/schemas/OpenClawAgentConfig"
               },
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -13998,6 +14001,7 @@
             "default": ""
           },
           "metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata",
             "default": {}
@@ -14120,6 +14124,7 @@
           "extra_metadata": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -14232,6 +14237,7 @@
           "extra_metadata": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -14319,6 +14325,7 @@
                 "$ref": "#/components/schemas/OpenClawAgentConfig"
               },
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -14579,13 +14586,28 @@
           "unresolved_count": {
             "type": "integer",
             "title": "Unresolved Count"
+          },
+          "skip": {
+            "type": "integer",
+            "title": "Skip"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
           }
         },
         "type": "object",
         "required": [
           "items",
           "total",
-          "unresolved_count"
+          "unresolved_count",
+          "skip",
+          "limit",
+          "has_more"
         ],
         "title": "AlertListResponse"
       },
@@ -14890,6 +14912,7 @@
             "title": "Action Type"
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload",
             "default": {}
@@ -14924,6 +14947,7 @@
             "title": "Action Type"
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -14993,6 +15017,7 @@
             "description": "Name of the tool"
           },
           "tool_args": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Tool Args",
             "description": "Tool arguments"
@@ -15366,6 +15391,7 @@
                 "$ref": "#/components/schemas/OpenClawAgentConfig"
               },
               {
+                "additionalProperties": true,
                 "type": "object"
               }
             ],
@@ -15619,6 +15645,7 @@
                 "$ref": "#/components/schemas/OpenClawAgentConfig"
               },
               {
+                "additionalProperties": true,
                 "type": "object"
               }
             ],
@@ -15787,6 +15814,7 @@
             "title": "Event Type"
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -16098,6 +16126,7 @@
           "result": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -16142,6 +16171,7 @@
             "title": "Action"
           },
           "parameters": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Parameters"
           },
@@ -16190,11 +16220,13 @@
             "title": "Checked At"
           },
           "summary": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Summary"
           },
           "results": {
             "items": {
+              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -16290,6 +16322,7 @@
             "default": 900
           },
           "config": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Config"
           }
@@ -16344,6 +16377,7 @@
             "title": "Expires At"
           },
           "metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           }
@@ -17129,6 +17163,7 @@
             "title": "Sha256"
           },
           "metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -17172,6 +17207,7 @@
             "default": "managed"
           },
           "parameters": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Parameters"
           }
@@ -17216,6 +17252,7 @@
             "title": "Message"
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -17256,6 +17293,7 @@
           "result_summary": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -17368,6 +17406,7 @@
             "title": "Execution Mode"
           },
           "manifest": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Manifest"
           },
@@ -17412,10 +17451,12 @@
             "title": "Status"
           },
           "parameters": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Parameters"
           },
           "result_summary": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Result Summary"
           },
@@ -17767,6 +17808,7 @@
           },
           "components": {
             "additionalProperties": {
+              "additionalProperties": true,
               "type": "object"
             },
             "type": "object",
@@ -17899,6 +17941,7 @@
             "anyOf": [
               {
                 "items": {
+                  "additionalProperties": true,
                   "type": "object"
                 },
                 "type": "array"
@@ -18034,6 +18077,7 @@
             "title": "Chain Id"
           },
           "parameters": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Parameters"
           }
@@ -18309,6 +18353,7 @@
             "title": "Message"
           },
           "metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata",
             "default": {}
@@ -18473,6 +18518,7 @@
             "default": 0
           },
           "custom": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Custom",
             "default": {}
@@ -19353,6 +19399,7 @@
             "description": "Tags"
           },
           "run_metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Run Metadata",
             "description": "Additional metadata"
@@ -19599,6 +19646,7 @@
             "default": []
           },
           "run_metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Run Metadata",
             "default": {}
@@ -19921,6 +19969,7 @@
             "default": []
           },
           "run_metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Run Metadata",
             "default": {}
@@ -20099,6 +20148,7 @@
             "description": "Total tokens consumed by this step (input + output)"
           },
           "step_metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Step Metadata",
             "description": "Extension point for step-specific data"
@@ -20279,6 +20329,7 @@
             "description": "Tokens consumed"
           },
           "step_metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Step Metadata",
             "description": "Additional metadata"
@@ -20367,6 +20418,7 @@
             "title": "Action Type"
           },
           "import_source": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Import Source"
           },
@@ -20537,6 +20589,7 @@
             "title": "Step"
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           }
@@ -20714,6 +20767,7 @@
             "title": "Wakeups"
           },
           "metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -20875,6 +20929,7 @@
       },
       "PicoProgressPayload": {
         "properties": {},
+        "additionalProperties": true,
         "type": "object",
         "title": "PicoProgressPayload"
       },
@@ -21078,6 +21133,7 @@
           "progress": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21219,6 +21275,7 @@
           "onboarding": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21230,6 +21287,7 @@
           "runtime": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21250,6 +21308,7 @@
             "title": "Currentsurface"
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "title": "PicoTutorSetupContext"
       },
@@ -21558,6 +21617,7 @@
             "title": "Sha256"
           },
           "metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -21601,6 +21661,7 @@
             "default": "managed"
           },
           "parameters": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Parameters"
           }
@@ -21645,6 +21706,7 @@
             "title": "Message"
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -21685,6 +21747,7 @@
           "result_summary": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21797,6 +21860,7 @@
             "title": "Execution Mode"
           },
           "manifest": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Manifest"
           },
@@ -21841,10 +21905,12 @@
             "title": "Status"
           },
           "parameters": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Parameters"
           },
           "result_summary": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Result Summary"
           },
@@ -22277,6 +22343,7 @@
             "title": "Error Message"
           },
           "metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -22375,6 +22442,7 @@
             "title": "Error Message"
           },
           "metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -22592,6 +22660,7 @@
             "title": "Error Message"
           },
           "metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -22713,6 +22782,7 @@
             "title": "Message"
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -22810,6 +22880,7 @@
             "title": "Message"
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -23041,6 +23112,7 @@
             "title": "Last Action Type"
           },
           "import_source": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Import Source"
           },
@@ -23063,6 +23135,7 @@
             "default": "unknown"
           },
           "gateway": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Gateway"
           },
@@ -23121,6 +23194,7 @@
           "current_binding": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -23131,6 +23205,7 @@
           },
           "bindings": {
             "items": {
+              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -23362,6 +23437,7 @@
             "title": "Last Action Type"
           },
           "import_source": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Import Source"
           },
@@ -23384,6 +23460,7 @@
             "default": "unknown"
           },
           "gateway": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Gateway"
           },
@@ -23442,6 +23519,7 @@
           "current_binding": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -23452,6 +23530,7 @@
           },
           "bindings": {
             "items": {
+              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -23550,6 +23629,7 @@
             "default": "log"
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           }
@@ -23612,6 +23692,7 @@
             "title": "Task Type"
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -23745,6 +23826,7 @@
           "payload": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -23873,6 +23955,7 @@
         "properties": {
           "sessions": {
             "items": {
+              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -23967,6 +24050,7 @@
             "title": "Channels"
           },
           "runtime_metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Runtime Metadata"
           }
@@ -24280,12 +24364,27 @@
           "total": {
             "type": "integer",
             "title": "Total"
+          },
+          "skip": {
+            "type": "integer",
+            "title": "Skip"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
           }
         },
         "type": "object",
         "required": [
           "items",
-          "total"
+          "total",
+          "skip",
+          "limit",
+          "has_more"
         ],
         "title": "SwarmListResponse"
       },
@@ -24654,6 +24753,7 @@
           "metadata": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -24691,6 +24791,10 @@
           "limit": {
             "type": "integer",
             "title": "Limit"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
           }
         },
         "type": "object",
@@ -24698,7 +24802,8 @@
           "items",
           "total",
           "skip",
-          "limit"
+          "limit",
+          "has_more"
         ],
         "title": "UsageEventListResponse",
         "description": "Paginated response for usage events"
@@ -24764,6 +24869,7 @@
           "metadata": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -25208,19 +25314,6 @@
         "type": "object",
         "title": "WebhookUpdate"
       }
-    },
-    "securitySchemes": {
-      "BearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "JWT",
-        "description": "JWT bearer token or API key. Example: 'Bearer eyJ...'"
-      }
     }
-  },
-  "security": [
-    {
-      "BearerAuth": []
-    }
-  ]
+  }
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2,7 +2,6 @@
   "openapi": "3.1.0",
   "info": {
     "title": "mutx.dev API",
-    "description": "API for the mutx platform",
     "version": "1.0.0"
   },
   "paths": {
@@ -23,7 +22,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/v1/agents": {
@@ -432,7 +432,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Deploy Agent V1 Agents  Agent Id  Deploy Post"
                 }
               }
@@ -493,7 +492,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Stop Agent V1 Agents  Agent Id  Stop Post"
                 }
               }
@@ -2944,7 +2942,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/v1/auth/login": {
@@ -2985,7 +2984,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/v1/auth/local-bootstrap": {
@@ -3222,7 +3222,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/v1/auth/reset-password": {
@@ -3264,7 +3265,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/v1/auth/verify-email": {
@@ -3306,7 +3308,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/v1/auth/resend-verification": {
@@ -3348,7 +3351,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/v1/auth/oauth/{provider}/authorize": {
@@ -7676,7 +7680,6 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "additionalProperties": true,
                 "title": "Status Update"
               }
             }
@@ -9867,7 +9870,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Pico Progress V1 Pico Progress Get"
                 }
               }
@@ -9926,7 +9928,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Pico Progress Update V1 Pico Progress Post"
                 }
               }
@@ -10408,7 +10409,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Scheduler V1 Scheduler Get"
                 }
               }
@@ -13164,7 +13164,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/ready": {
@@ -13180,7 +13181,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/": {
@@ -13367,7 +13369,6 @@
             "description": "Name of the tool"
           },
           "tool_args": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Tool Args",
             "description": "Tool arguments"
@@ -13500,7 +13501,6 @@
                 "$ref": "#/components/schemas/OpenClawAgentConfig"
               },
               {
-                "additionalProperties": true,
                 "type": "object"
               }
             ],
@@ -13532,7 +13532,6 @@
           "config": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -13576,7 +13575,6 @@
           "config": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -13642,7 +13640,6 @@
                 "$ref": "#/components/schemas/OpenClawAgentConfig"
               },
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -14001,7 +13998,6 @@
             "default": ""
           },
           "metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Metadata",
             "default": {}
@@ -14124,7 +14120,6 @@
           "extra_metadata": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -14237,7 +14232,6 @@
           "extra_metadata": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -14325,7 +14319,6 @@
                 "$ref": "#/components/schemas/OpenClawAgentConfig"
               },
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -14912,7 +14905,6 @@
             "title": "Action Type"
           },
           "payload": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Payload",
             "default": {}
@@ -14947,7 +14939,6 @@
             "title": "Action Type"
           },
           "payload": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -15017,7 +15008,6 @@
             "description": "Name of the tool"
           },
           "tool_args": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Tool Args",
             "description": "Tool arguments"
@@ -15391,7 +15381,6 @@
                 "$ref": "#/components/schemas/OpenClawAgentConfig"
               },
               {
-                "additionalProperties": true,
                 "type": "object"
               }
             ],
@@ -15645,7 +15634,6 @@
                 "$ref": "#/components/schemas/OpenClawAgentConfig"
               },
               {
-                "additionalProperties": true,
                 "type": "object"
               }
             ],
@@ -15814,7 +15802,6 @@
             "title": "Event Type"
           },
           "payload": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -16126,7 +16113,6 @@
           "result": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -16171,7 +16157,6 @@
             "title": "Action"
           },
           "parameters": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Parameters"
           },
@@ -16220,13 +16205,11 @@
             "title": "Checked At"
           },
           "summary": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Summary"
           },
           "results": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -16322,7 +16305,6 @@
             "default": 900
           },
           "config": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Config"
           }
@@ -16377,7 +16359,6 @@
             "title": "Expires At"
           },
           "metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           }
@@ -17163,7 +17144,6 @@
             "title": "Sha256"
           },
           "metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -17207,7 +17187,6 @@
             "default": "managed"
           },
           "parameters": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Parameters"
           }
@@ -17252,7 +17231,6 @@
             "title": "Message"
           },
           "payload": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -17293,7 +17271,6 @@
           "result_summary": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -17406,7 +17383,6 @@
             "title": "Execution Mode"
           },
           "manifest": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Manifest"
           },
@@ -17451,12 +17427,10 @@
             "title": "Status"
           },
           "parameters": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Parameters"
           },
           "result_summary": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Result Summary"
           },
@@ -17808,7 +17782,6 @@
           },
           "components": {
             "additionalProperties": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "object",
@@ -17941,7 +17914,6 @@
             "anyOf": [
               {
                 "items": {
-                  "additionalProperties": true,
                   "type": "object"
                 },
                 "type": "array"
@@ -18077,7 +18049,6 @@
             "title": "Chain Id"
           },
           "parameters": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Parameters"
           }
@@ -18353,7 +18324,6 @@
             "title": "Message"
           },
           "metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Metadata",
             "default": {}
@@ -18518,7 +18488,6 @@
             "default": 0
           },
           "custom": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Custom",
             "default": {}
@@ -19399,7 +19368,6 @@
             "description": "Tags"
           },
           "run_metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Run Metadata",
             "description": "Additional metadata"
@@ -19646,7 +19614,6 @@
             "default": []
           },
           "run_metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Run Metadata",
             "default": {}
@@ -19969,7 +19936,6 @@
             "default": []
           },
           "run_metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Run Metadata",
             "default": {}
@@ -20148,7 +20114,6 @@
             "description": "Total tokens consumed by this step (input + output)"
           },
           "step_metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Step Metadata",
             "description": "Extension point for step-specific data"
@@ -20329,7 +20294,6 @@
             "description": "Tokens consumed"
           },
           "step_metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Step Metadata",
             "description": "Additional metadata"
@@ -20418,7 +20382,6 @@
             "title": "Action Type"
           },
           "import_source": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Import Source"
           },
@@ -20589,7 +20552,6 @@
             "title": "Step"
           },
           "payload": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           }
@@ -20767,7 +20729,6 @@
             "title": "Wakeups"
           },
           "metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -20929,7 +20890,6 @@
       },
       "PicoProgressPayload": {
         "properties": {},
-        "additionalProperties": true,
         "type": "object",
         "title": "PicoProgressPayload"
       },
@@ -21133,7 +21093,6 @@
           "progress": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21275,7 +21234,6 @@
           "onboarding": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21287,7 +21245,6 @@
           "runtime": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21308,7 +21265,6 @@
             "title": "Currentsurface"
           }
         },
-        "additionalProperties": true,
         "type": "object",
         "title": "PicoTutorSetupContext"
       },
@@ -21617,7 +21573,6 @@
             "title": "Sha256"
           },
           "metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -21661,7 +21616,6 @@
             "default": "managed"
           },
           "parameters": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Parameters"
           }
@@ -21706,7 +21660,6 @@
             "title": "Message"
           },
           "payload": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -21747,7 +21700,6 @@
           "result_summary": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21860,7 +21812,6 @@
             "title": "Execution Mode"
           },
           "manifest": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Manifest"
           },
@@ -21905,12 +21856,10 @@
             "title": "Status"
           },
           "parameters": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Parameters"
           },
           "result_summary": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Result Summary"
           },
@@ -22343,7 +22292,6 @@
             "title": "Error Message"
           },
           "metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -22442,7 +22390,6 @@
             "title": "Error Message"
           },
           "metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -22660,7 +22607,6 @@
             "title": "Error Message"
           },
           "metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -22782,7 +22728,6 @@
             "title": "Message"
           },
           "payload": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -22880,7 +22825,6 @@
             "title": "Message"
           },
           "payload": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -23112,7 +23056,6 @@
             "title": "Last Action Type"
           },
           "import_source": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Import Source"
           },
@@ -23135,7 +23078,6 @@
             "default": "unknown"
           },
           "gateway": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Gateway"
           },
@@ -23194,7 +23136,6 @@
           "current_binding": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -23205,7 +23146,6 @@
           },
           "bindings": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -23437,7 +23377,6 @@
             "title": "Last Action Type"
           },
           "import_source": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Import Source"
           },
@@ -23460,7 +23399,6 @@
             "default": "unknown"
           },
           "gateway": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Gateway"
           },
@@ -23519,7 +23457,6 @@
           "current_binding": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -23530,7 +23467,6 @@
           },
           "bindings": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -23629,7 +23565,6 @@
             "default": "log"
           },
           "payload": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           }
@@ -23692,7 +23627,6 @@
             "title": "Task Type"
           },
           "payload": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           },
@@ -23826,7 +23760,6 @@
           "payload": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -23955,7 +23888,6 @@
         "properties": {
           "sessions": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -24050,7 +23982,6 @@
             "title": "Channels"
           },
           "runtime_metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Runtime Metadata"
           }
@@ -24753,7 +24684,6 @@
           "metadata": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -24869,7 +24799,6 @@
           "metadata": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -25314,6 +25243,19 @@
         "type": "object",
         "title": "WebhookUpdate"
       }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "JWT bearer token or API key. Example: 'Bearer eyJ...'"
+      }
     }
-  }
+  },
+  "security": [
+    {
+      "BearerAuth": []
+    }
+  ]
 }

--- a/src/api/routes/monitoring.py
+++ b/src/api/routes/monitoring.py
@@ -37,6 +37,9 @@ class AlertListResponse(BaseModel):
     items: list[AlertResponse]
     total: int
     unresolved_count: int
+    skip: int
+    limit: int
+    has_more: bool
 
 
 class AlertResolveRequest(BaseModel):
@@ -139,6 +142,9 @@ async def list_alerts(
         items=[_serialize_alert(a) for a in alerts],
         total=total,
         unresolved_count=unresolved_count,
+        skip=skip,
+        limit=limit,
+        has_more=total > skip + len(alerts),
     )
 
 

--- a/src/api/routes/swarms.py
+++ b/src/api/routes/swarms.py
@@ -73,6 +73,9 @@ class SwarmResponse(BaseModel):
 class SwarmListResponse(BaseModel):
     items: list[SwarmResponse]
     total: int
+    skip: int
+    limit: int
+    has_more: bool
 
 
 @router.get("/blueprints", response_model=list[SwarmBlueprintResponse])
@@ -162,6 +165,9 @@ async def list_swarms(
     return SwarmListResponse(
         items=[await _serialize_swarm(s, db) for s in swarms],
         total=total,
+        skip=skip,
+        limit=limit,
+        has_more=total > skip + len(swarms),
     )
 
 

--- a/src/api/routes/usage.py
+++ b/src/api/routes/usage.py
@@ -26,6 +26,7 @@ class UsageEventListResponse(BaseModel):
     total: int
     skip: int
     limit: int
+    has_more: bool
 
 
 @router.post("/events", response_model=UsageEventResponse, status_code=201)
@@ -83,6 +84,7 @@ async def list_usage_events(
         total=total,
         skip=skip,
         limit=limit,
+        has_more=total > skip + len(events),
     )
 
 

--- a/tests/api/test_swarms.py
+++ b/tests/api/test_swarms.py
@@ -19,6 +19,8 @@ class TestListSwarms:
         # Response is wrapped in {"items": [...], "total": N}
         assert data["items"] == []
         assert data["total"] == 0
+        assert "has_more" in data
+        assert data["has_more"] is False
 
     @pytest.mark.asyncio
     async def test_list_swarms_after_create(self, client: AsyncClient, test_agent):

--- a/tests/api/test_usage.py
+++ b/tests/api/test_usage.py
@@ -105,6 +105,8 @@ class TestListUsageEvents:
         data = response.json()
         assert "items" in data
         assert "total" in data
+        assert "has_more" in data
+        assert data["has_more"] is False
         assert len(data["items"]) == 0
 
     @pytest.mark.asyncio
@@ -185,12 +187,14 @@ class TestListUsageEvents:
         data = response.json()
         assert len(data["items"]) == 5
         assert data["limit"] == 5
+        assert data["has_more"] is True
 
         # Test offset
         response = await client.get("/v1/usage/events?skip=10&limit=5")
         assert response.status_code == 200
         data = response.json()
         assert len(data["items"]) == 5
+        assert data["has_more"] is False
 
     @pytest.mark.asyncio
     async def test_list_usage_events_requires_auth(self, client_no_auth: AsyncClient):


### PR DESCRIPTION
## Summary

Three inline route schemas were missing the `has_more` field despite accepting `skip`/`limit` pagination parameters. Clients had no way to determine if more pages existed.

This adds `has_more: bool` (and `skip`/`limit` where missing) to:

| Schema | Route File |
|--------|-----------|
| `UsageEventListResponse` | `usage.py` |
| `AlertListResponse` | `monitoring.py` |
| `SwarmListResponse` | `swarms.py` |

## Pattern

Follows the existing convention: `has_more = total > skip + len(items)`. Complements the 11 schemas fixed in #3668.

## Files Changed

- `src/api/routes/usage.py` — add `has_more` field + compute in constructor
- `src/api/routes/monitoring.py` — add `skip`, `limit`, `has_more` fields + compute in constructor
- `src/api/routes/swarms.py` — add `skip`, `limit`, `has_more` fields + compute in constructor
- `tests/api/test_usage.py` — assert `has_more` in empty + paginated cases
- `tests/api/test_swarms.py` — assert `has_more` in empty case
- `docs/api/openapi.json` — regenerated
- `app/types/api.ts` — regenerated

## Validation

- `ruff check` — all checks passed
- `.venv/bin/python -m pytest tests/api/test_usage.py tests/api/test_swarms.py tests/api/test_monitoring.py` — 32 passed
- `npm run build` — frontend builds clean
- `npm run generate-types` — types regenerated