### PR TITLE
fix: stabilize Python CI and port dashboard panel navigation

### DIFF
--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -21,6 +21,7 @@ import {
 import { DesktopWindowShell } from "@/components/desktop/DesktopWindowShell";
 import { useDesktopStatus } from "@/components/desktop/useDesktopStatus";
 import { useDesktopWindow } from "@/components/desktop/useDesktopWindow";
+import { panelHref, useNavigateToPanel, usePrefetchPanel } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 
 import {
@@ -35,11 +36,25 @@ interface DashboardShellProps {
 }
 
 interface DashboardNavProps {
+  navigateToPanel: (panel: string) => void;
+  prefetchPanel: (panel: string) => void;
   onNavigate?: () => void;
   pathname: string;
 }
 
-function DashboardNav({ onNavigate, pathname }: DashboardNavProps) {
+const DASHBOARD_NAV_PANELS: Partial<Record<(typeof ALL_DASHBOARD_NAV_ITEMS)[number]["key"], string>> = {
+  home: "overview",
+  agents: "agents",
+  sessions: "chat",
+  analytics: "tokens",
+  control: "settings",
+}
+
+function getDashboardNavPanel(key: (typeof ALL_DASHBOARD_NAV_ITEMS)[number]["key"]) {
+  return DASHBOARD_NAV_PANELS[key] ?? key
+}
+
+function DashboardNav({ navigateToPanel, onNavigate, pathname, prefetchPanel }: DashboardNavProps) {
   return (
     <nav className="space-y-3">
       {DASHBOARD_NAV_GROUPS.map((group) => (
@@ -52,13 +67,25 @@ function DashboardNav({ onNavigate, pathname }: DashboardNavProps) {
 
           {group.items.map((item) => {
             const isActive = isDashboardNavItemActive(pathname, item);
-            const href = getDashboardNavHref(pathname, item);
+            const panel = getDashboardNavPanel(item.key);
+            const href = pathname.startsWith("/dashboard")
+              ? panelHref(panel)
+              : getDashboardNavHref(pathname, item);
 
             return (
               <Link
                 key={`${group.key}-${item.title}`}
                 href={href}
-                onClick={onNavigate}
+                onClick={(event) => {
+                  if (pathname.startsWith("/dashboard")) {
+                    event.preventDefault();
+                    navigateToPanel(panel);
+                  }
+
+                  onNavigate?.();
+                }}
+                onFocus={() => prefetchPanel(panel)}
+                onMouseEnter={() => prefetchPanel(panel)}
                 title={item.description}
                 className={cn(
                   "group relative flex items-center gap-3 rounded-[16px] px-3.5 py-3 text-[13px] transition-all duration-150",
@@ -95,6 +122,8 @@ function DashboardNav({ onNavigate, pathname }: DashboardNavProps) {
 export function DashboardShell({ children }: DashboardShellProps) {
   const pathname = usePathname();
   const router = useRouter();
+  const navigateToPanel = useNavigateToPanel();
+  const prefetchPanel = usePrefetchPanel();
   const { status, isDesktop, platformReady, refetch } = useDesktopStatus();
   const { currentWindow, openPreferences, updateCurrentWindow } = useDesktopWindow();
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -411,7 +440,12 @@ export function DashboardShell({ children }: DashboardShellProps) {
             </div>
 
             <div className="flex-1 overflow-y-auto px-3 py-3">
-              <DashboardNav pathname={pathname} onNavigate={() => setMobileOpen(false)} />
+              <DashboardNav
+                navigateToPanel={navigateToPanel}
+                pathname={pathname}
+                onNavigate={() => setMobileOpen(false)}
+                prefetchPanel={prefetchPanel}
+              />
             </div>
             {sidebarFooter}
           </aside>
@@ -462,7 +496,11 @@ export function DashboardShell({ children }: DashboardShellProps) {
             <aside className="hidden w-[290px] shrink-0 flex-col border-r border-[rgba(191,219,254,0.08)] bg-[linear-gradient(180deg,#101722_0%,#0a0f18_100%)] lg:flex">
               <div className="border-b border-[rgba(191,219,254,0.08)] px-4 py-5">{sidebarBrand}</div>
               <div className="flex-1 overflow-y-auto px-3 py-3">
-                <DashboardNav pathname={pathname} />
+                <DashboardNav
+                  navigateToPanel={navigateToPanel}
+                  pathname={pathname}
+                  prefetchPanel={prefetchPanel}
+                />
               </div>
               {sidebarFooter}
             </aside>

--- a/docs/ui-port-progress.md
+++ b/docs/ui-port-progress.md
@@ -16,7 +16,7 @@ Last updated: 2026-04-16
 
 ### MUTX Current Architecture
 - **Routing**: Next.js App Router with 28 separate page routes under `app/dashboard/` — each is a full page load
-- **State**: Pure React Context/hooks — **no Zustand, no global store**. State is local to component trees
+- **State**: Hybrid provider + Zustand model — `lib/store.ts` now carries boot, connection, navigation, and dashboard entity state alongside the existing desktop providers
 - **Design Tokens**: CSS custom-property token system (`components/dashboard/tokens.ts`) — 30+ tokens + statusTokens; uses `var()` with hardcoded fallbacks
 - **Navigation**: `DashboardShell` (592 LOC) with inline `DashboardNav`, grouped sidebar from `dashboardNav.ts`; has `components/ui/nav-rail.tsx` (17KB, partially implemented)
 - **Polling**: **None** — no smart polling or adaptive refresh pattern exists
@@ -28,7 +28,7 @@ Last updated: 2026-04-16
 | Aspect | Mission-Control | MUTX | Gap |
 |--------|----------------|------|-----|
 | Routing | Single catch-all, panel switch | 28 separate page routes | L — needs SPA shell |
-| State management | Zustand single store | React Context only | L — needs store layer |
+| State management | Zustand single store | Desktop providers + `lib/store.ts` | M — store foundation landed, adoption still incomplete |
 | Design tokens | HSL triplets + helpers | CSS var tokens | S — similar, needs alignment |
 | Real-time | WS + SSE + smart poll | None | L — needs full real-time layer |
 | Boot sequence | 9-step parallel init | Desktop provider chain | M — needs data boot |
@@ -41,14 +41,14 @@ Last updated: 2026-04-16
 
 ### 1. Zustand Store (`useMissionControl`)
 - **MC Source**: `src/store/index.ts` (~1100 LOC)
-- **MUTX Equivalent**: **MISSING** — no global store exists
-- **Gap**: Entire state management layer absent. MUTX uses scattered React Context providers (DesktopStatusProvider, DesktopWindowProvider, DesktopJobProvider) with no centralized state.
-- **Port Scope**: **L** — Create new `lib/store.ts` with Zustand. Must define 15+ domain interfaces (Session, LogEntry, CronJob, Agent, Task, Activity, Notification, etc.), 20+ actions, connection state, boot state, navigation state. Adapt MC's store shape to use MUTX API endpoints (`/v1/*` routes).
+- **MUTX Equivalent**: `lib/store.ts`
+- **Gap**: Foundation landed, but the dashboard still mixes direct page-local data fetching with the shared store instead of using the store end to end.
+- **Port Scope**: **L** — Continue migrating dashboard surfaces onto the existing Zustand store and remove duplicate page-local fetch logic where the shared store now covers the same ground.
 - **Dependencies**: None (this is the foundation)
 - **API Surface**: All MUTX `/v1/*` endpoints — agents, sessions, tasks, activities, notifications, cron, memory, skills, settings, auth/me
 - **Design Details**: Uses `subscribeWithSelector` middleware for fine-grained subscriptions. Task has 9-status workflow + 5 priority levels + GitHub sync fields.
 - **Priority**: **critical** — blocks all other porting work
-- **Status**: spec'd
+- **Status**: foundation landed
 
 ### 2. SPA Shell & Panel Router (`ContentRouter`)
 - **MC Source**: `src/app/[[...panel]]/page.tsx` — ContentRouter component
@@ -75,13 +75,13 @@ Last updated: 2026-04-16
 ### 4. Navigation System
 - **MC Source**: `src/lib/navigation.ts` — panelHref, useNavigateToPanel, usePrefetchPanel
 - **MUTX Equivalent**: `components/dashboard/dashboardNav.ts` — nav config + helpers; `components/ui/nav-rail.tsx` — nav rail UI
-- **Gap**: MUTX has nav config and sidebar rendering but lacks: (1) prefetch system, (2) `panelHref` URL helper, (3) `useNavigateToPanel` hook with transition wrapping, (4) route deduplication, (5) navigation timing.
-- **Port Scope**: **M** — Create `lib/navigation.ts` with `panelHref()`, `useNavigateToPanel()`, `usePrefetchPanel()`. Add default prefetch panel list. Integrate with store for `activeTab` sync.
+- **Gap**: Core dashboard navigation hooks now exist in `lib/navigation.ts`, but only the dashboard shell uses them and there is still no navigation timing layer or catch-all panel router.
+- **Port Scope**: **M** — Keep expanding `lib/navigation.ts` usage beyond the shell, and wire any future SPA shell work into the same route normalization + prefetch path instead of reintroducing one-off link logic.
 - **Dependencies**: Zustand store (#1)
 - **API Surface**: N/A (internal routing)
 - **Design Details**: `panelHref()` normalizes 'overview' → '/'. `useNavigateToPanel()` uses `startTransition()` + `router.push(href, { scroll: false })`. Dedup via `PREFETCHED_ROUTES` Set. Default prefetch: overview, chat, tasks, agents, activity, notifications, tokens.
 - **Priority**: **high** — UX performance
-- **Status**: spec'd
+- **Status**: landed in shell
 
 ### 5. Smart Polling Hook
 - **MC Source**: `src/lib/use-smart-poll.ts` — useSmartPoll
@@ -113,8 +113,7 @@ Last updated: 2026-04-16
 1. **Zustand Store** (`lib/store.ts`) — Foundation for everything else. Define all interfaces, state shape, actions. Wire to MUTX `/v1/*` API endpoints.
 2. **Design Token Alignment** (`components/dashboard/tokens.ts`) — Add HSL helpers, surface scale, accent palette. No dependencies, can be done in parallel.
 3. **Smart Poll Hook** (`lib/use-smart-poll.ts`) — Needs store for connection state. Low risk, high value.
-4. **Navigation System** (`lib/navigation.ts`) — Needs store for activeTab. Enables SPA-like transitions.
-5. **SPA Shell / ContentRouter** — Needs store + navigation + tokens. Largest change. Consider feature flag to switch between old multi-page and new SPA modes.
+4. **SPA Shell / ContentRouter** — Needs the existing store + navigation foundations to be adopted consistently. Largest change. Consider feature flag to switch between old multi-page and new SPA modes.
 
 ## Engineering Notes
 

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,0 +1,131 @@
+'use client'
+
+import { startTransition, useEffect } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+
+import { useMissionControl } from '@/lib/store'
+
+const PREFETCHED_ROUTES = new Set<string>()
+let lastDefaultPrefetchPath = ''
+
+const PANEL_ROUTE_MAP: Record<string, string> = {
+  overview: '/dashboard',
+  agents: '/dashboard/agents',
+  tasks: '/dashboard/orchestration',
+  chat: '/dashboard/sessions',
+  activity: '/dashboard/history',
+  notifications: '/dashboard/monitoring',
+  tokens: '/dashboard/analytics',
+  logs: '/dashboard/logs',
+  cron: '/dashboard/autonomy',
+  memory: '/dashboard/memory',
+  skills: '/dashboard/skills',
+  settings: '/dashboard/control',
+  'cost-tracker': '/dashboard/budgets',
+  webhooks: '/dashboard/webhooks',
+  security: '/dashboard/security',
+}
+
+const DEFAULT_PREFETCH_PANELS = [
+  'overview',
+  'chat',
+  'tasks',
+  'agents',
+  'activity',
+  'notifications',
+  'tokens',
+]
+
+function normalizePanel(panel: string): string {
+  return panel.trim().toLowerCase().replace(/^\/+|\/+$/g, '')
+}
+
+function normalizePathname(pathname: string | null | undefined): string {
+  if (!pathname || pathname === '/') {
+    return '/dashboard'
+  }
+
+  if (pathname !== '/dashboard' && pathname.endsWith('/')) {
+    return pathname.slice(0, -1)
+  }
+
+  return pathname
+}
+
+function prefetchHref(router: ReturnType<typeof useRouter>, href: string) {
+  if (PREFETCHED_ROUTES.has(href)) {
+    return
+  }
+
+  PREFETCHED_ROUTES.add(href)
+
+  try {
+    router.prefetch(href)
+  } catch {
+    PREFETCHED_ROUTES.delete(href)
+  }
+}
+
+export function panelHref(panel: string): string {
+  const normalizedPanel = normalizePanel(panel)
+
+  if (!normalizedPanel || normalizedPanel === 'overview') {
+    return '/dashboard'
+  }
+
+  return PANEL_ROUTE_MAP[normalizedPanel] ?? `/dashboard/${normalizedPanel}`
+}
+
+export function usePrefetchPanel(): (panel: string) => void {
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    const currentPath = normalizePathname(pathname)
+    if (lastDefaultPrefetchPath === currentPath) {
+      return
+    }
+
+    lastDefaultPrefetchPath = currentPath
+
+    for (const panel of DEFAULT_PREFETCH_PANELS) {
+      const href = panelHref(panel)
+      if (href !== currentPath) {
+        prefetchHref(router, href)
+      }
+    }
+  }, [pathname, router])
+
+  return (panel: string) => {
+    prefetchHref(router, panelHref(panel))
+  }
+}
+
+export function useNavigateToPanel(): (panel: string) => void {
+  const pathname = usePathname()
+  const router = useRouter()
+  const setActiveTab = useMissionControl((state) => state.setActiveTab)
+  const setChatPanelOpen = useMissionControl((state) => state.setChatPanelOpen)
+  const prefetchPanel = usePrefetchPanel()
+
+  return (panel: string) => {
+    const normalizedPanel = normalizePanel(panel) || 'overview'
+    const href = panelHref(normalizedPanel)
+
+    if (normalizePathname(pathname) === href) {
+      setActiveTab(normalizedPanel)
+      return
+    }
+
+    prefetchPanel(normalizedPanel)
+    setActiveTab(normalizedPanel)
+
+    if (normalizedPanel === 'chat') {
+      setChatPanelOpen(false)
+    }
+
+    startTransition(() => {
+      router.push(href, { scroll: false })
+    })
+  }
+}

--- a/tests/unit/navigation.test.ts
+++ b/tests/unit/navigation.test.ts
@@ -1,0 +1,21 @@
+import { panelHref } from '../../lib/navigation'
+
+describe('panelHref', () => {
+  it('maps mission-control panel ids to dashboard routes', () => {
+    expect(panelHref('overview')).toBe('/dashboard')
+    expect(panelHref('agents')).toBe('/dashboard/agents')
+    expect(panelHref('chat')).toBe('/dashboard/sessions')
+    expect(panelHref('tasks')).toBe('/dashboard/orchestration')
+    expect(panelHref('activity')).toBe('/dashboard/history')
+    expect(panelHref('tokens')).toBe('/dashboard/analytics')
+  })
+
+  it('normalizes casing and whitespace before building routes', () => {
+    expect(panelHref(' Overview ')).toBe('/dashboard')
+    expect(panelHref('  SKILLS  ')).toBe('/dashboard/skills')
+  })
+
+  it('falls back to dashboard-prefixed routes for unknown panels', () => {
+    expect(panelHref('deployments')).toBe('/dashboard/deployments')
+  })
+})


### PR DESCRIPTION
## Summary
- format the Python files currently breaking the `Python Validation` workflow on `main`
- port mission-control style panel navigation + deduped prefetching into the dashboard shell
- update the UI port progress tracker so it matches the current store/navigation reality

## Validation
- `npm run test:app`
- `npm run typecheck`
- `npm run lint`
- `ruff check src/api cli sdk src/security`
- `ruff format --check src/api cli sdk src/security`
- `python -m compileall src/api cli sdk/mutx src/security`

Fixes #3692
Fixes #3707
Fixes #3708
Fixes #3709
Fixes #3710
Fixes #3711
Fixes #3712
Fixes #3713
Fixes #3714
Fixes #3715
Fixes #3716
Fixes #3717
Fixes #3718
Fixes #3719
Fixes #3720
Fixes #3721
