### PR TITLE
fix(api): replace response_model=dict with typed Pydantic models on 3 endpoints

### DIFF
--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -3501,6 +3501,16 @@ export interface components {
             /** Config */
             config?: Record<string, never> | string | null;
         };
+        /** AgentDeployResponse */
+        AgentDeployResponse: {
+            /**
+             * Deployment Id
+             * Format: uuid
+             */
+            deployment_id: string;
+            /** Status */
+            status: string;
+        };
         /** AgentDetailResponse */
         AgentDetailResponse: {
             /**
@@ -3873,6 +3883,11 @@ export interface components {
             node_id?: string | null;
             /** Error Message */
             error_message?: string | null;
+        };
+        /** AgentStopResponse */
+        AgentStopResponse: {
+            /** Status */
+            status: string;
         };
         /**
          * AgentType
@@ -7442,6 +7457,13 @@ export interface components {
              */
             expires_in: number;
         };
+        /** SchedulerListResponse */
+        SchedulerListResponse: {
+            /** Tasks */
+            tasks: components["schemas"]["SchedulerTaskResponse"][];
+            /** Total */
+            total: number;
+        };
         /** SchedulerTaskCreate */
         SchedulerTaskCreate: {
             /** Name */
@@ -8382,7 +8404,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["AgentDeployResponse"];
                 };
             };
             /** @description Validation Error */
@@ -8415,7 +8437,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["AgentStopResponse"];
                 };
             };
             /** @description Validation Error */
@@ -13593,7 +13615,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["SchedulerListResponse"];
                 };
             };
             /** @description Validation Error */

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -431,8 +431,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "title": "Response Deploy Agent V1 Agents  Agent Id  Deploy Post"
+                  "$ref": "#/components/schemas/AgentDeployResponse"
                 }
               }
             }
@@ -491,8 +490,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "title": "Response Stop Agent V1 Agents  Agent Id  Stop Post"
+                  "$ref": "#/components/schemas/AgentStopResponse"
                 }
               }
             }
@@ -10407,8 +10405,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "title": "Response Get Scheduler V1 Scheduler Get"
+                  "$ref": "#/components/schemas/SchedulerListResponse"
                 }
               }
             }
@@ -13597,6 +13594,25 @@
         ],
         "title": "AgentCreate"
       },
+      "AgentDeployResponse": {
+        "properties": {
+          "deployment_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Deployment Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "deployment_id",
+          "status"
+        ],
+        "title": "AgentDeployResponse"
+      },
       "AgentDetailResponse": {
         "properties": {
           "id": {
@@ -14468,6 +14484,19 @@
           "status"
         ],
         "title": "AgentStatusUpdate"
+      },
+      "AgentStopResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "AgentStopResponse"
       },
       "AgentType": {
         "type": "string",
@@ -23660,6 +23689,27 @@
         ],
         "title": "SSOCallbackResponse",
         "description": "Response model for SSO callback."
+      },
+      "SchedulerListResponse": {
+        "properties": {
+          "tasks": {
+            "items": {
+              "$ref": "#/components/schemas/SchedulerTaskResponse"
+            },
+            "type": "array",
+            "title": "Tasks"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tasks",
+          "total"
+        ],
+        "title": "SchedulerListResponse"
       },
       "SchedulerTaskCreate": {
         "properties": {

--- a/src/api/routes/agents.py
+++ b/src/api/routes/agents.py
@@ -404,7 +404,16 @@ async def delete_agent(
     logger.info(f"Deleted agent: {agent_id}")
 
 
-@router.post("/{agent_id}/deploy", response_model=dict)
+class AgentDeployResponse(BaseModel):
+    deployment_id: uuid.UUID
+    status: str
+
+
+class AgentStopResponse(BaseModel):
+    status: str
+
+
+@router.post("/{agent_id}/deploy", response_model=AgentDeployResponse)
 async def deploy_agent(
     agent_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
@@ -459,7 +468,7 @@ async def deploy_agent(
         ) from e
 
 
-@router.post("/{agent_id}/stop", response_model=dict)
+@router.post("/{agent_id}/stop", response_model=AgentStopResponse)
 async def stop_agent(
     agent_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),

--- a/src/api/routes/scheduler.py
+++ b/src/api/routes/scheduler.py
@@ -233,17 +233,22 @@ def _serialize_task(task: dict[str, Any]) -> SchedulerTaskResponse:
 # --- Routes ---
 
 
-@router.get("", response_model=dict)
+class SchedulerListResponse(BaseModel):
+    tasks: list[SchedulerTaskResponse]
+    total: int
+
+
+@router.get("", response_model=SchedulerListResponse)
 async def get_scheduler(
     current_user: User = Depends(get_current_internal_user),
-) -> dict:
+) -> SchedulerListResponse:
     """List all scheduled tasks for the admin user."""
     _ensure_scheduler_running()
 
     async with _scheduler_lock:
-        tasks = [_serialize_task(t).model_dump() for t in _task_store.values()]
+        tasks = [_serialize_task(t) for t in _task_store.values()]
 
-    return {"tasks": tasks, "total": len(tasks)}
+    return SchedulerListResponse(tasks=tasks, total=len(tasks))
 
 
 @router.post("", response_model=SchedulerTaskResponse, status_code=201)


### PR DESCRIPTION
## Summary
Replace untyped `response_model=dict` with proper Pydantic response models on 3 endpoints.

### Changes

**`src/api/routes/agents.py`**
- `POST /{agent_id}/deploy` → `AgentDeployResponse(deployment_id: UUID, status: str)`
- `POST /{agent_id}/stop` → `AgentStopResponse(status: str)`

**`src/api/routes/scheduler.py`**
- `GET /scheduler` → `SchedulerListResponse(tasks: list[SchedulerTaskResponse], total: int)`
- Removed redundant `.model_dump()` call — return models directly, FastAPI handles serialization

### Why
Untyped `dict` response models produce loose OpenAPI schemas (`additionalProperties: true`) which undermine frontend type safety and API documentation quality.

### Testing
- `ruff check` passes on both files
- All 54 existing tests pass (`tests/api/test_agents.py`, `tests/api/test_scheduler_route.py`)

### Also shipped this run
- Regenerated OpenAPI artifacts on PR #3678 to fix its CI failure