### PR TITLE
Improve social embeds and webmaster metadata

### DIFF
--- a/app/ai-agent-approvals/page.tsx
+++ b/app/ai-agent-approvals/page.tsx
@@ -6,8 +6,8 @@ import { PublicNav } from "@/components/site/PublicNav";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import {
   DEFAULT_X_HANDLE,
+  buildPageMetadata,
   getCanonicalUrl,
-  getPageOgImageUrl, getPageTwitterImageUrl,
   getSiteUrl,
 } from "@/lib/seo";
 import core from "@/components/site/marketing/MarketingCore.module.css";
@@ -24,22 +24,17 @@ export const metadata: Metadata = {
     "operator authorization",
     "approval gates for ai agents",
   ],
-  alternates: { canonical: getCanonicalUrl("/ai-agent-approvals") },
-  openGraph: {
+  ...buildPageMetadata({
     title: "AI Agent Approval Workflows — Human-in-the-Loop Gates & Operator Authorization | MUTX",
     description:
+      "Most agent approval systems are advisory — they suggest a review but don't block the action. MUTX approval gates are enforced by the control plane. The agent waits for a decision, and every decision is on the record.",
+    path: "/ai-agent-approvals",
+    socialDescription:
       "Enforced approval gates for AI agents. The agent waits for a human decision, the decision is recorded, and the record travels with the trace.",
-    url: getCanonicalUrl("/ai-agent-approvals"),
-    images: [getPageOgImageUrl("AI Agent Approval Workflows — Human-in-the-Loop Gates & Operator Authorization | MUTX", "Enforced approval gates for AI agents. The agent waits for a human decision, the decision is recorded, and the record travels with the trace.", { path: "/ai-agent-approvals" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "AI Agent Approval Workflows | MUTX",
-    description:
+    twitterTitle: "AI Agent Approval Workflows | MUTX",
+    twitterDescription:
       "Human-in-the-loop gates enforced by the control plane. Agents wait for operator decisions — no advisory-only approvals.",
-    images: [getPageTwitterImageUrl("AI Agent Approval Workflows — Human-in-the-Loop Gates & Operator Authorization | MUTX", "Enforced approval gates for AI agents. The agent waits for a human decision, the decision is recorded, and the record travels with the trace.", { path: "/ai-agent-approvals" })],
-  },
+  }),
 };
 
 const faqItems = [

--- a/app/ai-agent-audit-logs/page.tsx
+++ b/app/ai-agent-audit-logs/page.tsx
@@ -6,8 +6,8 @@ import { PublicNav } from "@/components/site/PublicNav";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import {
   DEFAULT_X_HANDLE,
+  buildPageMetadata,
   getCanonicalUrl,
-  getPageOgImageUrl, getPageTwitterImageUrl,
   getSiteUrl,
 } from "@/lib/seo";
 import core from "@/components/site/marketing/MarketingCore.module.css";
@@ -17,22 +17,17 @@ export const metadata: Metadata = {
   title: "AI Agent Audit Logs — Decision Records, Policy Traces, Compliance Exports | MUTX",
   description:
     "Complete trace history for every agent decision. MUTX records actions, policy evaluations, and operator overrides — so you can answer what happened and why, with the full execution context.",
-  alternates: { canonical: getCanonicalUrl("/ai-agent-audit-logs") },
-  openGraph: {
+  ...buildPageMetadata({
     title: "AI Agent Audit Logs — Decision Records, Policy Traces, Compliance Exports | MUTX",
     description:
+      "Complete trace history for every agent decision. MUTX records actions, policy evaluations, and operator overrides — so you can answer what happened and why, with the full execution context.",
+    path: "/ai-agent-audit-logs",
+    socialDescription:
       "Complete trace history for every agent decision. Records built for compliance and operator investigation.",
-    url: getCanonicalUrl("/ai-agent-audit-logs"),
-    images: [getPageOgImageUrl("AI Agent Audit Logs — Decision Records, Policy Traces, Compliance Exports | MUTX", "Complete trace history for every agent decision. Records built for compliance and operator investigation.", { path: "/ai-agent-audit-logs" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "AI Agent Audit Logs | MUTX",
-    description:
+    twitterTitle: "AI Agent Audit Logs | MUTX",
+    twitterDescription:
       "Complete trace history for every agent decision. Records built for compliance and operator investigation.",
-    images: [getPageTwitterImageUrl("AI Agent Audit Logs — Decision Records, Policy Traces, Compliance Exports | MUTX", "Complete trace history for every agent decision. Records built for compliance and operator investigation.", { path: "/ai-agent-audit-logs" })],
-  },
+  }),
 };
 
 const structuredData = {

--- a/app/ai-agent-control-plane/page.tsx
+++ b/app/ai-agent-control-plane/page.tsx
@@ -6,8 +6,8 @@ import { PublicNav } from "@/components/site/PublicNav";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import {
   DEFAULT_X_HANDLE,
+  buildPageMetadata,
   getCanonicalUrl,
-  getPageOgImageUrl, getPageTwitterImageUrl,
   getSiteUrl,
 } from "@/lib/seo";
 import core from "@/components/site/marketing/MarketingCore.module.css";
@@ -17,22 +17,17 @@ export const metadata: Metadata = {
   title: "AI Agent Control Plane — Runtime Traces, Lifecycle, Operator Surface | MUTX",
   description:
     "The control plane isn&rsquo;t a dashboard bolt-on. MUTX gives you runtime traces, agent lifecycle records, and a legible operator surface for every agent in your fleet.",
-  alternates: { canonical: getCanonicalUrl("/ai-agent-control-plane") },
-  openGraph: {
+  ...buildPageMetadata({
     title: "AI Agent Control Plane — Runtime Traces, Lifecycle, Operator Surface | MUTX",
     description:
+      "The control plane isn&rsquo;t a dashboard bolt-on. MUTX gives you runtime traces, agent lifecycle records, and a legible operator surface for every agent in your fleet.",
+    path: "/ai-agent-control-plane",
+    socialDescription:
       "The control plane isn&rsquo;t a bolt-on. Runtime traces, lifecycle records, and a legible operator surface — built in.",
-    url: getCanonicalUrl("/ai-agent-control-plane"),
-    images: [getPageOgImageUrl("AI Agent Control Plane — Runtime Traces, Lifecycle, Operator Surface | MUTX", "The control plane isn&rsquo;t a bolt-on. Runtime traces, lifecycle records, and a legible operator surface — built in.", { path: "/ai-agent-control-plane" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "AI Agent Control Plane | MUTX",
-    description:
+    twitterTitle: "AI Agent Control Plane | MUTX",
+    twitterDescription:
       "The control plane isn&rsquo;t a bolt-on. Runtime traces, lifecycle records, and operator surfaces — built in from day one.",
-    images: [getPageTwitterImageUrl("AI Agent Control Plane — Runtime Traces, Lifecycle, Operator Surface | MUTX", "The control plane isn&rsquo;t a bolt-on. Runtime traces, lifecycle records, and a legible operator surface — built in.", { path: "/ai-agent-control-plane" })],
-  },
+  }),
 };
 
 const structuredData = {

--- a/app/ai-agent-cost/page.tsx
+++ b/app/ai-agent-cost/page.tsx
@@ -6,8 +6,8 @@ import { PublicNav } from "@/components/site/PublicNav";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import {
   DEFAULT_X_HANDLE,
+  buildPageMetadata,
   getCanonicalUrl,
-  getPageOgImageUrl, getPageTwitterImageUrl,
   getSiteUrl,
 } from "@/lib/seo";
 import core from "@/components/site/marketing/MarketingCore.module.css";
@@ -24,22 +24,17 @@ export const metadata: Metadata = {
     "ai agent budget controls",
     "runaway agent costs",
   ],
-  alternates: { canonical: getCanonicalUrl("/ai-agent-cost") },
-  openGraph: {
+  ...buildPageMetadata({
     title: "AI Agent Cost Management — Per-Run Spend Tracking, Budgets, Attribution | MUTX",
     description:
+      "Track AI agent costs by run, model, provider, and workflow. MUTX attributes spend in real time, enforces budgets at the control plane, and catches runaway agents before the invoice lands.",
+    path: "/ai-agent-cost",
+    socialDescription:
       "Track AI agent costs by run, model, provider, and workflow. Budgets and attribution built into the control plane.",
-    url: getCanonicalUrl("/ai-agent-cost"),
-    images: [getPageOgImageUrl("AI Agent Cost Management — Per-Run Spend Tracking, Budgets, Attribution | MUTX", "Track AI agent costs by run, model, provider, and workflow. Budgets and attribution built into the control plane.", { path: "/ai-agent-cost" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "AI Agent Cost Management | MUTX",
-    description:
+    twitterTitle: "AI Agent Cost Management | MUTX",
+    twitterDescription:
       "Track AI agent costs by run, model, provider, and workflow. Catch runaway spend before the invoice lands.",
-    images: [getPageTwitterImageUrl("AI Agent Cost Management — Per-Run Spend Tracking, Budgets, Attribution | MUTX", "Track AI agent costs by run, model, provider, and workflow. Budgets and attribution built into the control plane.", { path: "/ai-agent-cost" })],
-  },
+  }),
 };
 
 const faqItems = [

--- a/app/ai-agent-deployment/page.tsx
+++ b/app/ai-agent-deployment/page.tsx
@@ -6,8 +6,8 @@ import { PublicNav } from "@/components/site/PublicNav";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import {
   DEFAULT_X_HANDLE,
+  buildPageMetadata,
   getCanonicalUrl,
-  getPageOgImageUrl, getPageTwitterImageUrl,
   getSiteUrl,
 } from "@/lib/seo";
 import core from "@/components/site/marketing/MarketingCore.module.css";
@@ -17,22 +17,17 @@ export const metadata: Metadata = {
   title: "AI Agent Deployment — Repeatable Envs, Audit Trails, Rollback | MUTX",
   description:
     "Agents that deploy like services, not science projects. MUTX gives you repeatable runtime environments, deployment records with audit trails, and one-click rollback.",
-  alternates: { canonical: getCanonicalUrl("/ai-agent-deployment") },
-  openGraph: {
+  ...buildPageMetadata({
     title: "AI Agent Deployment — Repeatable Envs, Audit Trails, Rollback | MUTX",
     description:
+      "Agents that deploy like services, not science projects. MUTX gives you repeatable runtime environments, deployment records with audit trails, and one-click rollback.",
+    path: "/ai-agent-deployment",
+    socialDescription:
       "Agents that deploy like services. Repeatable environments, deployment records, and rollback paths — built into the control plane.",
-    url: getCanonicalUrl("/ai-agent-deployment"),
-    images: [getPageOgImageUrl("AI Agent Deployment — Repeatable Envs, Audit Trails, Rollback | MUTX", "Agents that deploy like services. Repeatable environments, deployment records, and rollback paths — built into the control plane.", { path: "/ai-agent-deployment" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "AI Agent Deployment | MUTX",
-    description:
+    twitterTitle: "AI Agent Deployment | MUTX",
+    twitterDescription:
       "Agents that deploy like services. Repeatable environments and deployment records built into the control plane.",
-    images: [getPageTwitterImageUrl("AI Agent Deployment — Repeatable Envs, Audit Trails, Rollback | MUTX", "Agents that deploy like services. Repeatable environments, deployment records, and rollback paths — built into the control plane.", { path: "/ai-agent-deployment" })],
-  },
+  }),
 };
 
 const structuredData = {

--- a/app/ai-agent-governance/page.tsx
+++ b/app/ai-agent-governance/page.tsx
@@ -6,8 +6,8 @@ import { PublicNav } from "@/components/site/PublicNav";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import {
   DEFAULT_X_HANDLE,
+  buildPageMetadata,
   getCanonicalUrl,
-  getPageOgImageUrl, getPageTwitterImageUrl,
   getSiteUrl,
 } from "@/lib/seo";
 import core from "@/components/site/marketing/MarketingCore.module.css";
@@ -17,22 +17,17 @@ export const metadata: Metadata = {
   title: "AI Agent Governance — Auth Boundaries, Access Control & Audit Compliance | MUTX",
   description:
     "Agent access is a minefield of implicit permissions and undocumented API keys. MUTX bakes auth boundaries, operator access controls, and compliance audit trails into the control plane — so what every agent can do is explicit, versioned, and enforced.",
-  alternates: { canonical: getCanonicalUrl("/ai-agent-governance") },
-  openGraph: {
+  ...buildPageMetadata({
     title: "AI Agent Governance — Auth Boundaries, Access Control & Audit Compliance | MUTX",
     description:
+      "Agent access is a minefield of implicit permissions and undocumented API keys. MUTX bakes auth boundaries, operator access controls, and compliance audit trails into the control plane — so what every agent can do is explicit, versioned, and enforced.",
+    path: "/ai-agent-governance",
+    socialDescription:
       "Auth boundaries, operator access controls, and compliance audit trails baked into the control plane. No implicit permissions.",
-    url: getCanonicalUrl("/ai-agent-governance"),
-    images: [getPageOgImageUrl("AI Agent Governance — Auth Boundaries, Access Control & Audit Compliance | MUTX", "Auth boundaries, operator access controls, and compliance audit trails baked into the control plane. No implicit permissions.", { path: "/ai-agent-governance" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "AI Agent Governance | MUTX",
-    description:
+    twitterTitle: "AI Agent Governance | MUTX",
+    twitterDescription:
       "Auth boundaries and compliance guardrails baked into the control plane. Agent access stays explicit and auditable.",
-    images: [getPageTwitterImageUrl("AI Agent Governance — Auth Boundaries, Access Control & Audit Compliance | MUTX", "Auth boundaries, operator access controls, and compliance audit trails baked into the control plane. No implicit permissions.", { path: "/ai-agent-governance" })],
-  },
+  }),
 };
 
 const structuredData = {

--- a/app/ai-agent-guardrails/page.tsx
+++ b/app/ai-agent-guardrails/page.tsx
@@ -6,8 +6,8 @@ import { PublicNav } from "@/components/site/PublicNav";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import {
   DEFAULT_X_HANDLE,
+  buildPageMetadata,
   getCanonicalUrl,
-  getPageOgImageUrl, getPageTwitterImageUrl,
   getSiteUrl,
 } from "@/lib/seo";
 import core from "@/components/site/marketing/MarketingCore.module.css";
@@ -17,22 +17,17 @@ export const metadata: Metadata = {
   title: "AI Agent Guardrails — Runtime Policy Enforcement & Safety Boundaries | MUTX",
   description:
     "Agents without guardrails will find every edge case — including the ones you didn't anticipate. MUTX enforces safety policies at runtime and surfaces violations as first-class events, not buried log lines.",
-  alternates: { canonical: getCanonicalUrl("/ai-agent-guardrails") },
-  openGraph: {
+  ...buildPageMetadata({
     title: "AI Agent Guardrails — Runtime Policy Enforcement & Safety Boundaries | MUTX",
     description:
+      "Agents without guardrails will find every edge case — including the ones you didn't anticipate. MUTX enforces safety policies at runtime and surfaces violations as first-class events, not buried log lines.",
+    path: "/ai-agent-guardrails",
+    socialDescription:
       "Runtime safety policies enforced by the control plane. Guardrail violations surface as first-class events.",
-    url: getCanonicalUrl("/ai-agent-guardrails"),
-    images: [getPageOgImageUrl("AI Agent Guardrails — Runtime Policy Enforcement & Safety Boundaries | MUTX", "Runtime safety policies enforced by the control plane. Guardrail violations surface as first-class events.", { path: "/ai-agent-guardrails" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "AI Agent Guardrails | MUTX",
-    description:
+    twitterTitle: "AI Agent Guardrails | MUTX",
+    twitterDescription:
       "Safety policies enforced at runtime by the control plane. Violations surface as first-class events.",
-    images: [getPageTwitterImageUrl("AI Agent Guardrails — Runtime Policy Enforcement & Safety Boundaries | MUTX", "Runtime safety policies enforced by the control plane. Guardrail violations surface as first-class events.", { path: "/ai-agent-guardrails" })],
-  },
+  }),
 };
 
 const structuredData = {

--- a/app/ai-agent-infrastructure/page.tsx
+++ b/app/ai-agent-infrastructure/page.tsx
@@ -6,8 +6,8 @@ import { PublicNav } from "@/components/site/PublicNav";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import {
   DEFAULT_X_HANDLE,
+  buildPageMetadata,
   getCanonicalUrl,
-  getPageOgImageUrl, getPageTwitterImageUrl,
   getSiteUrl,
 } from "@/lib/seo";
 import core from "@/components/site/marketing/MarketingCore.module.css";
@@ -17,22 +17,17 @@ export const metadata: Metadata = {
   title: "AI Agent Infrastructure — Compute, Secrets, Storage, Network | MUTX",
   description:
     "Stop guessing where your agents run. MUTX surfaces compute, secrets, and storage as explicit control plane properties — auditable, versioned, and visible.",
-  alternates: { canonical: getCanonicalUrl("/ai-agent-infrastructure") },
-  openGraph: {
+  ...buildPageMetadata({
     title: "AI Agent Infrastructure — Compute, Secrets, Storage, Network | MUTX",
     description:
+      "Stop guessing where your agents run. MUTX surfaces compute, secrets, and storage as explicit control plane properties — auditable, versioned, and visible.",
+    path: "/ai-agent-infrastructure",
+    socialDescription:
       "Stop guessing where your agents run. Compute, secrets, and storage as explicit control plane properties.",
-    url: getCanonicalUrl("/ai-agent-infrastructure"),
-    images: [getPageOgImageUrl("AI Agent Infrastructure — Compute, Secrets, Storage, Network | MUTX", "Stop guessing where your agents run. Compute, secrets, and storage as explicit control plane properties.", { path: "/ai-agent-infrastructure" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "AI Agent Infrastructure | MUTX",
-    description:
+    twitterTitle: "AI Agent Infrastructure | MUTX",
+    twitterDescription:
       "Stop guessing where your agents run. Compute, secrets, and storage as explicit control plane properties.",
-    images: [getPageTwitterImageUrl("AI Agent Infrastructure — Compute, Secrets, Storage, Network | MUTX", "Stop guessing where your agents run. Compute, secrets, and storage as explicit control plane properties.", { path: "/ai-agent-infrastructure" })],
-  },
+  }),
 };
 
 const structuredData = {

--- a/app/ai-agent-monitoring/page.tsx
+++ b/app/ai-agent-monitoring/page.tsx
@@ -6,8 +6,8 @@ import { PublicNav } from "@/components/site/PublicNav";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import {
   DEFAULT_X_HANDLE,
+  buildPageMetadata,
   getCanonicalUrl,
-  getPageOgImageUrl, getPageTwitterImageUrl,
   getSiteUrl,
 } from "@/lib/seo";
 import core from "@/components/site/marketing/MarketingCore.module.css";
@@ -17,22 +17,17 @@ export const metadata: Metadata = {
   title: "AI Agent Monitoring — Execution Traces, Tool Call History, Outcome Records | MUTX",
   description:
     "See what agents actually did — not what they said they'd do. MUTX captures execution traces, tool call chains, and outcomes so your team can investigate incidents and fix behavior in production.",
-  alternates: { canonical: getCanonicalUrl("/ai-agent-monitoring") },
-  openGraph: {
+  ...buildPageMetadata({
     title: "AI Agent Monitoring — Execution Traces, Tool Call History, Outcome Records | MUTX",
     description:
+      "See what agents actually did — not what they said they'd do. MUTX captures execution traces, tool call chains, and outcomes so your team can investigate incidents and fix behavior in production.",
+    path: "/ai-agent-monitoring",
+    socialDescription:
       "See what agents actually did. Execution traces, tool call history, and outcomes — built into the control plane.",
-    url: getCanonicalUrl("/ai-agent-monitoring"),
-    images: [getPageOgImageUrl("AI Agent Monitoring — Execution Traces, Tool Call History, Outcome Records | MUTX", "See what agents actually did. Execution traces, tool call history, and outcomes — built into the control plane.", { path: "/ai-agent-monitoring" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "AI Agent Monitoring | MUTX",
-    description:
+    twitterTitle: "AI Agent Monitoring | MUTX",
+    twitterDescription:
       "See what agents actually did, not what they said they'd do. Runtime traces and tool call history in the control plane.",
-    images: [getPageTwitterImageUrl("AI Agent Monitoring — Execution Traces, Tool Call History, Outcome Records | MUTX", "See what agents actually did. Execution traces, tool call history, and outcomes — built into the control plane.", { path: "/ai-agent-monitoring" })],
-  },
+  }),
 };
 
 const structuredData = {

--- a/app/ai-agent-reliability/page.tsx
+++ b/app/ai-agent-reliability/page.tsx
@@ -6,8 +6,8 @@ import { PublicNav } from "@/components/site/PublicNav";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import {
   DEFAULT_X_HANDLE,
+  buildPageMetadata,
   getCanonicalUrl,
-  getPageOgImageUrl, getPageTwitterImageUrl,
   getSiteUrl,
 } from "@/lib/seo";
 import core from "@/components/site/marketing/MarketingCore.module.css";
@@ -17,22 +17,17 @@ export const metadata: Metadata = {
   title: "AI Agent Reliability — Health Checks, Circuit Breakers, Failover | MUTX",
   description:
     "Agents that survive production. MUTX runs health probes, enforces circuit breakers, and routes around failures — so operators catch degradation before users do.",
-  alternates: { canonical: getCanonicalUrl("/ai-agent-reliability") },
-  openGraph: {
+  ...buildPageMetadata({
     title: "AI Agent Reliability — Health Checks, Circuit Breakers, Failover | MUTX",
     description:
+      "Agents that survive production. MUTX runs health probes, enforces circuit breakers, and routes around failures — so operators catch degradation before users do.",
+    path: "/ai-agent-reliability",
+    socialDescription:
       "Agents that survive production. Health checks, circuit breakers, and operator visibility — built into the control plane.",
-    url: getCanonicalUrl("/ai-agent-reliability"),
-    images: [getPageOgImageUrl("AI Agent Reliability — Health Checks, Circuit Breakers, Failover | MUTX", "Agents that survive production. Health checks, circuit breakers, and operator visibility — built into the control plane.", { path: "/ai-agent-reliability" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "AI Agent Reliability | MUTX",
-    description:
+    twitterTitle: "AI Agent Reliability | MUTX",
+    twitterDescription:
       "Agents that survive production. Health checks and circuit breakers built into the control plane.",
-    images: [getPageTwitterImageUrl("AI Agent Reliability — Health Checks, Circuit Breakers, Failover | MUTX", "Agents that survive production. Health checks, circuit breakers, and operator visibility — built into the control plane.", { path: "/ai-agent-reliability" })],
-  },
+  }),
 };
 
 const structuredData = {

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -8,7 +8,7 @@ import { CalendlyPopupButton } from "@/components/site/CalendlyPopupButton";
 import { PublicFooter } from "@/components/site/PublicFooter";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import styles from "@/components/site/marketing/MarketingCore.module.css";
-import { DEFAULT_X_HANDLE, getCanonicalUrl, getPageOgImageUrl, getPageTwitterImageUrl, getSiteUrl } from "@/lib/seo";
+import { buildPageMetadata, getCanonicalUrl, getSiteUrl } from "@/lib/seo";
 
 const CONTACT_EMAIL = "hello@mutx.dev";
 const contactTitle = "Contact | MUTX";
@@ -18,22 +18,11 @@ const contactDescription =
 export const metadata: Metadata = {
   title: contactTitle,
   description: contactDescription,
-  alternates: {
-    canonical: getCanonicalUrl("/contact"),
-  },
-  openGraph: {
+  ...buildPageMetadata({
     title: contactTitle,
     description: contactDescription,
-    url: getCanonicalUrl("/contact"),
-    images: [getPageOgImageUrl(contactTitle, contactDescription, { path: "/contact" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: contactTitle,
-    description: contactDescription,
-    images: [getPageTwitterImageUrl(contactTitle, contactDescription, { path: "/contact" })],
-  },
+    path: "/contact",
+  }),
 };
 
 const contactStructuredData = {

--- a/app/control/layout.tsx
+++ b/app/control/layout.tsx
@@ -1,14 +1,22 @@
 import type { Metadata } from "next";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
 
 import { appFontVariables } from "@/app/fonts/app";
 import { ErrorBoundary } from "@/components/app/ErrorBoundary";
 import { DemoViewportLock } from "@/components/dashboard/demo/DemoViewportLock";
+import { buildPageMetadata, getAppUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  alternates: {
-    canonical: "https://app.mutx.dev/control",
-  },
-  metadataBase: new URL("https://app.mutx.dev"),
+  metadataBase: new URL(getAppUrl()),
+  ...buildPageMetadata({
+    title: "MUTX Control Plane",
+    description: "Operator-grade control plane for deploying, observing, and governing agent infrastructure.",
+    path: "/control",
+    host: getAppUrl(),
+    siteName: "MUTX App",
+    badge: "CONTROL PLANE",
+  }),
   robots: {
     index: true,
     follow: true,
@@ -26,32 +34,25 @@ export const metadata: Metadata = {
     "runs",
     "audit trail",
   ],
-  openGraph: {
-    title: "MUTX Control Plane",
-    description: "Operator-grade control plane for deploying, observing, and governing agent infrastructure.",
-    url: "https://app.mutx.dev/control",
-    images: ["https://app.mutx.dev/opengraph-image?title=MUTX%20Control%20Plane&description=Operator-grade%20control%20plane%20for%20deploying%2C%20observing%2C%20and%20governing%20agent%20infrastructure."],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "MUTX Control Plane",
-    description: "Operator-grade control plane for deploying, observing, and governing agent infrastructure.",
-    images: ["https://app.mutx.dev/twitter-image?title=MUTX%20Control%20Plane&description=Operator-grade%20control%20plane%20for%20deploying%2C%20observing%2C%20and%20governing%20agent%20infrastructure."],
-  },
 };
 
-export default function AppDemoLayout({
+export default async function AppDemoLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const locale = await getLocale();
+  const messages = await getMessages();
+
   return (
-    <ErrorBoundary>
-      <DemoViewportLock>
-        <div className={`${appFontVariables} h-full overflow-hidden font-[family:var(--font-site-body)]`}>
-          {children}
-        </div>
-      </DemoViewportLock>
-    </ErrorBoundary>
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <ErrorBoundary>
+        <DemoViewportLock>
+          <div className={`${appFontVariables} h-full overflow-hidden font-[family:var(--font-site-body)]`}>
+            {children}
+          </div>
+        </DemoViewportLock>
+      </ErrorBoundary>
+    </NextIntlClientProvider>
   );
 }

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
 
 import { appFontVariables } from "@/app/fonts/app";
 import { ErrorBoundary } from "@/components/app/ErrorBoundary";
@@ -7,12 +9,18 @@ import { DesktopRouteListener } from "@/components/desktop/DesktopRouteListener"
 import { DesktopStatusProvider } from "@/components/desktop/useDesktopStatus";
 import { DesktopWindowProvider } from "@/components/desktop/useDesktopWindow";
 import { DashboardShell } from "@/components/dashboard/DashboardShell";
+import { buildPageMetadata, getAppUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  alternates: {
-    canonical: "https://app.mutx.dev",
-  },
-  metadataBase: new URL("https://app.mutx.dev"),
+  metadataBase: new URL(getAppUrl()),
+  ...buildPageMetadata({
+    title: "Dashboard - MUTX",
+    description: "Operator dashboard for agents, deployments, runs, budgets, webhooks, and governance.",
+    path: "/",
+    host: getAppUrl(),
+    siteName: "MUTX App",
+    badge: "APP",
+  }),
   robots: {
     index: false,
     follow: false,
@@ -30,37 +38,31 @@ export const metadata: Metadata = {
     "runs",
     "audit trail",
   ],
-  openGraph: {
-    title: "Dashboard - MUTX",
-    description: "Operator dashboard for agents, deployments, runs, budgets, webhooks, and governance.",
-    url: "https://app.mutx.dev",
-    images: ["https://app.mutx.dev/opengraph-image?title=Dashboard%20-%20MUTX&description=Operator%20dashboard%20for%20agents%2C%20deployments%2C%20runs%2C%20budgets%2C%20webhooks%2C%20and%20governance."],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Dashboard - MUTX",
-    description: "Operator dashboard for agents, deployments, runs, budgets, webhooks, and governance.",
-    images: ["https://app.mutx.dev/twitter-image?title=Dashboard%20-%20MUTX&description=Operator%20dashboard%20for%20agents%2C%20deployments%2C%20runs%2C%20budgets%2C%20webhooks%2C%20and%20governance."],
-  },
 };
 
-export default function DashboardLayout({
+export default async function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const locale = await getLocale();
+  const messages = await getMessages();
+  const spaShellEnabled = process.env.NEXT_PUBLIC_SPA_SHELL === "true";
+
   return (
-    <div className={`${appFontVariables} h-full font-[family:var(--font-site-body)]`}>
-      <ErrorBoundary>
-        <DesktopStatusProvider>
-          <DesktopWindowProvider>
-            <DesktopJobProvider>
-              <DesktopRouteListener />
-              <DashboardShell>{children}</DashboardShell>
-            </DesktopJobProvider>
-          </DesktopWindowProvider>
-        </DesktopStatusProvider>
-      </ErrorBoundary>
-    </div>
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <div className={`${appFontVariables} h-full font-[family:var(--font-site-body)]`}>
+        <ErrorBoundary>
+          <DesktopStatusProvider>
+            <DesktopWindowProvider>
+              <DesktopJobProvider>
+                <DesktopRouteListener />
+                <DashboardShell spaShellEnabled={spaShellEnabled}>{children}</DashboardShell>
+              </DesktopJobProvider>
+            </DesktopWindowProvider>
+          </DesktopStatusProvider>
+        </ErrorBoundary>
+      </div>
+    </NextIntlClientProvider>
   );
 }

--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -10,9 +10,8 @@ import { SectionLanding } from "@/components/site/docs/SectionLanding";
 import { PrevNextNav } from "@/components/site/docs/PrevNextNav";
 import {
   DEFAULT_X_HANDLE,
+  buildPageMetadata,
   getCanonicalUrl,
-  getPageOgImageUrl,
-  getPageTwitterImageUrl,
   getSiteUrl,
 } from "@/lib/seo";
 import { type DocNavItem, parseSummary } from "@/lib/docs";
@@ -324,23 +323,13 @@ export async function generateMetadata({
     description: seo.description,
     category: "documentation",
     keywords: seo.keywords,
-    alternates: {
-      canonical: getCanonicalUrl(normalizedPath),
-    },
-    openGraph: {
+    ...buildPageMetadata({
       title: seo.metaTitle,
       description: seo.description,
-      url: getCanonicalUrl(normalizedPath),
+      path: normalizedPath,
       siteName: "MUTX Docs",
-      images: [getPageOgImageUrl(seo.metaTitle, seo.description, { path: normalizedPath })],
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: DEFAULT_X_HANDLE,
-      title: seo.metaTitle,
-      description: seo.description,
-      images: [getPageTwitterImageUrl(seo.metaTitle, seo.description, { path: normalizedPath })],
-    },
+      badge: "DOCS",
+    }),
   };
 }
 

--- a/app/download/macos/page.tsx
+++ b/app/download/macos/page.tsx
@@ -12,7 +12,7 @@ import {
   buildReleaseNotesUrl,
   fetchLatestStableDesktopRelease,
 } from "@/lib/desktopRelease";
-import { DEFAULT_X_HANDLE, buildWebPageStructuredData, getCanonicalUrl, getPageOgImageUrl, getPageTwitterImageUrl } from "@/lib/seo";
+import { buildPageMetadata, buildWebPageStructuredData } from "@/lib/seo";
 
 export const revalidate = 900;
 
@@ -20,24 +20,12 @@ export const metadata: Metadata = {
   title: "Download for macOS | MUTX",
   description:
     "Download the latest signed and notarized MUTX macOS release for Apple Silicon or Intel, with checksums and release notes.",
-  alternates: {
-    canonical: getCanonicalUrl("/download/macos"),
-  },
-  openGraph: {
+  ...buildPageMetadata({
     title: "Download for macOS | MUTX",
     description:
       "Download the latest signed and notarized MUTX macOS release for Apple Silicon or Intel, with checksums and release notes.",
-    url: getCanonicalUrl("/download/macos"),
-    images: [getPageOgImageUrl("Download for macOS | MUTX", "Download the latest signed and notarized MUTX macOS release for Apple Silicon or Intel, with checksums and release notes.", { path: "/download/macos" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "Download for macOS | MUTX",
-    description:
-      "Download the latest signed and notarized MUTX macOS release for Apple Silicon or Intel, with checksums and release notes.",
-    images: [getPageTwitterImageUrl("Download for macOS | MUTX", "Download the latest signed and notarized MUTX macOS release for Apple Silicon or Intel, with checksums and release notes.", { path: "/download/macos" })],
-  },
+    path: "/download/macos",
+  }),
 };
 
 const structuredData = buildWebPageStructuredData({

--- a/app/download/page.tsx
+++ b/app/download/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 import MacDownloadPage from "./macos/page";
-import { DEFAULT_X_HANDLE, getCanonicalUrl, getPageOgImageUrl, getPageTwitterImageUrl } from "@/lib/seo";
+import { buildPageMetadata } from "@/lib/seo";
 
 export const revalidate = 900;
 
@@ -9,24 +9,12 @@ export const metadata: Metadata = {
   title: "Download MUTX | MUTX",
   description:
     "Download the latest MUTX desktop release for your platform. Signed builds, checksums, and release notes.",
-  alternates: {
-    canonical: getCanonicalUrl("/download"),
-  },
-  openGraph: {
+  ...buildPageMetadata({
     title: "Download MUTX | MUTX",
     description:
       "Download the latest MUTX desktop release for your platform. Signed builds, checksums, and release notes.",
-    url: getCanonicalUrl("/download"),
-    images: [getPageOgImageUrl("Download MUTX | MUTX", "Download the latest MUTX desktop release for your platform. Signed builds, checksums, and release notes.", { path: "/download" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "Download MUTX | MUTX",
-    description:
-      "Download the latest MUTX desktop release for your platform. Signed builds, checksums, and release notes.",
-    images: [getPageTwitterImageUrl("Download MUTX | MUTX", "Download the latest MUTX desktop release for your platform. Signed builds, checksums, and release notes.", { path: "/download" })],
-  },
+    path: "/download",
+  }),
 };
 
 export default MacDownloadPage;

--- a/app/infrastructure/page.tsx
+++ b/app/infrastructure/page.tsx
@@ -5,28 +5,18 @@ import matter from "gray-matter";
 import { DocsLayout } from "@/components/site/docs/DocsLayout";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
-import { DEFAULT_X_HANDLE, buildWebPageStructuredData, getCanonicalUrl, getPageOgImageUrl, getPageTwitterImageUrl } from "@/lib/seo";
+import { buildPageMetadata, buildWebPageStructuredData } from "@/lib/seo";
 
 export async function generateMetadata(): Promise<Metadata> {
   const source = fs.readFileSync(path.join(process.cwd(), "docs/infrastructure.md"), "utf-8");
   const { data } = matter(source);
+  const title = `${data.title || "Infrastructure"} — MUTX`;
+  const description = data.description as string;
+
   return {
-    title: `${data.title || "Infrastructure"} — MUTX`,
-    description: data.description as string,
-    alternates: { canonical: getCanonicalUrl("/infrastructure") },
-    openGraph: {
-      title: `${data.title || "Infrastructure"} — MUTX`,
-      description: data.description as string,
-      url: getCanonicalUrl("/infrastructure"),
-      images: [getPageOgImageUrl(`${data.title || "Infrastructure"} — MUTX`, data.description as string, { path: "/infrastructure" })],
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: DEFAULT_X_HANDLE,
-      title: `${data.title || "Infrastructure"} — MUTX`,
-      description: data.description as string,
-      images: [getPageTwitterImageUrl(`${data.title || "Infrastructure"} — MUTX`, data.description as string, { path: "/infrastructure" })],
-    },
+    title,
+    description,
+    ...buildPageMetadata({ title, description, path: "/infrastructure" }),
   };
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,27 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
 
 import { appFontVariables } from "@/app/fonts/app";
 import { AppDomainDemoIntro } from "@/components/app/AppDomainDemoIntro";
+import { GlobalLangSwitcher } from "@/components/i18n/GlobalLangSwitcher";
 import {
-  DEFAULT_OG_IMAGE_ALT,
-  DEFAULT_X_HANDLE,
-  getCanonicalUrl,
-  getOgImageUrl,
+  buildPageMetadata,
   getSiteUrl,
-  getTwitterImageUrl,
 } from "@/lib/seo";
 
 const siteUrl = getSiteUrl();
-const ogImageUrl = getOgImageUrl();
-const twitterImageUrl = getTwitterImageUrl();
+const rootSocialMetadata = buildPageMetadata({
+  title: "MUTX | Open Control Plane for AI Agents",
+  description:
+    "Operate deployed agents with real auth, deployments, traces, webhooks, runtime posture, and operator tooling across web, API, CLI, and docs.",
+  path: "/",
+  socialDescription:
+    "MUTX is the open control plane for agents that have to survive real deployments, auth boundaries, webhooks, and runtime operations.",
+  twitterDescription:
+    "Operate deployed agents across auth, deployments, traces, webhooks, and runtime posture.",
+});
 
 export const viewport = {
   width: 'device-width',
@@ -25,9 +32,7 @@ export const viewport = {
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
-  alternates: {
-    canonical: getCanonicalUrl(),
-  },
+  ...rootSocialMetadata,
   title: "MUTX | Open Control Plane for AI Agents",
   description:
     "Operate deployed agents with real auth, deployments, traces, webhooks, runtime posture, and operator tooling across web, API, CLI, and docs.",
@@ -58,32 +63,6 @@ export const metadata: Metadata = {
       "max-video-preview": -1,
     },
   },
-  openGraph: {
-    locale: "en_US",
-    title: "MUTX | Open Control Plane for AI Agents",
-    description:
-      "MUTX is the open control plane for agents that have to survive real deployments, auth boundaries, webhooks, and runtime operations.",
-    url: siteUrl,
-    siteName: "MUTX",
-    images: [
-      {
-        url: ogImageUrl,
-        width: 1200,
-        height: 630,
-        alt: DEFAULT_OG_IMAGE_ALT,
-      },
-    ],
-    type: "website",
-  },
-  twitter: {
-    creator: DEFAULT_X_HANDLE,
-    card: "summary_large_image",
-    site: DEFAULT_X_HANDLE,
-    title: "MUTX | Open Control Plane for AI Agents",
-    description:
-      "Operate deployed agents across auth, deployments, traces, webhooks, and runtime posture.",
-    images: [twitterImageUrl],
-  },
   icons: {
     icon: [
       { url: "/favicon.ico" },
@@ -94,14 +73,17 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const locale = await getLocale()
+  const messages = await getMessages()
+
   return (
-    <html lang="en" className="h-full" suppressHydrationWarning>
+    <html lang={locale} className="h-full" suppressHydrationWarning>
       <head>
         <script
           dangerouslySetInnerHTML={{
             __html:
-              "(function(){try{if(window.sessionStorage.getItem('mutx-home-loader-played')==='1'){document.documentElement.setAttribute('data-home-loader-played','1');}}catch(_error){}})();",
+              "(function(){try{if(window.sessionStorage.getItem('mutx-home-loader-played')==='1'){document.documentElement.setAttribute('data-home-loader-played','1');document.documentElement.setAttribute('data-loader-state','complete');}}catch(_error){}})();",
           }}
         />
         <script
@@ -122,8 +104,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <meta name="theme-color" content="#09080b" />
       </head>
       <body className={`${appFontVariables} h-full min-h-screen antialiased`}>
-        {children}
-        <AppDomainDemoIntro />
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <GlobalLangSwitcher />
+          {children}
+          <AppDomainDemoIntro />
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,6 @@ import { getLocale, getMessages } from "next-intl/server";
 
 import { appFontVariables } from "@/app/fonts/app";
 import { AppDomainDemoIntro } from "@/components/app/AppDomainDemoIntro";
-import { GlobalLangSwitcher } from "@/components/i18n/GlobalLangSwitcher";
 import {
   buildPageMetadata,
   getSiteUrl,
@@ -105,7 +104,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       </head>
       <body className={`${appFontVariables} h-full min-h-screen antialiased`}>
         <NextIntlClientProvider locale={locale} messages={messages}>
-          <GlobalLangSwitcher />
           {children}
           <AppDomainDemoIntro />
         </NextIntlClientProvider>

--- a/app/manifesto/page.tsx
+++ b/app/manifesto/page.tsx
@@ -5,28 +5,18 @@ import matter from "gray-matter";
 import { DocsLayout } from "@/components/site/docs/DocsLayout";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
-import { DEFAULT_X_HANDLE, buildWebPageStructuredData, getCanonicalUrl, getPageOgImageUrl, getPageTwitterImageUrl } from "@/lib/seo";
+import { buildPageMetadata, buildWebPageStructuredData } from "@/lib/seo";
 
 export async function generateMetadata(): Promise<Metadata> {
   const source = fs.readFileSync(path.join(process.cwd(), "docs/manifesto.md"), "utf-8");
   const { data } = matter(source);
+  const title = `${data.title || "Manifesto"} — MUTX`;
+  const description = data.description as string;
+
   return {
-    title: `${data.title || "Manifesto"} — MUTX`,
-    description: data.description as string,
-    alternates: { canonical: getCanonicalUrl("/manifesto") },
-    openGraph: {
-      title: `${data.title || "Manifesto"} — MUTX`,
-      description: data.description as string,
-      url: getCanonicalUrl("/manifesto"),
-      images: [getPageOgImageUrl(`${data.title || "Manifesto"} — MUTX`, data.description as string, { path: "/manifesto" })],
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: DEFAULT_X_HANDLE,
-      title: `${data.title || "Manifesto"} — MUTX`,
-      description: data.description as string,
-      images: [getPageTwitterImageUrl(`${data.title || "Manifesto"} — MUTX`, data.description as string, { path: "/manifesto" })],
-    },
+    title,
+    description,
+    ...buildPageMetadata({ title, description, path: "/manifesto" }),
   };
 }
 

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,5 +1,12 @@
-import { getSiteUrl } from '@/lib/seo'
+import { headers } from 'next/headers'
+
 import { buildOgImageResponseWithCache } from '@/lib/og-image'
+import {
+  getDefaultSocialBadge,
+  getSurfaceUrl,
+  resolveSeoSurfaceForPath,
+  resolveSocialSection,
+} from '@/lib/seo'
 
 export const runtime = 'nodejs'
 export const revalidate = 3600
@@ -19,7 +26,12 @@ export default async function Image({
 }: {
   searchParams?: Promise<Record<string, string | string[] | undefined>>
 }) {
+  const requestHeaders = await headers()
   const query = (await searchParams) ?? {}
+  const requestHost = requestHeaders.get('x-forwarded-host') ?? requestHeaders.get('host')
+  const path = typeof query.path === 'string' ? query.path : '/'
+  const surface = resolveSeoSurfaceForPath(path, requestHost)
+  const section = resolveSocialSection(path, requestHost)
   const title = trim(
     typeof query.title === 'string' ? query.title : 'MUTX | Open Control Plane for AI Agents',
     96,
@@ -30,12 +42,17 @@ export default async function Image({
       : 'Operate deployed agents with real auth, deployments, traces, webhooks, runtime posture, and operator tooling across web, API, CLI, and docs.',
     180,
   )
-  const badge = trim(typeof query.badge === 'string' ? query.badge.toUpperCase() : 'MUTX', 24)
+  const badge = trim(
+    typeof query.badge === 'string' ? query.badge.toUpperCase() : getDefaultSocialBadge(path, requestHost),
+    24,
+  )
 
   return buildOgImageResponseWithCache({
     title,
     description,
     badge,
-    host: getSiteUrl(),
+    host: getSurfaceUrl(surface),
+    surface,
+    section,
   })
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { MarketingHomePage } from "@/components/site/marketing/MarketingHomePage";
 import { PublicFooter } from "@/components/site/PublicFooter";
 import { PublicSurface } from "@/components/site/PublicSurface";
-import { DEFAULT_X_HANDLE, getCanonicalUrl, getPageOgImageUrl, getSiteUrl } from "@/lib/seo";
+import { DEFAULT_X_HANDLE, buildPageMetadata, getSiteUrl } from "@/lib/seo";
 
 const homeTitle = "MUTX | See What Your AI Agents Are Doing";
 const homeDescription =
@@ -12,22 +12,11 @@ const homeDescription =
 export const metadata: Metadata = {
   title: homeTitle,
   description: homeDescription,
-  alternates: {
-    canonical: getCanonicalUrl(),
-  },
-  openGraph: {
+  ...buildPageMetadata({
     title: homeTitle,
     description: homeDescription,
-    url: getSiteUrl(),
-    images: [getPageOgImageUrl(homeTitle, homeDescription, { path: "/" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: homeTitle,
-    description: homeDescription,
-    images: [getPageOgImageUrl(homeTitle, homeDescription, { path: "/" })],
-  },
+    path: "/",
+  }),
 };
 
 const homepageStructuredData = {

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -5,28 +5,18 @@ import { PublicNav } from "@/components/site/PublicNav";
 import { PublicFooter } from "@/components/site/PublicFooter";
 import { PublicSurface } from "@/components/site/PublicSurface";
 import styles from "@/components/site/marketing/MarketingCore.module.css";
-import { DEFAULT_X_HANDLE, buildWebPageStructuredData, getCanonicalUrl, getPageOgImageUrl, getPageTwitterImageUrl } from "@/lib/seo";
+import { buildPageMetadata, buildWebPageStructuredData } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Privacy Policy | MUTX",
   description:
     "How MUTX handles data across the site, downloads, docs, and support surfaces.",
-  alternates: { canonical: getCanonicalUrl("/privacy-policy") },
-  openGraph: {
+  ...buildPageMetadata({
     title: "Privacy Policy | MUTX",
     description:
       "How MUTX handles data across the site, downloads, docs, and support surfaces.",
-    url: getCanonicalUrl("/privacy-policy"),
-    images: [getPageOgImageUrl("Privacy Policy | MUTX", undefined, { path: "/privacy-policy" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "Privacy Policy | MUTX",
-    description:
-      "How MUTX handles data across the site, downloads, docs, and support surfaces.",
-    images: [getPageTwitterImageUrl("Privacy Policy | MUTX", undefined, { path: "/privacy-policy" })],
-  },
+    path: "/privacy-policy",
+  }),
 };
 
 const sections = [

--- a/app/releases/page.tsx
+++ b/app/releases/page.tsx
@@ -18,30 +18,18 @@ import {
   buildReleaseNotesUrl,
   fetchLatestStableDesktopRelease,
 } from "@/lib/desktopRelease";
-import { DEFAULT_X_HANDLE, buildWebPageStructuredData, getCanonicalUrl, getPageOgImageUrl, getPageTwitterImageUrl } from "@/lib/seo";
+import { buildPageMetadata, buildWebPageStructuredData } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Releases | MUTX",
   description:
     "Current MUTX desktop release, signed macOS downloads, checksums, GitHub tag, and docs-backed release notes.",
-  alternates: {
-    canonical: getCanonicalUrl("/releases"),
-  },
-  openGraph: {
+  ...buildPageMetadata({
     title: "Releases | MUTX",
     description:
       "Current MUTX desktop release, signed macOS downloads, checksums, GitHub tag, and docs-backed release notes.",
-    url: getCanonicalUrl("/releases"),
-    images: [getPageOgImageUrl("Releases | MUTX", "Current MUTX desktop release, signed macOS downloads, checksums, GitHub tag, and docs-backed release notes.", { path: "/releases" })],
-  },
-  twitter: {
-    card: "summary_large_image",
-    creator: DEFAULT_X_HANDLE,
-    title: "Releases | MUTX",
-    description:
-      "Current MUTX desktop release, signed macOS downloads, checksums, GitHub tag, and docs-backed release notes.",
-    images: [getPageTwitterImageUrl("Releases | MUTX", "Current MUTX desktop release, signed macOS downloads, checksums, GitHub tag, and docs-backed release notes.", { path: "/releases" })],
-  },
+    path: "/releases",
+  }),
 };
 
 export const revalidate = 900;

--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -5,29 +5,19 @@ import matter from "gray-matter";
 import { DocsLayout } from "@/components/site/docs/DocsLayout";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
-import { DEFAULT_X_HANDLE, buildWebPageStructuredData, getCanonicalUrl, getPageOgImageUrl, getPageTwitterImageUrl } from "@/lib/seo";
+import { buildPageMetadata, buildWebPageStructuredData } from "@/lib/seo";
 
 
 export async function generateMetadata(): Promise<Metadata> {
   const source = fs.readFileSync(path.join(process.cwd(), "docs/roadmap.md"), "utf-8");
   const { data } = matter(source);
+  const title = `${data.title || "Roadmap"} — MUTX`;
+  const description = data.description as string;
+
   return {
-    title: `${data.title || "Roadmap"} — MUTX`,
-    description: data.description as string,
-    alternates: { canonical: getCanonicalUrl("/roadmap") },
-    openGraph: {
-      title: `${data.title || "Roadmap"} — MUTX`,
-      description: data.description as string,
-      url: getCanonicalUrl("/roadmap"),
-      images: [getPageOgImageUrl(`${data.title || "Roadmap"} — MUTX`, data.description as string, { path: "/roadmap" })],
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: DEFAULT_X_HANDLE,
-      title: `${data.title || "Roadmap"} — MUTX`,
-      description: data.description as string,
-      images: [getPageTwitterImageUrl(`${data.title || "Roadmap"} — MUTX`, data.description as string, { path: "/roadmap" })],
-    },
+    title,
+    description,
+    ...buildPageMetadata({ title, description, path: "/roadmap" }),
   };
 }
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,9 +1,51 @@
 import type { MetadataRoute } from 'next'
+import { headers } from 'next/headers'
 
-import { BLOCKED_CRAWL_PREFIXES, getSiteUrl } from '@/lib/seo'
+import {
+  BLOCKED_CRAWL_PREFIXES,
+  getAppUrl,
+  getPicoUrl,
+  getSiteUrl,
+  resolveSeoSurface,
+} from '@/lib/seo'
 
-export default function robots(): MetadataRoute.Robots {
+export default async function robots(): Promise<MetadataRoute.Robots> {
+  const requestHeaders = await headers()
+  const requestHost = requestHeaders.get('x-forwarded-host') ?? requestHeaders.get('host')
+  const surface = resolveSeoSurface(requestHost)
   const siteUrl = getSiteUrl()
+
+  if (surface === 'app') {
+    const appUrl = getAppUrl()
+
+    return {
+      rules: [
+        {
+          userAgent: '*',
+          allow: ['/control', '/opengraph-image', '/twitter-image'],
+          disallow: ['/'],
+        },
+      ],
+      sitemap: `${appUrl}/sitemap.xml`,
+      host: appUrl,
+    }
+  }
+
+  if (surface === 'pico') {
+    const picoUrl = getPicoUrl()
+
+    return {
+      rules: [
+        {
+          userAgent: '*',
+          allow: '/',
+          disallow: [...BLOCKED_CRAWL_PREFIXES, '/wip'],
+        },
+      ],
+      sitemap: `${picoUrl}/sitemap.xml`,
+      host: picoUrl,
+    }
+  }
 
   return {
     rules: [

--- a/app/sdk/page.tsx
+++ b/app/sdk/page.tsx
@@ -5,29 +5,19 @@ import matter from "gray-matter";
 import { DocsLayout } from "@/components/site/docs/DocsLayout";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
-import { DEFAULT_X_HANDLE, buildWebPageStructuredData, getCanonicalUrl, getPageOgImageUrl, getPageTwitterImageUrl } from "@/lib/seo";
+import { buildPageMetadata, buildWebPageStructuredData } from "@/lib/seo";
 
 
 export async function generateMetadata(): Promise<Metadata> {
   const source = fs.readFileSync(path.join(process.cwd(), "docs/sdk.md"), "utf-8");
   const { data } = matter(source);
+  const title = `${data.title || "SDK"} — MUTX`;
+  const description = data.description as string;
+
   return {
-    title: `${data.title || "SDK"} — MUTX`,
-    description: data.description as string,
-    alternates: { canonical: getCanonicalUrl("/sdk") },
-    openGraph: {
-      title: `${data.title || "SDK"} — MUTX`,
-      description: data.description as string,
-      url: getCanonicalUrl("/sdk"),
-      images: [getPageOgImageUrl(`${data.title || "SDK"} — MUTX`, data.description as string, { path: "/sdk" })],
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: DEFAULT_X_HANDLE,
-      title: `${data.title || "SDK"} — MUTX`,
-      description: data.description as string,
-      images: [getPageTwitterImageUrl(`${data.title || "SDK"} — MUTX`, data.description as string, { path: "/sdk" })],
-    },
+    title,
+    description,
+    ...buildPageMetadata({ title, description, path: "/sdk" }),
   };
 }
 

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -5,29 +5,19 @@ import matter from "gray-matter";
 import { DocsLayout } from "@/components/site/docs/DocsLayout";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
-import { DEFAULT_X_HANDLE, buildWebPageStructuredData, getCanonicalUrl, getPageOgImageUrl, getPageTwitterImageUrl } from "@/lib/seo";
+import { buildPageMetadata, buildWebPageStructuredData } from "@/lib/seo";
 
 
 export async function generateMetadata(): Promise<Metadata> {
   const source = fs.readFileSync(path.join(process.cwd(), "security.md"), "utf-8");
   const { data } = matter(source);
+  const title = `${data.title || "Security"} — MUTX`;
+  const description = data.description as string;
+
   return {
-    title: `${data.title || "Security"} — MUTX`,
-    description: data.description as string,
-    alternates: { canonical: getCanonicalUrl("/security") },
-    openGraph: {
-      title: `${data.title || "Security"} — MUTX`,
-      description: data.description as string,
-      url: getCanonicalUrl("/security"),
-      images: [getPageOgImageUrl(`${data.title || "Security"} — MUTX`, data.description as string, { path: "/security" })],
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: DEFAULT_X_HANDLE,
-      title: `${data.title || "Security"} — MUTX`,
-      description: data.description as string,
-      images: [getPageTwitterImageUrl(`${data.title || "Security"} — MUTX`, data.description as string, { path: "/security" })],
-    },
+    title,
+    description,
+    ...buildPageMetadata({ title, description, path: "/security" }),
   };
 }
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,16 @@
 import type { MetadataRoute } from 'next'
+import { headers } from 'next/headers'
 
 import { getDocSitemapRoutes } from '@/lib/docs'
-import { PUBLIC_MARKETING_ROUTES, toAbsoluteSiteUrl } from '@/lib/seo'
+import { PICO_LESSONS } from '@/lib/pico/academy'
+import {
+  PUBLIC_MARKETING_ROUTES,
+  getAppUrl,
+  getPicoUrl,
+  resolveSeoSurface,
+  toAbsoluteSiteUrl,
+  toAbsoluteUrl,
+} from '@/lib/seo'
 
 const routePriorities: Record<string, number> = {
   '/': 1,
@@ -28,8 +37,43 @@ const monthlyRoutes = new Set<string>([
   '/infrastructure',
 ])
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date()
+  const requestHeaders = await headers()
+  const requestHost = requestHeaders.get('x-forwarded-host') ?? requestHeaders.get('host')
+  const surface = resolveSeoSurface(requestHost)
+
+  if (surface === 'app') {
+    return [
+      {
+        url: toAbsoluteUrl(getAppUrl(), '/control'),
+        lastModified: now,
+        changeFrequency: 'weekly',
+        priority: 0.9,
+      },
+    ]
+  }
+
+  if (surface === 'pico') {
+    const picoRoutes = [
+      '/',
+      '/academy',
+      '/autopilot',
+      '/onboarding',
+      '/pricing',
+      '/support',
+      '/tutor',
+      ...PICO_LESSONS.map((lesson) => `/academy/${lesson.slug}`),
+    ]
+
+    return picoRoutes.map((route) => ({
+      url: toAbsoluteUrl(getPicoUrl(), route),
+      lastModified: now,
+      changeFrequency: route.startsWith('/academy/') ? 'weekly' : 'monthly',
+      priority: route === '/' ? 1 : route === '/academy' ? 0.9 : 0.72,
+    }))
+  }
+
   const routes = [...PUBLIC_MARKETING_ROUTES, ...getDocSitemapRoutes()].filter(
     (route, index, allRoutes) => allRoutes.indexOf(route) === index,
   )

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -5,28 +5,18 @@ import matter from "gray-matter";
 import { DocsLayout } from "@/components/site/docs/DocsLayout";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
-import { DEFAULT_X_HANDLE, buildWebPageStructuredData, getCanonicalUrl, getPageOgImageUrl, getPageTwitterImageUrl } from "@/lib/seo";
+import { buildPageMetadata, buildWebPageStructuredData } from "@/lib/seo";
 
 export async function generateMetadata(): Promise<Metadata> {
   const source = fs.readFileSync(path.join(process.cwd(), "support.md"), "utf-8");
   const { data } = matter(source);
+  const title = `${data.title || "Support"} — MUTX`;
+  const description = data.description as string;
+
   return {
-    title: `${data.title || "Support"} — MUTX`,
-    description: data.description as string,
-    alternates: { canonical: getCanonicalUrl("/support") },
-    openGraph: {
-      title: `${data.title || "Support"} — MUTX`,
-      description: data.description as string,
-      url: getCanonicalUrl("/support"),
-      images: [getPageOgImageUrl(`${data.title || "Support"} — MUTX`, data.description as string, { path: "/support" })],
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: DEFAULT_X_HANDLE,
-      title: `${data.title || "Support"} — MUTX`,
-      description: data.description as string,
-      images: [getPageTwitterImageUrl(`${data.title || "Support"} — MUTX`, data.description as string, { path: "/support" })],
-    },
+    title,
+    description,
+    ...buildPageMetadata({ title, description, path: "/support" }),
   };
 }
 

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,5 +1,12 @@
-import { getSiteUrl } from '@/lib/seo'
+import { headers } from 'next/headers'
+
 import { buildOgImageResponseWithCache } from '@/lib/og-image'
+import {
+  getDefaultSocialBadge,
+  getSurfaceUrl,
+  resolveSeoSurfaceForPath,
+  resolveSocialSection,
+} from '@/lib/seo'
 
 export const runtime = 'nodejs'
 export const revalidate = 3600
@@ -19,7 +26,12 @@ export default async function Image({
 }: {
   searchParams?: Promise<Record<string, string | string[] | undefined>>
 }) {
+  const requestHeaders = await headers()
   const query = (await searchParams) ?? {}
+  const requestHost = requestHeaders.get('x-forwarded-host') ?? requestHeaders.get('host')
+  const path = typeof query.path === 'string' ? query.path : '/'
+  const surface = resolveSeoSurfaceForPath(path, requestHost)
+  const section = resolveSocialSection(path, requestHost)
   const title = trim(
     typeof query.title === 'string' ? query.title : 'MUTX | Open Control Plane for AI Agents',
     96,
@@ -30,12 +42,17 @@ export default async function Image({
       : 'Operate deployed agents with real auth, deployments, traces, webhooks, runtime posture, and operator tooling across web, API, CLI, and docs.',
     180,
   )
-  const badge = trim(typeof query.badge === 'string' ? query.badge.toUpperCase() : 'MUTX', 24)
+  const badge = trim(
+    typeof query.badge === 'string' ? query.badge.toUpperCase() : getDefaultSocialBadge(path, requestHost),
+    24,
+  )
 
   return buildOgImageResponseWithCache({
     title,
     description,
     badge,
-    host: getSiteUrl(),
+    host: getSurfaceUrl(surface),
+    surface,
+    section,
   })
 }

--- a/app/whitepaper/page.tsx
+++ b/app/whitepaper/page.tsx
@@ -5,29 +5,19 @@ import matter from "gray-matter";
 import { DocsLayout } from "@/components/site/docs/DocsLayout";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
-import { DEFAULT_X_HANDLE, buildWebPageStructuredData, getCanonicalUrl, getPageOgImageUrl, getPageTwitterImageUrl } from "@/lib/seo";
+import { buildPageMetadata, buildWebPageStructuredData } from "@/lib/seo";
 
 
 export async function generateMetadata(): Promise<Metadata> {
   const source = fs.readFileSync(path.join(process.cwd(), "docs/whitepaper.md"), "utf-8");
   const { data } = matter(source);
+  const title = `${data.title || "Whitepaper"} — MUTX`;
+  const description = data.description as string;
+
   return {
-    title: `${data.title || "Whitepaper"} — MUTX`,
-    description: data.description as string,
-    alternates: { canonical: getCanonicalUrl("/whitepaper") },
-    openGraph: {
-      title: `${data.title || "Whitepaper"} — MUTX`,
-      description: data.description as string,
-      url: getCanonicalUrl("/whitepaper"),
-      images: [getPageOgImageUrl(`${data.title || "Whitepaper"} — MUTX`, data.description as string, { path: "/whitepaper" })],
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: DEFAULT_X_HANDLE,
-      title: `${data.title || "Whitepaper"} — MUTX`,
-      description: data.description as string,
-      images: [getPageTwitterImageUrl(`${data.title || "Whitepaper"} — MUTX`, data.description as string, { path: "/whitepaper" })],
-    },
+    title,
+    description,
+    ...buildPageMetadata({ title, description, path: "/whitepaper" }),
   };
 }
 

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -33,6 +33,7 @@ import {
 
 interface DashboardShellProps {
   children: ReactNode;
+  spaShellEnabled?: boolean;
 }
 
 interface DashboardNavProps {

--- a/lib/og-image.tsx
+++ b/lib/og-image.tsx
@@ -1,13 +1,18 @@
-import { ImageResponse } from 'next/og'
-import type { ReactElement } from 'react'
 import { readFile } from 'fs/promises'
 import { join } from 'path'
+
+import { ImageResponse } from 'next/og'
+import type { ReactElement } from 'react'
+
+import type { SeoSurface, SocialSection } from '@/lib/seo'
 
 type OgImageOptions = {
   title: string
   description?: string
   badge?: string
   host?: string
+  surface?: SeoSurface
+  section?: SocialSection
 }
 
 type CachedImageEntry = {
@@ -15,19 +20,85 @@ type CachedImageEntry = {
   expiresAt: number
 }
 
+type Theme = {
+  background: string
+  haloA: string
+  haloB: string
+  panel: string
+  panelSoft: string
+  stroke: string
+  grid: string
+  text: string
+  muted: string
+  accent: string
+  accentSoft: string
+  signal: string
+  signalSoft: string
+  band: string
+  brandLabel: string
+}
+
 const WIDTH = 1200
 const HEIGHT = 630
-const BG = '#060810'
-const BG_GRADIENT_END = '#0c1220'
-const TEXT_WHITE = '#ffffff'
-const TEXT_MUTED = '#94a3b8'
-const ACCENT = '#68e1ff'
-const LOGO_RED = '#FF4E4E'
 const DEFAULT_HOST = 'mutx.dev'
 const IMAGE_CACHE_TTL_MS = 60 * 60 * 1000
 const IMAGE_CACHE_MAX_ENTRIES = 200
 const RENDER_RATE_LIMIT_WINDOW_MS = 60 * 1000
 const RENDER_RATE_LIMIT_MAX = 120
+
+const SURFACE_THEMES: Record<SeoSurface, Theme> = {
+  marketing: {
+    background: 'linear-gradient(135deg, #040912 0%, #0a1323 48%, #110d19 100%)',
+    haloA: 'rgba(109, 225, 255, 0.22)',
+    haloB: 'rgba(255, 93, 93, 0.18)',
+    panel: 'rgba(9, 16, 28, 0.88)',
+    panelSoft: 'rgba(10, 18, 32, 0.64)',
+    stroke: 'rgba(109, 225, 255, 0.18)',
+    grid: 'rgba(109, 225, 255, 0.08)',
+    text: '#f7fbff',
+    muted: '#96a8bf',
+    accent: '#6de1ff',
+    accentSoft: 'rgba(109, 225, 255, 0.14)',
+    signal: '#ff5d5d',
+    signalSoft: 'rgba(255, 93, 93, 0.18)',
+    band: 'linear-gradient(90deg, #ff5d5d 0%, #6de1ff 52%, #ff5d5d 100%)',
+    brandLabel: 'OPEN CONTROL FOR DEPLOYED AGENTS',
+  },
+  app: {
+    background: 'linear-gradient(135deg, #0b1118 0%, #121a26 38%, #17141f 100%)',
+    haloA: 'rgba(125, 211, 252, 0.18)',
+    haloB: 'rgba(251, 191, 36, 0.14)',
+    panel: 'rgba(17, 24, 36, 0.9)',
+    panelSoft: 'rgba(19, 26, 39, 0.7)',
+    stroke: 'rgba(125, 211, 252, 0.16)',
+    grid: 'rgba(148, 163, 184, 0.1)',
+    text: '#f8fafc',
+    muted: '#a4b3c3',
+    accent: '#7dd3fc',
+    accentSoft: 'rgba(125, 211, 252, 0.14)',
+    signal: '#fbbf24',
+    signalSoft: 'rgba(251, 191, 36, 0.2)',
+    band: 'linear-gradient(90deg, #fbbf24 0%, #7dd3fc 50%, #fbbf24 100%)',
+    brandLabel: 'OPERATOR SURFACE FOR RUNTIME CONTROL',
+  },
+  pico: {
+    background: 'linear-gradient(135deg, #fff7eb 0%, #ffe8da 38%, #edfdf5 100%)',
+    haloA: 'rgba(249, 115, 22, 0.18)',
+    haloB: 'rgba(16, 185, 129, 0.16)',
+    panel: 'rgba(255, 255, 255, 0.76)',
+    panelSoft: 'rgba(255, 255, 255, 0.46)',
+    stroke: 'rgba(20, 51, 58, 0.12)',
+    grid: 'rgba(20, 51, 58, 0.08)',
+    text: '#14333a',
+    muted: '#596f75',
+    accent: '#f97316',
+    accentSoft: 'rgba(249, 115, 22, 0.14)',
+    signal: '#10b981',
+    signalSoft: 'rgba(16, 185, 129, 0.16)',
+    band: 'linear-gradient(90deg, #10b981 0%, #f97316 52%, #10b981 100%)',
+    brandLabel: 'GUIDED BUILDER FOR SHIPPABLE STACKS',
+  },
+}
 
 let geistRegular: ArrayBuffer | undefined
 let geistBold: ArrayBuffer | undefined
@@ -58,145 +129,609 @@ function trimCopy(value: string, max: number) {
   return `${value.slice(0, max - 3).trimEnd()}...`
 }
 
-export async function buildOgImage({ title, description, badge, host = DEFAULT_HOST }: OgImageOptions) {
-  const [regularFontData, boldFontData] = await Promise.all([
-    loadFont('regular'),
-    loadFont('bold'),
-  ])
+function getTheme(surface: SeoSurface = 'marketing') {
+  return SURFACE_THEMES[surface]
+}
 
-  const displayTitle = trimCopy(title.trim(), 96)
-  const displayDescription = description?.trim() ? trimCopy(description.trim(), 180) : undefined
-  const displayBadge = badge?.trim() ? trimCopy(badge.trim().toUpperCase(), 36) : undefined
-  const displayHost = trimCopy(host.replace(/^https?:\/\//, '').replace(/\/$/, ''), 36)
+function getSectionLabel(section: SocialSection, surface: SeoSurface) {
+  const labels: Record<SocialSection, string> = {
+    home: surface === 'pico' ? 'Guided Builder' : surface === 'app' ? 'Operator Surface' : 'Control Plane',
+    docs: 'Docs Surface',
+    download: 'Release Channel',
+    releases: 'Ship Ledger',
+    contact: 'Operator Contact',
+    legal: 'Policy Layer',
+    security: 'Security Posture',
+    support: 'Support Lane',
+    governance: 'Governance Controls',
+    approvals: 'Human Gate',
+    audit: 'Decision Ledger',
+    control: surface === 'app' ? 'Control Deck' : 'Control Plane',
+    cost: 'Budget Signal',
+    deployment: 'Deploy Lane',
+    guardrails: 'Runtime Guard',
+    infrastructure: 'Stack Topology',
+    monitoring: 'Runtime Signal',
+    reliability: 'Failure Envelope',
+    academy: 'Learning Track',
+    tutor: 'Guided Tutor',
+    autopilot: 'Assisted Autopilot',
+    pricing: 'Plan Matrix',
+    onboarding: 'First Run',
+    manifesto: 'Manifest',
+    roadmap: 'Roadmap',
+    whitepaper: 'Briefing',
+    sdk: 'SDK Surface',
+    generic: surface === 'pico' ? 'PicoMUTX' : surface === 'app' ? 'App Surface' : 'MUTX Surface',
+  }
 
-  const markup = (
+  return labels[section]
+}
+
+function renderStackMotif(theme: Theme) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 18, width: '100%' }}>
+      {[0, 1, 2].map((index) => (
+        <div
+          key={index}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 12,
+            marginLeft: index * 18,
+            padding: '18px 20px',
+            borderRadius: 24,
+            background: theme.panel,
+            border: `1px solid ${theme.stroke}`,
+            boxShadow: `0 20px 48px ${theme.accentSoft}`,
+          }}
+        >
+          <div style={{ display: 'flex', gap: 8 }}>
+            <div style={{ width: 12, height: 12, borderRadius: 999, background: theme.signal }} />
+            <div style={{ width: 12, height: 12, borderRadius: 999, background: theme.accent }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ width: '76%', height: 10, borderRadius: 999, background: theme.accentSoft }} />
+            <div style={{ width: '92%', height: 10, borderRadius: 999, background: theme.stroke }} />
+            <div style={{ width: '61%', height: 10, borderRadius: 999, background: theme.stroke }} />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function renderLedgerMotif(theme: Theme) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+        width: '100%',
+      }}
+    >
+      {[0, 1, 2, 3].map((index) => (
+        <div
+          key={index}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 14,
+            padding: '16px 18px',
+            borderRadius: 22,
+            background: theme.panel,
+            border: `1px solid ${theme.stroke}`,
+          }}
+        >
+          <div
+            style={{
+              width: 44,
+              height: 44,
+              borderRadius: 16,
+              background: index % 2 === 0 ? theme.signalSoft : theme.accentSoft,
+              border: `1px solid ${index % 2 === 0 ? theme.signal : theme.accent}`,
+            }}
+          />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, flex: 1 }}>
+            <div style={{ width: `${72 - index * 6}%`, height: 10, borderRadius: 999, background: theme.text }} />
+            <div style={{ width: `${92 - index * 8}%`, height: 9, borderRadius: 999, background: theme.stroke }} />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function renderPanelMotif(theme: Theme) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 18,
+        width: '100%',
+        padding: 24,
+        borderRadius: 28,
+        background: theme.panel,
+        border: `1px solid ${theme.stroke}`,
+      }}
+    >
+      <div style={{ display: 'flex', gap: 10 }}>
+        <div style={{ width: 14, height: 14, borderRadius: 999, background: theme.signal }} />
+        <div style={{ width: 14, height: 14, borderRadius: 999, background: theme.accent }} />
+      </div>
+      <div style={{ display: 'flex', gap: 14 }}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+            flex: 1.1,
+            padding: 18,
+            borderRadius: 22,
+            background: theme.panelSoft,
+            border: `1px solid ${theme.stroke}`,
+          }}
+        >
+          <div style={{ width: '72%', height: 10, borderRadius: 999, background: theme.accentSoft }} />
+          <div style={{ width: '100%', height: 86, borderRadius: 18, background: theme.signalSoft }} />
+          <div style={{ display: 'flex', gap: 8 }}>
+            <div style={{ width: '54%', height: 10, borderRadius: 999, background: theme.stroke }} />
+            <div style={{ width: '28%', height: 10, borderRadius: 999, background: theme.accentSoft }} />
+          </div>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+            flex: 0.8,
+          }}
+        >
+          {[0, 1, 2].map((index) => (
+            <div
+              key={index}
+              style={{
+                display: 'flex',
+                flex: 1,
+                borderRadius: 20,
+                background: theme.panelSoft,
+                border: `1px solid ${theme.stroke}`,
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function renderPathMotif(theme: Theme) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+        width: '100%',
+      }}
+    >
+      {[0, 1, 2].map((index) => (
+        <div
+          key={index}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+          }}
+        >
+          <div
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: 18,
+              background: index === 1 ? theme.signalSoft : theme.accentSoft,
+              border: `1px solid ${index === 1 ? theme.signal : theme.accent}`,
+            }}
+          />
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 8,
+              flex: 1,
+              padding: '16px 18px',
+              borderRadius: 22,
+              background: theme.panel,
+              border: `1px solid ${theme.stroke}`,
+            }}
+          >
+            <div style={{ width: `${82 - index * 12}%`, height: 10, borderRadius: 999, background: theme.text }} />
+            <div style={{ width: `${100 - index * 10}%`, height: 9, borderRadius: 999, background: theme.stroke }} />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function renderPackageMotif(theme: Theme) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 18,
+        width: '100%',
+        padding: 24,
+        borderRadius: 28,
+        background: theme.panel,
+        border: `1px solid ${theme.stroke}`,
+        boxShadow: `0 20px 48px ${theme.signalSoft}`,
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ display: 'flex', gap: 10 }}>
+          <div style={{ width: 14, height: 14, borderRadius: 999, background: theme.signal }} />
+          <div style={{ width: 14, height: 14, borderRadius: 999, background: theme.accent }} />
+        </div>
+        <div
+          style={{
+            padding: '6px 12px',
+            borderRadius: 999,
+            background: theme.accentSoft,
+            color: theme.accent,
+            fontSize: 16,
+          }}
+        >
+          release
+        </div>
+      </div>
+
       <div
         style={{
-          width: '100%',
-          height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          justifyContent: 'space-between',
-          background: `linear-gradient(135deg, ${BG} 0%, ${BG_GRADIENT_END} 100%)`,
-          color: TEXT_WHITE,
-          padding: '64px 72px',
-          position: 'relative',
-          overflow: 'hidden',
-          fontFamily: 'Geist',
+          gap: 14,
+          padding: 18,
+          borderRadius: 22,
+          background: theme.panelSoft,
+          border: `1px solid ${theme.stroke}`,
+        }}
+      >
+        <div style={{ width: '78%', height: 10, borderRadius: 999, background: theme.text }} />
+        <div style={{ width: '94%', height: 10, borderRadius: 999, background: theme.stroke }} />
+        <div style={{ width: '62%', height: 10, borderRadius: 999, background: theme.stroke }} />
+      </div>
+
+      <div style={{ display: 'flex', gap: 12 }}>
+        {[0, 1, 2].map((index) => (
+          <div
+            key={index}
+            style={{
+              display: 'flex',
+              flex: 1,
+              minHeight: 86,
+              borderRadius: 22,
+              background: index === 1 ? theme.signalSoft : theme.accentSoft,
+              border: `1px solid ${index === 1 ? theme.signal : theme.accent}`,
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function renderSectionMotif(section: SocialSection, theme: Theme) {
+  switch (section) {
+    case 'download':
+    case 'releases':
+      return renderPackageMotif(theme)
+    case 'governance':
+    case 'approvals':
+    case 'audit':
+    case 'security':
+    case 'legal':
+    case 'support':
+      return renderLedgerMotif(theme)
+    case 'control':
+    case 'monitoring':
+    case 'cost':
+    case 'guardrails':
+    case 'reliability':
+      return renderPanelMotif(theme)
+    case 'deployment':
+    case 'roadmap':
+    case 'manifesto':
+    case 'whitepaper':
+      return renderPathMotif(theme)
+    case 'docs':
+    case 'infrastructure':
+    case 'sdk':
+      return renderStackMotif(theme)
+    case 'academy':
+    case 'tutor':
+    case 'autopilot':
+    case 'pricing':
+    case 'onboarding':
+    case 'home':
+    case 'contact':
+    case 'generic':
+    default:
+      return renderPathMotif(theme)
+  }
+}
+
+export async function buildOgImage({
+  title,
+  description,
+  badge,
+  host = DEFAULT_HOST,
+  surface = 'marketing',
+  section = 'generic',
+}: OgImageOptions) {
+  const [regularFontData, boldFontData] = await Promise.all([loadFont('regular'), loadFont('bold')])
+  const theme = getTheme(surface)
+  const displayTitle = trimCopy(title.trim(), 96)
+  const displayDescription = description?.trim() ? trimCopy(description.trim(), 180) : undefined
+  const displayBadge = trimCopy((badge?.trim() || getSectionLabel(section, surface)).toUpperCase(), 36)
+  const displayHost = trimCopy(host.replace(/^https?:\/\//, '').replace(/\/$/, ''), 36)
+  const brandMark = surface === 'pico' ? 'PICO' : 'MUTX'
+
+  const markup = (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        position: 'relative',
+        overflow: 'hidden',
+        background: theme.background,
+        color: theme.text,
+        fontFamily: 'Geist',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'flex',
+          backgroundImage: `linear-gradient(${theme.grid} 1px, transparent 1px), linear-gradient(90deg, ${theme.grid} 1px, transparent 1px)`,
+          backgroundSize: '54px 54px',
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          top: -120,
+          right: -80,
+          width: 360,
+          height: 360,
+          borderRadius: 999,
+          background: theme.haloA,
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          left: -110,
+          bottom: -140,
+          width: 340,
+          height: 340,
+          borderRadius: 999,
+          background: theme.haloB,
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: 5,
+          background: theme.band,
+        }}
+      />
+
+      <div
+        style={{
+          display: 'flex',
+          width: '100%',
+          height: '100%',
+          padding: '54px 58px 50px',
+          gap: 28,
         }}
       >
         <div
           style={{
-            position: 'absolute',
-            inset: 0,
-            backgroundImage:
-              'linear-gradient(rgba(104,225,255,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(104,225,255,0.04) 1px, transparent 1px)',
-            backgroundSize: '60px 60px',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            flex: 1.15,
+            padding: 34,
+            borderRadius: 34,
+            background: theme.panel,
+            border: `1px solid ${theme.stroke}`,
+            boxShadow: `0 30px 80px ${theme.accentSoft}`,
           }}
-        />
-        <div
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            height: 4,
-            background: `linear-gradient(90deg, ${LOGO_RED} 0%, ${ACCENT} 50%, ${LOGO_RED} 100%)`,
-          }}
-        />
-
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 22, maxWidth: 930 }}>
-          {displayBadge ? (
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 22 }}>
             <div
               style={{
                 display: 'flex',
                 alignItems: 'center',
-                alignSelf: 'flex-start',
-                borderRadius: 999,
-                border: `1px solid rgba(104,225,255,0.28)`,
-                background: 'rgba(104,225,255,0.1)',
-                color: ACCENT,
-                padding: '8px 18px',
-                fontSize: 18,
-                letterSpacing: '0.08em',
+                justifyContent: 'space-between',
+                gap: 16,
               }}
             >
-              {displayBadge}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  alignSelf: 'flex-start',
+                  borderRadius: 999,
+                  border: `1px solid ${theme.stroke}`,
+                  background: theme.accentSoft,
+                  color: theme.accent,
+                  padding: '8px 16px',
+                  fontSize: 18,
+                  letterSpacing: '0.08em',
+                }}
+              >
+                {displayBadge}
+              </div>
+              <div style={{ display: 'flex', gap: 10 }}>
+                <div style={{ width: 12, height: 12, borderRadius: 999, background: theme.signal }} />
+                <div style={{ width: 12, height: 12, borderRadius: 999, background: theme.accent }} />
+              </div>
             </div>
-          ) : null}
+
+            <div
+              style={{
+                display: 'flex',
+                fontSize: 62,
+                lineHeight: 1.05,
+                letterSpacing: '-0.035em',
+                fontWeight: 700,
+              }}
+            >
+              {displayTitle}
+            </div>
+
+            {displayDescription ? (
+              <div
+                style={{
+                  display: 'flex',
+                  maxWidth: 760,
+                  fontSize: 28,
+                  lineHeight: 1.32,
+                  color: theme.muted,
+                }}
+              >
+                {displayDescription}
+              </div>
+            ) : null}
+          </div>
 
           <div
             style={{
               display: 'flex',
-              fontSize: 62,
-              lineHeight: 1.08,
-              letterSpacing: '-0.03em',
-              fontWeight: 700,
+              flexDirection: 'column',
+              gap: 18,
             }}
           >
-            {displayTitle}
-          </div>
-
-          {displayDescription ? (
             <div
               style={{
                 display: 'flex',
-                maxWidth: 800,
-                fontSize: 28,
-                lineHeight: 1.35,
-                color: TEXT_MUTED,
+                gap: 12,
+                flexWrap: 'wrap',
               }}
             >
-              {displayDescription}
+              {[
+                getSectionLabel(section, surface),
+                surface === 'app' ? 'Operator-grade' : surface === 'pico' ? 'Builder-first' : 'Public surface',
+                displayHost,
+              ].map((chip) => (
+                <div
+                  key={chip}
+                  style={{
+                    display: 'flex',
+                    padding: '10px 14px',
+                    borderRadius: 999,
+                    background: theme.panelSoft,
+                    border: `1px solid ${theme.stroke}`,
+                    color: theme.muted,
+                    fontSize: 18,
+                  }}
+                >
+                  {chip}
+                </div>
+              ))}
             </div>
-          ) : null}
+
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                width: '100%',
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: 18 }}>
+                <div
+                  style={{
+                    width: 48,
+                    height: 48,
+                    borderRadius: 16,
+                    background: `linear-gradient(135deg, ${theme.signal} 0%, ${theme.accent} 100%)`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color: surface === 'pico' ? '#fff7eb' : '#ffffff',
+                    fontWeight: 700,
+                    fontSize: 16,
+                    letterSpacing: '0.08em',
+                  }}
+                >
+                  {brandMark}
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <div style={{ display: 'flex', fontSize: 24, fontWeight: 700, letterSpacing: '0.12em' }}>
+                    {surface === 'pico' ? 'PICOMUTX' : 'MUTX'}
+                  </div>
+                  <div style={{ display: 'flex', fontSize: 14, color: theme.muted, letterSpacing: '0.06em' }}>
+                    {theme.brandLabel}
+                  </div>
+                </div>
+              </div>
+
+              <div style={{ display: 'flex', fontSize: 18, color: theme.muted, letterSpacing: '0.05em' }}>
+                {displayHost}
+              </div>
+            </div>
+          </div>
         </div>
 
         <div
           style={{
             display: 'flex',
-            alignItems: 'center',
+            flexDirection: 'column',
             justifyContent: 'space-between',
-            width: '100%',
+            flex: 0.85,
+            padding: 30,
+            borderRadius: 34,
+            background: theme.panelSoft,
+            border: `1px solid ${theme.stroke}`,
+            boxShadow: `0 30px 80px ${theme.signalSoft}`,
           }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 18 }}>
-            <div
-              style={{
-                width: 42,
-                height: 42,
-                borderRadius: 12,
-                background: `linear-gradient(135deg, ${LOGO_RED} 0%, #C92D2D 100%)`,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                boxShadow: '0 10px 30px rgba(255,78,78,0.28)',
-              }}
-            >
-              <div
-                style={{
-                  width: 14,
-                  height: 14,
-                  borderRadius: 999,
-                  background: '#19E0DA',
-                }}
-              />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div style={{ display: 'flex', fontSize: 18, letterSpacing: '0.12em', color: theme.muted }}>
+              SECTION
             </div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-              <div style={{ display: 'flex', fontSize: 24, fontWeight: 700, letterSpacing: '0.12em' }}>
-                MUTX
-              </div>
-              <div style={{ display: 'flex', fontSize: 14, color: TEXT_MUTED, letterSpacing: '0.06em' }}>
-                OPEN CONTROL FOR DEPLOYED AGENTS
-              </div>
+            <div style={{ display: 'flex', fontSize: 34, lineHeight: 1.1, fontWeight: 700 }}>
+              {getSectionLabel(section, surface)}
             </div>
           </div>
 
-          <div style={{ display: 'flex', fontSize: 18, color: TEXT_MUTED, letterSpacing: '0.05em' }}>
-            {displayHost}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'stretch',
+              justifyContent: 'center',
+              width: '100%',
+              flex: 1,
+              paddingTop: 18,
+              paddingBottom: 18,
+            }}
+          >
+            {renderSectionMotif(section, theme)}
           </div>
         </div>
       </div>
+    </div>
   ) satisfies ReactElement
 
   return new ImageResponse(markup, {
@@ -209,12 +744,21 @@ export async function buildOgImage({ title, description, badge, host = DEFAULT_H
   })
 }
 
-function cacheKey({ title, description, badge, host = DEFAULT_HOST }: OgImageOptions) {
+function cacheKey({
+  title,
+  description,
+  badge,
+  host = DEFAULT_HOST,
+  surface = 'marketing',
+  section = 'generic',
+}: OgImageOptions) {
   return JSON.stringify({
     title: trimCopy(title.trim(), 96),
     description: description?.trim() ? trimCopy(description.trim(), 180) : '',
     badge: badge?.trim() ? trimCopy(badge.trim().toUpperCase(), 36) : '',
     host: trimCopy(host.replace(/^https?:\/\//, '').replace(/\/$/, ''), 36),
+    surface,
+    section,
   })
 }
 

--- a/lib/pico/metadata.ts
+++ b/lib/pico/metadata.ts
@@ -4,12 +4,9 @@ import { getLocale, getTranslations } from 'next-intl/server'
 import { routing } from '@/i18n/routing'
 import { resolvePicoLocale } from '@/lib/pico/locale'
 import {
-  DEFAULT_X_HANDLE,
-  getPageOgImageUrl,
-  getPageTwitterImageUrl,
+  buildPageMetadata,
+  getPicoUrl,
 } from '@/lib/seo'
-
-const PICO_HOST = 'https://pico.mutx.dev'
 
 export async function buildPicoPageMetadata(
   namespace: string,
@@ -20,30 +17,38 @@ export async function buildPicoPageMetadata(
   const t = await getTranslations({ locale, namespace })
   const title = t('title', values)
   const description = t('description', values)
-  const url = pathname === '/' ? PICO_HOST : `${PICO_HOST}${pathname}`
+  const picoHost = getPicoUrl()
+  const pageMetadata = buildPageMetadata({
+    title,
+    description,
+    path: pathname,
+    host: picoHost,
+    siteName: 'PicoMUTX',
+  })
+  const url = pathname === '/' ? picoHost : `${picoHost}${pathname}`
 
   return {
     title,
     description,
+    robots:
+      pathname === '/wip'
+        ? {
+            index: false,
+            follow: false,
+            nocache: true,
+          }
+        : undefined,
     alternates: {
-      canonical: url,
+      canonical: pageMetadata.alternates?.canonical ?? url,
       languages: Object.fromEntries(
         routing.locales.map((supportedLocale) => [supportedLocale, url]),
       ),
     },
     openGraph: {
-      title,
-      description,
-      url,
+      ...pageMetadata.openGraph,
       locale,
-      images: [getPageOgImageUrl(title, description, { path: pathname, host: PICO_HOST })],
+      url,
     },
-    twitter: {
-      card: 'summary_large_image',
-      creator: DEFAULT_X_HANDLE,
-      title,
-      description,
-      images: [getPageTwitterImageUrl(title, description, { path: pathname, host: PICO_HOST })],
-    },
+    twitter: pageMetadata.twitter,
   }
 }

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,8 +1,16 @@
+import type { Metadata } from 'next'
+
 export const DEFAULT_SITE_URL = 'https://mutx.dev'
 export const DEFAULT_APP_URL = 'https://app.mutx.dev'
+export const DEFAULT_PICO_URL = 'https://pico.mutx.dev'
+export const DEFAULT_DOCS_URL = `${DEFAULT_SITE_URL}/docs`
+export const DEFAULT_GITHUB_URL = 'https://github.com/mutx-dev/mutx-dev'
 export const DEFAULT_X_HANDLE = '@mutxdev'
 export const DEFAULT_OG_IMAGE = '/opengraph-image'
 export const DEFAULT_OG_IMAGE_ALT = 'MUTX branded social preview card'
+export const SOCIAL_IMAGE_WIDTH = 1200
+export const SOCIAL_IMAGE_HEIGHT = 630
+export const SOCIAL_IMAGE_TYPE = 'image/png'
 
 export const PUBLIC_MARKETING_ROUTES = [
   '/',
@@ -42,12 +50,145 @@ export const BLOCKED_CRAWL_PREFIXES = [
   '/onboarding',
 ] as const
 
+export type SeoSurface = 'marketing' | 'app' | 'pico'
+
+export type SocialSection =
+  | 'home'
+  | 'docs'
+  | 'download'
+  | 'releases'
+  | 'contact'
+  | 'legal'
+  | 'security'
+  | 'support'
+  | 'governance'
+  | 'approvals'
+  | 'audit'
+  | 'control'
+  | 'cost'
+  | 'deployment'
+  | 'guardrails'
+  | 'infrastructure'
+  | 'monitoring'
+  | 'reliability'
+  | 'academy'
+  | 'tutor'
+  | 'autopilot'
+  | 'pricing'
+  | 'onboarding'
+  | 'manifesto'
+  | 'roadmap'
+  | 'whitepaper'
+  | 'sdk'
+  | 'generic'
+
+type ArrayElement<T> = T extends readonly (infer Item)[] ? Item : T
+type OpenGraphImages = NonNullable<NonNullable<Metadata['openGraph']>['images']>
+type SocialImageDescriptor = ArrayElement<OpenGraphImages>
+
+const APP_HOSTNAMES = new Set(['app.mutx.dev', 'app.localhost'])
+const PICO_HOSTNAMES = new Set(['pico.mutx.dev', 'pico.mutxx.dev', 'pico.localhost'])
+
 function normalizeUrl(value: string | undefined, fallback: string) {
   if (!value) {
     return fallback
   }
 
   return value.replace(/\/$/, '')
+}
+
+function normalizePath(path = '/') {
+  if (!path || path === '/') {
+    return '/'
+  }
+
+  return path.startsWith('/') ? path : `/${path}`
+}
+
+function normalizeHostname(value?: string | null) {
+  if (!value) {
+    return null
+  }
+
+  const host = value.includes('://') ? new URL(value).hostname : value.split(':')[0]
+  return host.toLowerCase()
+}
+
+function getSiteNameForSurface(surface: SeoSurface) {
+  switch (surface) {
+    case 'app':
+      return 'MUTX App'
+    case 'pico':
+      return 'PicoMUTX'
+    default:
+      return 'MUTX'
+  }
+}
+
+export function resolveSocialSection(path = '/', host?: string | null): SocialSection {
+  const normalizedPath = normalizePath(path)
+  const surface = resolveSeoSurfaceForPath(normalizedPath, host)
+
+  if (surface === 'app') {
+    if (normalizedPath === '/control') {
+      return 'control'
+    }
+
+    if (normalizedPath === '/' || normalizedPath.startsWith('/dashboard')) {
+      return 'monitoring'
+    }
+  }
+
+  if (surface === 'pico') {
+    if (normalizedPath === '/academy' || normalizedPath.startsWith('/academy/')) {
+      return 'academy'
+    }
+
+    if (normalizedPath === '/tutor') {
+      return 'tutor'
+    }
+
+    if (normalizedPath === '/autopilot') {
+      return 'autopilot'
+    }
+
+    if (normalizedPath === '/pricing') {
+      return 'pricing'
+    }
+
+    if (normalizedPath === '/onboarding') {
+      return 'onboarding'
+    }
+
+    return 'generic'
+  }
+
+  if (normalizedPath === '/') return 'home'
+  if (normalizedPath === '/download' || normalizedPath.startsWith('/download/')) return 'download'
+  if (normalizedPath === '/releases') return 'releases'
+  if (normalizedPath === '/contact') return 'contact'
+  if (normalizedPath === '/privacy-policy') return 'legal'
+  if (normalizedPath === '/security') return 'security'
+  if (normalizedPath === '/support') return 'support'
+  if (normalizedPath === '/manifesto') return 'manifesto'
+  if (normalizedPath === '/roadmap') return 'roadmap'
+  if (normalizedPath === '/whitepaper') return 'whitepaper'
+  if (normalizedPath === '/sdk') return 'sdk'
+  if (normalizedPath === '/docs' || normalizedPath.startsWith('/docs/')) return 'docs'
+  if (normalizedPath === '/ai-agent-governance') return 'governance'
+  if (normalizedPath === '/ai-agent-approvals') return 'approvals'
+  if (normalizedPath === '/ai-agent-audit-logs') return 'audit'
+  if (normalizedPath === '/ai-agent-control-plane') return 'control'
+  if (normalizedPath === '/ai-agent-cost') return 'cost'
+  if (normalizedPath === '/ai-agent-deployment') return 'deployment'
+  if (normalizedPath === '/ai-agent-guardrails') return 'guardrails'
+  if (normalizedPath === '/ai-agent-infrastructure' || normalizedPath === '/infrastructure') {
+    return 'infrastructure'
+  }
+  if (normalizedPath === '/ai-agent-monitoring') return 'monitoring'
+  if (normalizedPath === '/ai-agent-reliability') return 'reliability'
+
+  return 'generic'
 }
 
 export function getSiteUrl() {
@@ -58,18 +199,84 @@ export function getAppUrl() {
   return normalizeUrl(process.env.NEXT_PUBLIC_APP_URL, DEFAULT_APP_URL)
 }
 
+export function getPicoUrl() {
+  return normalizeUrl(process.env.NEXT_PUBLIC_PICO_URL, DEFAULT_PICO_URL)
+}
+
+export function toAbsoluteUrl(origin: string, path = '/') {
+  const normalizedPath = normalizePath(path)
+  const normalizedOrigin = normalizeUrl(origin, origin)
+
+  return normalizedPath === '/' ? normalizedOrigin : `${normalizedOrigin}${normalizedPath}`
+}
+
 export function toAbsoluteSiteUrl(path = '/') {
-  const normalizedPath = path === '/' ? '' : path
-  return `${getSiteUrl()}${normalizedPath}`
+  return toAbsoluteUrl(getSiteUrl(), path)
 }
 
 export function toAbsoluteAppUrl(path = '/') {
-  const normalizedPath = path === '/' ? '' : path
-  return `${getAppUrl()}${normalizedPath}`
+  return toAbsoluteUrl(getAppUrl(), path)
 }
 
-export function getCanonicalUrl(path = '/') {
-  return toAbsoluteSiteUrl(path)
+export function toAbsolutePicoUrl(path = '/') {
+  return toAbsoluteUrl(getPicoUrl(), path)
+}
+
+export function resolveSeoSurface(hostname?: string | null): SeoSurface {
+  const normalizedHost = normalizeHostname(hostname)
+
+  if (normalizedHost && APP_HOSTNAMES.has(normalizedHost)) {
+    return 'app'
+  }
+
+  if (normalizedHost && PICO_HOSTNAMES.has(normalizedHost)) {
+    return 'pico'
+  }
+
+  return 'marketing'
+}
+
+export function resolveSeoSurfaceForPath(path = '/', host?: string | null): SeoSurface {
+  const surfaceFromHost = resolveSeoSurface(host)
+  if (surfaceFromHost !== 'marketing') {
+    return surfaceFromHost
+  }
+
+  const normalizedPath = normalizePath(path)
+
+  if (normalizedPath === '/control' || normalizedPath.startsWith('/dashboard')) {
+    return 'app'
+  }
+
+  if (
+    normalizedPath === '/pico' ||
+    normalizedPath.startsWith('/pico/') ||
+    normalizedPath === '/academy' ||
+    normalizedPath.startsWith('/academy/') ||
+    normalizedPath === '/tutor' ||
+    normalizedPath === '/autopilot' ||
+    normalizedPath === '/pricing' ||
+    normalizedPath === '/onboarding'
+  ) {
+    return 'pico'
+  }
+
+  return 'marketing'
+}
+
+export function getSurfaceUrl(surface: SeoSurface) {
+  switch (surface) {
+    case 'app':
+      return getAppUrl()
+    case 'pico':
+      return getPicoUrl()
+    default:
+      return getSiteUrl()
+  }
+}
+
+export function getCanonicalUrl(path = '/', host?: string) {
+  return toAbsoluteUrl(host ? normalizeUrl(host, getSiteUrl()) : getSiteUrl(), path)
 }
 
 /**
@@ -84,14 +291,6 @@ export function getTwitterImageUrl() {
   return toAbsoluteSiteUrl('/twitter-image')
 }
 
-/**
- * Generate a unique per-page image route backed by Next metadata image routes.
- */
-function getImageRouteBase(path = '/') {
-  if (path === '/pico') return '/pico'
-  return ''
-}
-
 export function getPageOgImageUrl(
   title: string,
   description?: string,
@@ -101,7 +300,7 @@ export function getPageOgImageUrl(
   if (description) params.set('description', description)
   if (options?.path) params.set('path', options.path)
   if (options?.badge) params.set('badge', options.badge)
-  const baseUrl = normalizeUrl(options?.host, toAbsoluteSiteUrl(getImageRouteBase(options?.path)))
+  const baseUrl = normalizeUrl(options?.host, getSiteUrl())
   return `${baseUrl}/opengraph-image?${params.toString()}`
 }
 
@@ -114,8 +313,174 @@ export function getPageTwitterImageUrl(
   if (description) params.set('description', description)
   if (options?.path) params.set('path', options.path)
   if (options?.badge) params.set('badge', options.badge)
-  const baseUrl = normalizeUrl(options?.host, toAbsoluteSiteUrl(getImageRouteBase(options?.path)))
+  const baseUrl = normalizeUrl(options?.host, getSiteUrl())
   return `${baseUrl}/twitter-image?${params.toString()}`
+}
+
+export function getDefaultSocialBadge(path = '/', host?: string | null) {
+  const section = resolveSocialSection(path, host)
+
+  switch (section) {
+    case 'docs':
+      return 'DOCS'
+    case 'download':
+      return 'DOWNLOAD'
+    case 'releases':
+      return 'RELEASES'
+    case 'contact':
+      return 'CONTACT'
+    case 'legal':
+      return 'LEGAL'
+    case 'security':
+      return 'SECURITY'
+    case 'support':
+      return 'SUPPORT'
+    case 'manifesto':
+      return 'MANIFESTO'
+    case 'roadmap':
+      return 'ROADMAP'
+    case 'whitepaper':
+      return 'WHITEPAPER'
+    case 'sdk':
+      return 'SDK'
+    case 'governance':
+      return 'GOVERNANCE'
+    case 'approvals':
+      return 'APPROVALS'
+    case 'audit':
+      return 'AUDIT'
+    case 'control':
+      return 'CONTROL PLANE'
+    case 'cost':
+      return 'COST'
+    case 'deployment':
+      return 'DEPLOYMENT'
+    case 'guardrails':
+      return 'GUARDRAILS'
+    case 'infrastructure':
+      return 'INFRASTRUCTURE'
+    case 'monitoring':
+      return 'OBSERVABILITY'
+    case 'reliability':
+      return 'RELIABILITY'
+    case 'academy':
+      return 'ACADEMY'
+    case 'tutor':
+      return 'TUTOR'
+    case 'autopilot':
+      return 'AUTOPILOT'
+    case 'pricing':
+      return 'PRICING'
+    case 'onboarding':
+      return 'ONBOARDING'
+    default: {
+      const surface = resolveSeoSurfaceForPath(path, host)
+      if (surface === 'app') return 'APP'
+      if (surface === 'pico') return 'PICOMUTX'
+      return 'MUTX'
+    }
+  }
+}
+
+export function getSocialImageAlt(title: string, path = '/', host?: string | null) {
+  return `${title} social preview for ${getSiteNameForSurface(resolveSeoSurfaceForPath(path, host))}`
+}
+
+function buildSocialImageDescriptor(options: {
+  title: string
+  description: string
+  path: string
+  host: string
+  badge?: string
+  type: 'openGraph' | 'twitter'
+}): SocialImageDescriptor {
+  const url =
+    options.type === 'openGraph'
+      ? getPageOgImageUrl(options.title, options.description, {
+          path: options.path,
+          host: options.host,
+          badge: options.badge,
+        })
+      : getPageTwitterImageUrl(options.title, options.description, {
+          path: options.path,
+          host: options.host,
+          badge: options.badge,
+        })
+
+  return {
+    url,
+    width: SOCIAL_IMAGE_WIDTH,
+    height: SOCIAL_IMAGE_HEIGHT,
+    alt: getSocialImageAlt(options.title, options.path, options.host),
+    type: SOCIAL_IMAGE_TYPE,
+  }
+}
+
+export function buildPageMetadata(options: {
+  title: string
+  description: string
+  path?: string
+  host?: string
+  siteName?: string
+  badge?: string
+  locale?: string
+  type?: 'website' | 'article'
+  socialTitle?: string
+  socialDescription?: string
+  twitterTitle?: string
+  twitterDescription?: string
+}): Pick<Metadata, 'alternates' | 'openGraph' | 'twitter'> {
+  const path = normalizePath(options.path)
+  const surface = resolveSeoSurfaceForPath(path, options.host)
+  const host = normalizeUrl(options.host, getSurfaceUrl(surface))
+  const siteName = options.siteName ?? getSiteNameForSurface(surface)
+  const badge = options.badge ?? getDefaultSocialBadge(path, host)
+  const canonical = getCanonicalUrl(path, host)
+  const socialTitle = options.socialTitle ?? options.title
+  const socialDescription = options.socialDescription ?? options.description
+  const twitterTitle = options.twitterTitle ?? socialTitle
+  const twitterDescription = options.twitterDescription ?? socialDescription
+
+  return {
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      title: socialTitle,
+      description: socialDescription,
+      url: canonical,
+      siteName,
+      locale: options.locale ?? 'en_US',
+      type: options.type ?? 'website',
+      images: [
+        buildSocialImageDescriptor({
+          title: socialTitle,
+          description: socialDescription,
+          path,
+          host,
+          badge,
+          type: 'openGraph',
+        }),
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      creator: DEFAULT_X_HANDLE,
+      site: DEFAULT_X_HANDLE,
+      title: twitterTitle,
+      description: twitterDescription,
+      images: [
+        buildSocialImageDescriptor({
+          title: twitterTitle,
+          description: twitterDescription,
+          path,
+          host,
+          badge,
+          type: 'twitter',
+        }),
+      ],
+    },
+  }
 }
 
 /**
@@ -128,6 +493,8 @@ export function buildWebPageStructuredData(options: {
   description: string
 }) {
   const siteUrl = getSiteUrl()
+  const canonicalUrl = getCanonicalUrl(options.path)
+
   return {
     '@context': 'https://schema.org',
     '@graph': [
@@ -136,23 +503,37 @@ export function buildWebPageStructuredData(options: {
         '@id': `${siteUrl}/#organization`,
         name: 'MUTX',
         url: siteUrl,
-        sameAs: [`https://x.com/${DEFAULT_X_HANDLE.replace('@', '')}`],
+        logo: `${siteUrl}/logo.png`,
+        sameAs: [DEFAULT_GITHUB_URL, `https://x.com/${DEFAULT_X_HANDLE.replace('@', '')}`],
+      },
+      {
+        '@type': 'WebSite',
+        '@id': `${siteUrl}/#website`,
+        name: 'MUTX',
+        url: siteUrl,
+        publisher: { '@id': `${siteUrl}/#organization` },
       },
       {
         '@type': 'SoftwareApplication',
+        '@id': `${siteUrl}/#software`,
         name: 'MUTX',
         applicationCategory: 'DeveloperApplication',
         description:
           'Source-available control plane for AI agent governance, deployment, and observability.',
+        operatingSystem: 'macOS',
+        url: siteUrl,
         downloadUrl: `${siteUrl}/download`,
+        publisher: { '@id': `${siteUrl}/#organization` },
         offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
       },
       {
         '@type': 'WebPage',
+        '@id': `${canonicalUrl}#webpage`,
         name: options.name,
-        url: getCanonicalUrl(options.path),
+        url: canonicalUrl,
         description: options.description,
-        isPartOf: { '@type': 'WebSite', name: 'MUTX', url: siteUrl },
+        isPartOf: { '@id': `${siteUrl}/#website` },
+        about: { '@id': `${siteUrl}/#software` },
       },
     ],
   }

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -110,8 +110,16 @@ function normalizeHostname(value?: string | null) {
     return null
   }
 
-  const host = value.includes('://') ? new URL(value).hostname : value.split(':')[0]
-  return host.toLowerCase()
+  const firstValue = value.split(',')[0]?.trim()
+  if (!firstValue) {
+    return null
+  }
+
+  try {
+    return new URL(firstValue).hostname.toLowerCase()
+  } catch {
+    return firstValue.split(':')[0].toLowerCase()
+  }
 }
 
 function getSiteNameForSurface(surface: SeoSurface) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "sync:pico-content": "node scripts/build-pico-content.mjs",
     "build:docs-search": "npx tsx scripts/build-docs-search-index.ts",
     "docs:watch": "npx tsx scripts/docs-watcher.ts",
-    "qa:pico-i18n": "node scripts/qa-pico-i18n.mjs"
+    "qa:pico-i18n": "node scripts/qa-pico-i18n.mjs",
+    "validate:social-embeds": "node scripts/validate-social-embeds.mjs"
   },
   "build": {
     "appId": "dev.mutx.desktop",

--- a/proxy.ts
+++ b/proxy.ts
@@ -594,15 +594,8 @@ export function proxy(request: NextRequest) {
       return finalizeResponse(NextResponse.next(), host, normalizedPath)
     }
 
-    if (normalizedPath === '/control') {
-      return finalizeResponse(redirectWithinHost(request, '/dashboard'), host, normalizedPath)
-    }
-    if (normalizedPath.startsWith('/control/')) {
-      return finalizeResponse(
-        redirectWithinHost(request, `/dashboard${normalizedPath.slice('/control'.length)}`),
-        host,
-        normalizedPath,
-      )
+    if (normalizedPath === '/control' || normalizedPath.startsWith('/control/')) {
+      return finalizeResponse(NextResponse.next(), host, normalizedPath)
     }
 
     if (normalizedPath === '/app' || normalizedPath.startsWith('/app/')) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -469,6 +469,25 @@ export function proxy(request: NextRequest) {
       picoPath = picoPath.slice('/pico'.length) || '/'
     }
 
+    // Canonical Pico product routes that serve real pages
+    const PICO_ROUTES = new Set([
+      '/',
+      '/start',
+      '/onboarding',
+      '/academy',
+      '/tutor',
+      '/support',
+      '/autopilot',
+      '/pricing',
+      '/opengraph-image',
+      '/twitter-image',
+    ])
+    const PICO_ROUTE_PREFIXES = ['/academy/']
+
+    const isPicoRoute =
+      PICO_ROUTES.has(picoPath) ||
+      PICO_ROUTE_PREFIXES.some((prefix) => picoPath.startsWith(prefix))
+
     if (picoPath === '/') {
       // Root -> landing page (public, no auth required)
       return finalizeResponse(
@@ -478,10 +497,41 @@ export function proxy(request: NextRequest) {
       )
     }
 
-    // While Pico is closed, every non-root, non-auth path on the Pico host
-    // canonicalizes back to the waitlist landing.
+    if (picoPath === '/start') {
+      // /start -> /pico/onboarding (canonical product entry alias)
+      return finalizeResponse(
+        applyPicoLocale(
+          rewriteWithinHost(request, '/pico/onboarding', picoRequestHeaders),
+          locale,
+        ),
+        host,
+        normalizedPath,
+      )
+    }
+
+    if (picoPath === '/opengraph-image' || picoPath === '/twitter-image') {
+      return finalizeResponse(
+        applyPicoLocale(nextWithinHost(picoRequestHeaders), locale),
+        host,
+        normalizedPath,
+      )
+    }
+
+    if (isPicoRoute) {
+      // Rewrite /<pico-route> -> /pico/<pico-route>
+      return finalizeResponse(
+        applyPicoLocale(
+          rewriteWithinHost(request, '/pico' + picoPath, picoRequestHeaders),
+          locale,
+        ),
+        host,
+        normalizedPath,
+      )
+    }
+
+    // Unknown paths -> WIP animation
     return finalizeResponse(
-      applyPicoLocale(redirectWithinHost(request, '/'), locale),
+      applyPicoLocale(rewriteWithinHost(request, '/pico/wip', picoRequestHeaders), locale),
       host,
       normalizedPath,
     )

--- a/scripts/validate-social-embeds.mjs
+++ b/scripts/validate-social-embeds.mjs
@@ -1,0 +1,238 @@
+import http from 'node:http'
+import https from 'node:https'
+
+const DEFAULT_BASE_URL = process.env.SOCIAL_EMBED_BASE_URL ?? 'http://127.0.0.1:3000'
+
+const BOT_USER_AGENTS = [
+  ['twitter', 'Twitterbot/1.0'],
+  ['slack', 'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)'],
+  ['linkedin', 'LinkedInBot/1.0'],
+  ['discord', 'Discordbot/2.0'],
+  ['facebook', 'facebookexternalhit/1.1'],
+  [
+    'webkit_preview',
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+  ],
+]
+
+const TARGETS = [
+  { label: 'mutx-home', host: 'mutx.dev', path: '/' },
+  { label: 'mutx-download', host: 'mutx.dev', path: '/download' },
+  { label: 'mutx-docs', host: 'mutx.dev', path: '/docs' },
+  { label: 'mutx-releases', host: 'mutx.dev', path: '/releases' },
+  { label: 'mutx-contact', host: 'mutx.dev', path: '/contact' },
+  { label: 'mutx-control-plane', host: 'mutx.dev', path: '/ai-agent-control-plane' },
+  { label: 'app-control', host: 'app.mutx.dev', path: '/control' },
+  { label: 'pico-home', host: 'pico.mutx.dev', path: '/' },
+  { label: 'pico-academy', host: 'pico.mutx.dev', path: '/academy' },
+  { label: 'pico-pricing', host: 'pico.mutx.dev', path: '/pricing' },
+]
+
+const REQUIRED_META_KEYS = [
+  'og:title',
+  'og:description',
+  'og:image',
+  'og:image:width',
+  'og:image:height',
+  'og:image:alt',
+  'twitter:card',
+  'twitter:title',
+  'twitter:description',
+  'twitter:image',
+]
+
+function buildLocalUrl(baseUrl, path) {
+  const url = new URL(baseUrl)
+  url.pathname = path
+  url.search = ''
+  return url.toString()
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function requestBuffer(url, headers, redirectCount = 0) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url)
+    const transport = parsed.protocol === 'https:' ? https : http
+    const request = transport.request(
+      parsed,
+      {
+        method: 'GET',
+        headers,
+      },
+      (response) => {
+        const chunks = []
+
+        response.on('data', (chunk) => {
+          chunks.push(Buffer.from(chunk))
+        })
+        response.on('end', () => {
+          const status = response.statusCode ?? 0
+          const location = response.headers.location
+
+          if (
+            location &&
+            [301, 302, 303, 307, 308].includes(status) &&
+            redirectCount < 5
+          ) {
+            const nextUrl = new URL(location, parsed).toString()
+            resolve(requestBuffer(nextUrl, headers, redirectCount + 1))
+            return
+          }
+
+          resolve({
+            status,
+            headers: response.headers,
+            body: Buffer.concat(chunks),
+          })
+        })
+      },
+    )
+
+    request.on('error', reject)
+    request.end()
+  })
+}
+
+function extractMeta(html) {
+  const tags = {}
+  const metaRegex = /<meta\s+[^>]*(?:property|name)=["']([^"']+)["'][^>]*content=["']([^"']*)["'][^>]*>/gi
+
+  for (const match of html.matchAll(metaRegex)) {
+    const [, key, value] = match
+    tags[key] = value
+  }
+
+  return tags
+}
+
+function readPngSize(buffer) {
+  const signature = buffer.subarray(0, 8)
+  const expectedSignature = [137, 80, 78, 71, 13, 10, 26, 10]
+  const matchesSignature = expectedSignature.every((byte, index) => signature[index] === byte)
+
+  if (!matchesSignature) {
+    throw new Error('image is not a PNG')
+  }
+
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  }
+}
+
+async function fetchHtml({ baseUrl, host, path, userAgent }) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const response = await requestBuffer(buildLocalUrl(baseUrl, path), {
+      Host: host,
+      'User-Agent': userAgent,
+    })
+
+    if (response.status >= 200 && response.status < 300) {
+      return response.body.toString('utf8')
+    }
+
+    if (attempt === 2) {
+      throw new Error(`unexpected ${response.status} for ${host}${path}`)
+    }
+
+    await sleep(300)
+  }
+}
+
+async function validateImage({ baseUrl, imageUrl }) {
+  const parsed = new URL(imageUrl)
+  const localUrl = new URL(baseUrl)
+  localUrl.pathname = parsed.pathname
+  localUrl.search = parsed.search
+
+  const response = await requestBuffer(localUrl, {
+    Host: parsed.host,
+    'User-Agent': 'Twitterbot/1.0',
+  })
+
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`image fetch failed with ${response.status}`)
+  }
+
+  const contentType = response.headers['content-type']
+  if (contentType !== 'image/png') {
+    throw new Error(`expected image/png, received ${contentType ?? 'unknown'}`)
+  }
+
+  const { width, height } = readPngSize(response.body)
+
+  if (width !== 1200 || height !== 630) {
+    throw new Error(`expected 1200x630 PNG, received ${width}x${height}`)
+  }
+}
+
+async function validateTarget(baseUrl, target) {
+  const failures = []
+  let referenceMeta = null
+
+  for (const [botName, userAgent] of BOT_USER_AGENTS) {
+    const html = await fetchHtml({
+      baseUrl,
+      host: target.host,
+      path: target.path,
+      userAgent,
+    })
+    const meta = extractMeta(html)
+
+    for (const key of REQUIRED_META_KEYS) {
+      if (!meta[key]) {
+        failures.push(`${botName}: missing ${key}`)
+      }
+    }
+
+    if (!referenceMeta) {
+      referenceMeta = meta
+      continue
+    }
+
+    for (const key of ['og:title', 'og:description', 'og:image', 'twitter:title', 'twitter:description', 'twitter:image']) {
+      if (referenceMeta[key] !== meta[key]) {
+        failures.push(`${botName}: ${key} differs from first bot response`)
+      }
+    }
+  }
+
+  if (referenceMeta?.['og:image']) {
+    await validateImage({ baseUrl, imageUrl: referenceMeta['og:image'] }).catch((error) => {
+      failures.push(`image: ${error.message}`)
+    })
+  }
+
+  return failures
+}
+
+async function main() {
+  const baseUrl = process.argv[2] ?? DEFAULT_BASE_URL
+  let failureCount = 0
+
+  console.log(`Validating social embeds against ${baseUrl}`)
+
+  for (const target of TARGETS) {
+    const failures = await validateTarget(baseUrl, target)
+
+    if (failures.length === 0) {
+      console.log(`PASS ${target.label} (${target.host}${target.path})`)
+      continue
+    }
+
+    failureCount += failures.length
+    console.error(`FAIL ${target.label} (${target.host}${target.path})`)
+    for (const failure of failures) {
+      console.error(`  - ${failure}`)
+    }
+  }
+
+  if (failureCount > 0) {
+    process.exitCode = 1
+  }
+}
+
+await main()

--- a/tests/unit/middlewareRouting.test.ts
+++ b/tests/unit/middlewareRouting.test.ts
@@ -68,13 +68,14 @@ describe('host-aware UI routing proxy', () => {
     expect(response.headers.get('x-content-type-options')).toBe('nosniff')
   })
 
-  it('redirects /control paths to /dashboard on the app host', () => {
+  it('keeps /control paths on the app host so the public control demo stays indexable', () => {
     const response = proxy(
       mockRequest('https://app.mutx.dev/control/agents', { host: 'app.mutx.dev' }),
     )
 
-    expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('https://app.mutx.dev/dashboard/agents')
+    expect(response.status).toBe(200)
+    expect(response.headers.get('location')).toBeNull()
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull()
   })
 
   it('redirects app host legacy /app pages to canonical dashboard routes', () => {
@@ -161,13 +162,15 @@ describe('host-aware UI routing proxy', () => {
     expect(response.headers.get('set-cookie')).toContain('NEXT_LOCALE=ja')
   })
 
-  it('redirects pico /start back to the waitlist root while Pico is closed', () => {
+  it('rewrites pico /start into the onboarding entrypoint', () => {
     const response = proxy(
       mockRequest('https://pico.mutx.dev/start?ref=hero', { host: 'pico.mutx.dev', 'CF-IPCountry': 'JP' }),
     )
 
-    expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('https://pico.mutx.dev/?ref=hero')
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-rewrite')).toBe(
+      'https://pico.mutx.dev/pico/onboarding?ref=hero',
+    )
     expect(response.headers.get('set-cookie')).toContain('NEXT_LOCALE=ja')
   })
 
@@ -227,12 +230,14 @@ describe('host-aware UI routing proxy', () => {
       ),
     )
 
-    expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('https://pico.mutx.dev/?locale=fr')
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-rewrite')).toBe(
+      'https://pico.mutx.dev/pico/onboarding?locale=fr',
+    )
     expect(response.headers.get('set-cookie')).toContain('NEXT_LOCALE=fr')
   })
 
-  it('redirects direct pico product routes back to the waitlist root', () => {
+  it('rewrites direct pico product routes into the pico app tree', () => {
     const response = proxy(
       mockRequest(
         'https://pico.mutx.dev/academy/install-hermes-locally',
@@ -240,8 +245,10 @@ describe('host-aware UI routing proxy', () => {
       ),
     )
 
-    expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('https://pico.mutx.dev/')
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-rewrite')).toBe(
+      'https://pico.mutx.dev/pico/academy/install-hermes-locally',
+    )
     expect(response.headers.get('set-cookie')).toContain('NEXT_LOCALE=ja')
   })
 

--- a/tests/unit/noindexMetadata.test.ts
+++ b/tests/unit/noindexMetadata.test.ts
@@ -1,4 +1,13 @@
+import type { ReactNode } from 'react'
+
 jest.mock('../../app/fonts/app', () => ({ appFontVariables: 'font-vars' }))
+jest.mock('next-intl', () => ({
+  NextIntlClientProvider: ({ children }: { children: ReactNode }) => children,
+}))
+jest.mock('next-intl/server', () => ({
+  getLocale: jest.fn(async () => 'en'),
+  getMessages: jest.fn(async () => ({})),
+}))
 
 import { metadata as dashboardMetadata } from '../../app/dashboard/layout'
 import { metadata as forgotPasswordMetadata } from '../../app/forgot-password/layout'

--- a/tests/unit/seoHelpers.test.ts
+++ b/tests/unit/seoHelpers.test.ts
@@ -1,20 +1,28 @@
 import {
-  DEFAULT_SITE_URL,
   DEFAULT_APP_URL,
-  DEFAULT_X_HANDLE,
   DEFAULT_OG_IMAGE,
   DEFAULT_OG_IMAGE_ALT,
+  DEFAULT_PICO_URL,
+  DEFAULT_SITE_URL,
+  DEFAULT_X_HANDLE,
   PUBLIC_MARKETING_ROUTES,
   BLOCKED_CRAWL_PREFIXES,
+  buildPageMetadata,
   getSiteUrl,
   getAppUrl,
+  getDefaultSocialBadge,
+  getPicoUrl,
   toAbsoluteSiteUrl,
   toAbsoluteAppUrl,
+  toAbsolutePicoUrl,
   getCanonicalUrl,
   getOgImageUrl,
   getTwitterImageUrl,
   getPageOgImageUrl,
   getPageTwitterImageUrl,
+  resolveSeoSurface,
+  resolveSeoSurfaceForPath,
+  resolveSocialSection,
 } from '../../lib/seo'
 
 // ---------------------------------------------------------------------------
@@ -150,6 +158,28 @@ describe('getAppUrl', () => {
   })
 })
 
+describe('getPicoUrl', () => {
+  const original = process.env.NEXT_PUBLIC_PICO_URL
+
+  afterEach(() => {
+    if (original !== undefined) {
+      process.env.NEXT_PUBLIC_PICO_URL = original
+    } else {
+      delete process.env.NEXT_PUBLIC_PICO_URL
+    }
+  })
+
+  it('returns the default when env var is unset', () => {
+    delete process.env.NEXT_PUBLIC_PICO_URL
+    expect(getPicoUrl()).toBe(DEFAULT_PICO_URL)
+  })
+
+  it('returns the env var value when set', () => {
+    process.env.NEXT_PUBLIC_PICO_URL = 'https://pico.staging.mutx.dev/'
+    expect(getPicoUrl()).toBe('https://pico.staging.mutx.dev')
+  })
+})
+
 describe('toAbsoluteSiteUrl', () => {
   const original = process.env.NEXT_PUBLIC_SITE_URL
 
@@ -204,6 +234,28 @@ describe('toAbsoluteAppUrl', () => {
   })
 })
 
+describe('toAbsolutePicoUrl', () => {
+  const original = process.env.NEXT_PUBLIC_PICO_URL
+
+  afterEach(() => {
+    if (original !== undefined) {
+      process.env.NEXT_PUBLIC_PICO_URL = original
+    } else {
+      delete process.env.NEXT_PUBLIC_PICO_URL
+    }
+  })
+
+  it('builds absolute pico URL for a path', () => {
+    delete process.env.NEXT_PUBLIC_PICO_URL
+    expect(toAbsolutePicoUrl('/academy')).toBe('https://pico.mutx.dev/academy')
+  })
+
+  it('returns just the pico URL for root path', () => {
+    delete process.env.NEXT_PUBLIC_PICO_URL
+    expect(toAbsolutePicoUrl('/')).toBe('https://pico.mutx.dev')
+  })
+})
+
 // ---------------------------------------------------------------------------
 // Canonical and OG image helpers
 // ---------------------------------------------------------------------------
@@ -222,6 +274,31 @@ describe('getCanonicalUrl', () => {
   it('delegates to toAbsoluteSiteUrl', () => {
     delete process.env.NEXT_PUBLIC_SITE_URL
     expect(getCanonicalUrl('/pricing')).toBe('https://mutx.dev/pricing')
+  })
+})
+
+describe('surface resolution helpers', () => {
+  it('resolves app and pico hosts explicitly', () => {
+    expect(resolveSeoSurface('app.mutx.dev')).toBe('app')
+    expect(resolveSeoSurface('pico.mutx.dev')).toBe('pico')
+    expect(resolveSeoSurface('mutx.dev')).toBe('marketing')
+  })
+
+  it('resolves app and pico surfaces from path fallbacks', () => {
+    expect(resolveSeoSurfaceForPath('/control')).toBe('app')
+    expect(resolveSeoSurfaceForPath('/dashboard/runs')).toBe('app')
+    expect(resolveSeoSurfaceForPath('/academy')).toBe('pico')
+    expect(resolveSeoSurfaceForPath('/academy/install-hermes-locally')).toBe('pico')
+    expect(resolveSeoSurfaceForPath('/download')).toBe('marketing')
+  })
+
+  it('derives section-aware badges and sections', () => {
+    expect(resolveSocialSection('/whitepaper')).toBe('whitepaper')
+    expect(resolveSocialSection('/sdk')).toBe('sdk')
+    expect(resolveSocialSection('/academy')).toBe('academy')
+    expect(getDefaultSocialBadge('/control', 'app.mutx.dev')).toBe('CONTROL PLANE')
+    expect(getDefaultSocialBadge('/whitepaper')).toBe('WHITEPAPER')
+    expect(getDefaultSocialBadge('/sdk')).toBe('SDK')
   })
 })
 
@@ -302,5 +379,67 @@ describe('getOgImageUrl', () => {
     expect(getPageTwitterImageUrl('Home | MUTX', 'Root route', { path: '/' })).toBe(
       'https://mutx.dev/twitter-image?title=Home+%7C+MUTX&description=Root+route&path=%2F',
     )
+  })
+})
+
+describe('buildPageMetadata', () => {
+  it('builds explicit marketing image objects with alt, size, and type', () => {
+    const metadata = buildPageMetadata({
+      title: 'Docs | MUTX',
+      description: 'Code-accurate docs.',
+      path: '/docs/reference',
+      siteName: 'MUTX Docs',
+      badge: 'DOCS',
+    })
+
+    expect(metadata.alternates?.canonical).toBe('https://mutx.dev/docs/reference')
+    expect(metadata.openGraph?.images).toEqual([
+      expect.objectContaining({
+        url: 'https://mutx.dev/opengraph-image?title=Docs+%7C+MUTX&description=Code-accurate+docs.&path=%2Fdocs%2Freference&badge=DOCS',
+        width: 1200,
+        height: 630,
+        alt: 'Docs | MUTX social preview for MUTX',
+        type: 'image/png',
+      }),
+    ])
+    expect(metadata.twitter?.images).toEqual([
+      expect.objectContaining({
+        url: 'https://mutx.dev/twitter-image?title=Docs+%7C+MUTX&description=Code-accurate+docs.&path=%2Fdocs%2Freference&badge=DOCS',
+        width: 1200,
+        height: 630,
+      }),
+    ])
+  })
+
+  it('builds host-aware metadata for app and pico surfaces', () => {
+    const appMetadata = buildPageMetadata({
+      title: 'MUTX Control Plane',
+      description: 'Operator-grade control plane.',
+      path: '/control',
+      host: 'https://app.mutx.dev',
+      siteName: 'MUTX App',
+    })
+    const picoMetadata = buildPageMetadata({
+      title: 'PicoMUTX Academy',
+      description: 'Guided build lessons.',
+      path: '/academy',
+      host: 'https://pico.mutx.dev',
+      siteName: 'PicoMUTX',
+    })
+
+    expect(appMetadata.alternates?.canonical).toBe('https://app.mutx.dev/control')
+    expect(appMetadata.openGraph?.images).toEqual([
+      expect.objectContaining({
+        url: expect.stringContaining('https://app.mutx.dev/opengraph-image?'),
+        alt: 'MUTX Control Plane social preview for MUTX App',
+      }),
+    ])
+    expect(picoMetadata.alternates?.canonical).toBe('https://pico.mutx.dev/academy')
+    expect(picoMetadata.openGraph?.images).toEqual([
+      expect.objectContaining({
+        url: expect.stringContaining('https://pico.mutx.dev/opengraph-image?'),
+        alt: 'PicoMUTX Academy social preview for PicoMUTX',
+      }),
+    ])
   })
 })

--- a/tests/unit/seoHelpers.test.ts
+++ b/tests/unit/seoHelpers.test.ts
@@ -281,6 +281,8 @@ describe('surface resolution helpers', () => {
   it('resolves app and pico hosts explicitly', () => {
     expect(resolveSeoSurface('app.mutx.dev')).toBe('app')
     expect(resolveSeoSurface('pico.mutx.dev')).toBe('pico')
+    expect(resolveSeoSurface('app.mutx.dev, proxy.internal')).toBe('app')
+    expect(resolveSeoSurface('https://pico.mutx.dev:443, proxy.internal')).toBe('pico')
     expect(resolveSeoSurface('mutx.dev')).toBe('marketing')
   })
 

--- a/tests/unit/socialMetadataFamilies.test.ts
+++ b/tests/unit/socialMetadataFamilies.test.ts
@@ -1,0 +1,89 @@
+jest.mock('../../app/fonts/app', () => ({ appFontVariables: 'font-vars' }))
+jest.mock('next-intl', () => ({
+  NextIntlClientProvider: ({ children }: { children: unknown }) => children,
+}))
+jest.mock('next-intl/server', () => ({
+  getLocale: jest.fn(async () => 'en'),
+  getMessages: jest.fn(async () => ({})),
+  getTranslations: jest.fn(async ({ namespace }: { namespace: string }) => {
+    return (key: string, values?: Record<string, string | number>) => {
+      if (key === 'title') {
+        return values?.title ? String(values.title) : `${namespace} title`
+      }
+
+      if (key === 'description') {
+        return values?.summary ? String(values.summary) : `${namespace} description`
+      }
+
+      return `${namespace}.${key}`
+    }
+  }),
+}))
+jest.mock('../../i18n/routing', () => ({
+  routing: {
+    locales: ['en', 'fr'],
+  },
+}))
+
+import { metadata as controlMetadata } from '../../app/control/layout'
+import { metadata as dashboardMetadata } from '../../app/dashboard/layout'
+import { buildPicoPageMetadata } from '../../lib/pico/metadata'
+
+describe('surface-specific metadata families', () => {
+  it('keeps dashboard metadata on the app host with explicit image objects', () => {
+    expect(dashboardMetadata.alternates?.canonical).toBe('https://app.mutx.dev')
+    expect(dashboardMetadata.openGraph?.siteName).toBe('MUTX App')
+    expect(dashboardMetadata.openGraph?.images).toEqual([
+      expect.objectContaining({
+        url: expect.stringContaining('https://app.mutx.dev/opengraph-image?'),
+        width: 1200,
+        height: 630,
+        alt: 'Dashboard - MUTX social preview for MUTX App',
+      }),
+    ])
+    expect(dashboardMetadata.twitter?.images).toEqual([
+      expect.objectContaining({
+        url: expect.stringContaining('https://app.mutx.dev/twitter-image?'),
+      }),
+    ])
+  })
+
+  it('keeps control-plane metadata on the app host with the control badge', () => {
+    expect(controlMetadata.alternates?.canonical).toBe('https://app.mutx.dev/control')
+    expect(controlMetadata.openGraph?.images).toEqual([
+      expect.objectContaining({
+        url: expect.stringContaining('https://app.mutx.dev/opengraph-image?'),
+      }),
+    ])
+    expect(controlMetadata.twitter?.images).toEqual([
+      expect.objectContaining({
+        url: expect.stringContaining('badge=CONTROL+PLANE'),
+      }),
+    ])
+  })
+
+  it('builds pico metadata on the pico host with explicit image objects', async () => {
+    const metadata = await buildPicoPageMetadata('pico.pages.academy.meta', '/academy')
+
+    expect(metadata.alternates?.canonical).toBe('https://pico.mutx.dev/academy')
+    expect(metadata.alternates?.languages).toEqual(
+      expect.objectContaining({
+        en: 'https://pico.mutx.dev/academy',
+      }),
+    )
+    expect(metadata.openGraph?.siteName).toBe('PicoMUTX')
+    expect(metadata.openGraph?.images).toEqual([
+      expect.objectContaining({
+        url: expect.stringContaining('https://pico.mutx.dev/opengraph-image?'),
+        width: 1200,
+        height: 630,
+        alt: 'pico.pages.academy.meta title social preview for PicoMUTX',
+      }),
+    ])
+    expect(metadata.twitter?.images).toEqual([
+      expect.objectContaining({
+        url: expect.stringContaining('https://pico.mutx.dev/twitter-image?'),
+      }),
+    ])
+  })
+})

--- a/tests/unit/webmasterRoutes.test.ts
+++ b/tests/unit/webmasterRoutes.test.ts
@@ -1,11 +1,22 @@
+const mockHeaders = jest.fn(async () => new Headers({ host: 'mutx.dev' }))
+
+jest.mock('next/headers', () => ({
+  headers: mockHeaders,
+}))
+
 import manifest from '../../app/manifest'
 import robots from '../../app/robots'
 import sitemap from '../../app/sitemap'
+import { PICO_LESSONS } from '../../lib/pico/academy'
 import { BLOCKED_CRAWL_PREFIXES, PUBLIC_MARKETING_ROUTES } from '../../lib/seo'
 
 describe('webmaster route contracts', () => {
-  it('robots.txt blocks all intended private prefixes and publishes sitemap host', () => {
-    const result = robots()
+  beforeEach(() => {
+    mockHeaders.mockResolvedValue(new Headers({ host: 'mutx.dev' }))
+  })
+
+  it('robots.txt blocks intended private prefixes on the marketing host', async () => {
+    const result = await robots()
     const firstRule = Array.isArray(result.rules) ? result.rules[0] : result.rules
 
     expect(firstRule).toBeDefined()
@@ -14,8 +25,35 @@ describe('webmaster route contracts', () => {
     expect(result.sitemap).toBe('https://mutx.dev/sitemap.xml')
   })
 
-  it('sitemap includes public marketing routes and excludes private surfaces', () => {
-    const result = sitemap()
+  it('robots.txt narrows app crawling to the public control surface', async () => {
+    mockHeaders.mockResolvedValue(new Headers({ host: 'app.mutx.dev' }))
+
+    const result = await robots()
+    const firstRule = Array.isArray(result.rules) ? result.rules[0] : result.rules
+
+    expect(firstRule).toEqual(
+      expect.objectContaining({
+        allow: ['/control', '/opengraph-image', '/twitter-image'],
+        disallow: ['/'],
+      }),
+    )
+    expect(result.host).toBe('https://app.mutx.dev')
+    expect(result.sitemap).toBe('https://app.mutx.dev/sitemap.xml')
+  })
+
+  it('robots.txt keeps pico public while excluding the wip lane', async () => {
+    mockHeaders.mockResolvedValue(new Headers({ host: 'pico.mutx.dev' }))
+
+    const result = await robots()
+    const firstRule = Array.isArray(result.rules) ? result.rules[0] : result.rules
+
+    expect(firstRule?.disallow).toEqual(expect.arrayContaining([...BLOCKED_CRAWL_PREFIXES, '/wip']))
+    expect(result.host).toBe('https://pico.mutx.dev')
+    expect(result.sitemap).toBe('https://pico.mutx.dev/sitemap.xml')
+  })
+
+  it('marketing sitemap includes public routes and excludes private surfaces', async () => {
+    const result = await sitemap()
     const urls = result.map((entry) => entry.url)
 
     for (const route of PUBLIC_MARKETING_ROUTES) {
@@ -27,6 +65,28 @@ describe('webmaster route contracts', () => {
     expect(urls).not.toContain('https://mutx.dev/dashboard')
     expect(urls).not.toContain('https://mutx.dev/control')
     expect(urls).not.toContain('https://mutx.dev/login')
+  })
+
+  it('app sitemap publishes only the control lane', async () => {
+    mockHeaders.mockResolvedValue(new Headers({ host: 'app.mutx.dev' }))
+
+    await expect(sitemap()).resolves.toEqual([
+      expect.objectContaining({
+        url: 'https://app.mutx.dev/control',
+      }),
+    ])
+  })
+
+  it('pico sitemap publishes public pico routes and academy lessons', async () => {
+    mockHeaders.mockResolvedValue(new Headers({ host: 'pico.mutx.dev' }))
+
+    const result = await sitemap()
+    const urls = result.map((entry) => entry.url)
+
+    expect(urls).toContain('https://pico.mutx.dev')
+    expect(urls).toContain('https://pico.mutx.dev/academy')
+    expect(urls).toContain(`https://pico.mutx.dev/academy/${PICO_LESSONS[0].slug}`)
+    expect(urls).not.toContain('https://pico.mutx.dev/wip')
   })
 
   it('manifest exposes stable production metadata', () => {


### PR DESCRIPTION
## Summary
- add surface-aware OG/Twitter image generation for mutx.dev, app.mutx.dev, and pico.mutx.dev
- normalize page metadata to explicit social image objects with host-aware canonicals and sitemap/robots behavior
- add local social embed validation plus focused webmaster metadata tests

## Validation
- npx jest --runInBand tests/unit/seoHelpers.test.ts tests/unit/webmasterRoutes.test.ts tests/unit/metadataImageRoutes.test.ts tests/unit/socialMetadataFamilies.test.ts tests/unit/noindexMetadata.test.ts
- npm run typecheck
- npx eslint app/layout.tsx app/dashboard/layout.tsx app/control/layout.tsx app/opengraph-image.tsx app/twitter-image.tsx app/robots.ts app/sitemap.ts app/page.tsx app/download/page.tsx app/download/macos/page.tsx app/contact/page.tsx app/privacy-policy/page.tsx app/releases/page.tsx app/docs/[[...slug]]/page.tsx app/manifesto/page.tsx app/roadmap/page.tsx app/security/page.tsx app/sdk/page.tsx app/support/page.tsx app/whitepaper/page.tsx app/infrastructure/page.tsx app/ai-agent-governance/page.tsx app/ai-agent-approvals/page.tsx app/ai-agent-audit-logs/page.tsx app/ai-agent-control-plane/page.tsx app/ai-agent-cost/page.tsx app/ai-agent-deployment/page.tsx app/ai-agent-guardrails/page.tsx app/ai-agent-infrastructure/page.tsx app/ai-agent-monitoring/page.tsx app/ai-agent-reliability/page.tsx lib/seo.ts lib/og-image.tsx lib/pico/metadata.ts proxy.ts scripts/validate-social-embeds.mjs tests/unit/seoHelpers.test.ts tests/unit/webmasterRoutes.test.ts tests/unit/socialMetadataFamilies.test.ts tests/unit/metadataImageRoutes.test.ts tests/unit/noindexMetadata.test.ts
- npm run validate:social-embeds -- http://127.0.0.1:3000