### PR TITLE
Fix Pico OAuth routing

### DIFF
--- a/app/api/auth/oauth/[provider]/callback/route.ts
+++ b/app/api/auth/oauth/[provider]/callback/route.ts
@@ -29,7 +29,7 @@ function clearOAuthCookies(response: NextResponse, request: NextRequest) {
   for (const suffix of ["state", "next", "intent"]) {
     response.cookies.set(`${OAUTH_COOKIE_PREFIX}_${suffix}`, "", {
       httpOnly: true,
-      sameSite: "lax",
+      sameSite: "none",
       secure,
       domain,
       path: "/",

--- a/app/api/auth/oauth/[provider]/start/route.ts
+++ b/app/api/auth/oauth/[provider]/start/route.ts
@@ -32,7 +32,9 @@ function setOAuthCookie(
 ) {
   response.cookies.set(name, value, {
     httpOnly: true,
-    sameSite: "lax",
+    // Apple Sign In returns with response_mode=form_post, so the
+    // transient OAuth state cookies must be sent on a cross-site POST.
+    sameSite: "none",
     secure: shouldUseSecureCookies(request),
     domain: getCookieDomain(request),
     path: "/",

--- a/proxy.ts
+++ b/proxy.ts
@@ -23,12 +23,18 @@ type RateLimitState = {
 
 const SAFE_HTTP_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'TRACE'])
 const CSRF_FAILURE_DETAIL = 'CSRF validation failed: origin is not allowed'
-const PICO_AUTH_CLOSED_DETAIL = 'Pico waitlist is closed; beta opens soon'
 const APP_HOST = 'app.mutx.dev'
 const PICO_HOST = 'pico.mutx.dev'
 const APP_HOSTS = new Set([APP_HOST, 'app.localhost'])
 const MARKETING_HOSTS = new Set(['mutx.dev', 'www.mutx.dev'])
 const PICO_HOSTS = new Set([PICO_HOST, 'pico.localhost'])
+const PICO_AUTH_UI_PATHS = new Set([
+  '/forgot-password',
+  '/login',
+  '/register',
+  '/reset-password',
+  '/verify-email',
+])
 const PICO_WIP_PATH = '/pico/wip'
 const PICO_LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365
 const PICO_LOCALE_BY_COUNTRY: Partial<Record<string, PicoLocale>> = {
@@ -175,6 +181,10 @@ function normalizePathname(pathname: string): string {
   }
 
   return pathname
+}
+
+function isOAuthCallbackPath(pathname: string): boolean {
+  return /^\/api\/auth\/oauth\/[^/]+\/callback$/.test(pathname)
 }
 
 function mapLegacyAppPathToDashboard(pathname: string): string {
@@ -440,6 +450,7 @@ export function proxy(request: NextRequest) {
 
   if (
     normalizedPath.startsWith('/api') &&
+    !isOAuthCallbackPath(normalizedPath) &&
     !SAFE_HTTP_METHODS.has(request.method.toUpperCase()) &&
     request.headers.get('origin') &&
     !isAllowedApiOrigin(request, host)
@@ -451,25 +462,41 @@ export function proxy(request: NextRequest) {
     )
   }
 
-  if (PICO_HOSTS.has(host)) {
-    if (normalizedPath.startsWith('/api/auth/oauth/')) {
-      return finalizeResponse(redirectWithinHost(request, '/wip'), host, normalizedPath)
-    }
+  if (PICO_HOSTS.has(host) && !normalizedPath.startsWith('/api')) {
+    const locale = getLocaleFromRequest(request)
+    const picoRequestHeaders = buildPicoRequestHeaders(request, locale)
 
-    if (normalizedPath.startsWith('/api/auth/')) {
+    if (PICO_AUTH_UI_PATHS.has(normalizedPath)) {
       return finalizeResponse(
-        NextResponse.json({ detail: PICO_AUTH_CLOSED_DETAIL }, { status: 403 }),
+        applyPicoLocale(NextResponse.next(), locale),
         host,
         normalizedPath,
       )
     }
 
-    // API routes must hit the real /api/* handlers, not /pico/api/*
-    if (normalizedPath.startsWith('/api')) {
-      return finalizeResponse(NextResponse.next(), host, normalizedPath)
+    if (normalizedPath === '/pico') {
+      return finalizeResponse(
+        applyPicoLocale(redirectWithinHost(request, '/'), locale),
+        host,
+        normalizedPath,
+      )
     }
-    const locale = getLocaleFromRequest(request)
-    const picoRequestHeaders = buildPicoRequestHeaders(request, locale)
+
+    if (normalizedPath === '/') {
+      return finalizeResponse(
+        applyPicoLocale(rewriteWithinHost(request, '/pico', picoRequestHeaders), locale),
+        host,
+        normalizedPath,
+      )
+    }
+
+    if (normalizedPath === '/wip' || normalizedPath === PICO_WIP_PATH) {
+      return finalizeResponse(
+        applyPicoLocale(rewriteWithinHost(request, PICO_WIP_PATH, picoRequestHeaders), locale),
+        host,
+        normalizedPath,
+      )
+    }
 
     return finalizeResponse(
       applyPicoLocale(rewriteWithinHost(request, PICO_WIP_PATH, picoRequestHeaders), locale),

--- a/src/api/services/social_auth.py
+++ b/src/api/services/social_auth.py
@@ -112,15 +112,19 @@ async def exchange_code_for_user_profile(
     client_id = get_provider_client_id(provider)
     client_secret = get_provider_client_secret(provider)
 
-    if not client_id or not client_secret:
+    if not client_id:
         raise SocialAuthError(
             f"{provider.value.title()} OAuth is not configured on the backend.",
             status_code=500,
         )
 
-    # For Apple, client_secret must be a dynamically-generated JWT
     if provider == OAuthProvider.APPLE:
         client_secret = _generate_apple_client_secret()
+    elif not client_secret:
+        raise SocialAuthError(
+            f"{provider.value.title()} OAuth is not configured on the backend.",
+            status_code=500,
+        )
 
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -658,6 +658,57 @@ class TestAuthEndpoints:
         identity = identity_result.scalar_one()
         assert identity.user_id == user.id
 
+    @pytest.mark.asyncio
+    async def test_apple_oauth_exchange_generates_client_secret(self, monkeypatch):
+        from src.api.services import social_auth
+
+        captured: dict[str, str] = {}
+
+        async def fake_exchange_apple_code(
+            client,
+            *,
+            code: str,
+            redirect_uri: str,
+            client_id: str,
+            client_secret: str,
+        ) -> OAuthUserProfile:
+            captured["code"] = code
+            captured["redirect_uri"] = redirect_uri
+            captured["client_id"] = client_id
+            captured["client_secret"] = client_secret
+            return OAuthUserProfile(
+                provider=OAuthProvider.APPLE,
+                provider_user_id="apple-user-123",
+                email="apple@example.com",
+                email_verified=True,
+                display_name="Apple User",
+                username=None,
+                avatar_url=None,
+                profile={"sub": "apple-user-123"},
+            )
+
+        monkeypatch.setattr(social_auth.settings, "apple_client_id", "dev.mutx.web")
+        monkeypatch.setattr(
+            social_auth,
+            "_generate_apple_client_secret",
+            lambda: "generated-apple-secret",
+        )
+        monkeypatch.setattr(social_auth, "_exchange_apple_code", fake_exchange_apple_code)
+
+        profile = await social_auth.exchange_code_for_user_profile(
+            OAuthProvider.APPLE,
+            code="provider-code",
+            redirect_uri="https://pico.mutx.dev/api/auth/oauth/apple/callback",
+        )
+
+        assert profile.email == "apple@example.com"
+        assert captured == {
+            "code": "provider-code",
+            "redirect_uri": "https://pico.mutx.dev/api/auth/oauth/apple/callback",
+            "client_id": "dev.mutx.web",
+            "client_secret": "generated-apple-secret",
+        }
+
 
 class TestPasswordCompatibility:
     """Compatibility tests for legacy password hashes."""

--- a/tests/unit/authRoutes.test.ts
+++ b/tests/unit/authRoutes.test.ts
@@ -901,7 +901,40 @@ describe("auth route handlers", () => {
       expect(setCookieHeader).toContain("mutx_oauth_state=");
       expect(setCookieHeader).toContain("mutx_oauth_next=");
       expect(setCookieHeader).toContain("mutx_oauth_intent=");
+      expect(setCookieHeader).toContain("SameSite=none");
     });
+
+    it.each(["google", "github", "discord", "apple"])(
+      "starts %s OAuth with the pico callback origin",
+      async (provider) => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            authorization_url: `https://provider.example/${provider}`,
+          }),
+        });
+        const { GET } =
+          await import("../../app/api/auth/oauth/[provider]/start/route");
+
+        const response = await GET(
+          mockRequest(
+            {},
+            `https://pico.mutx.dev/api/auth/oauth/${provider}/start?next=%2Fonboarding&intent=login`,
+          ),
+          { params: Promise.resolve({ provider }) },
+        );
+
+        const authorizeUrl = (global.fetch as jest.Mock).mock.calls[0][0] as URL;
+        expect(authorizeUrl.searchParams.get("redirect_uri")).toBe(
+          `https://pico.mutx.dev/api/auth/oauth/${provider}/callback`,
+        );
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(
+          `https://provider.example/${provider}`,
+        );
+      },
+    );
   });
 
   describe("GET /api/auth/oauth/[provider]/callback", () => {
@@ -999,6 +1032,53 @@ describe("auth route handlers", () => {
         { params: Promise.resolve({ provider: "google" }) },
       );
 
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toBe("https://pico.mutx.dev/");
+    });
+
+    it("exchanges Apple form_post callbacks with the pico redirect URI", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: "oauth_access_token",
+          refresh_token: "oauth_refresh_token",
+          expires_in: 1800,
+        }),
+      });
+      const { POST } =
+        await import("../../app/api/auth/oauth/[provider]/callback/route");
+      const formData = new Map<string, string>([
+        ["code", "apple-code"],
+        ["state", "state-123"],
+      ]);
+
+      const response = await POST(
+        {
+          ...mockRequest(
+            {
+              mutx_oauth_state: "state-123",
+              mutx_oauth_intent: "login",
+            },
+            "https://pico.mutx.dev/api/auth/oauth/apple/callback",
+          ),
+          formData: async () => formData,
+        } as unknown as NextRequest,
+        { params: Promise.resolve({ provider: "apple" }) },
+      );
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:8000/v1/auth/oauth/apple/exchange",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            code: "apple-code",
+            redirect_uri: "https://pico.mutx.dev/api/auth/oauth/apple/callback",
+          }),
+          cache: "no-store",
+        },
+      );
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toBe("https://pico.mutx.dev/");
     });

--- a/tests/unit/middlewareRouting.test.ts
+++ b/tests/unit/middlewareRouting.test.ts
@@ -183,7 +183,7 @@ describe('host-aware UI routing proxy', () => {
     [
       'root',
       'https://pico.mutx.dev/',
-      'https://pico.mutx.dev/pico/wip',
+      'https://pico.mutx.dev/pico',
       'ja',
     ],
     [
@@ -223,30 +223,12 @@ describe('host-aware UI routing proxy', () => {
       'fr',
     ],
     [
-      'login',
-      'https://pico.mutx.dev/login?next=%2Fonboarding',
-      'https://pico.mutx.dev/pico/wip?next=%2Fonboarding',
-      'ja',
-    ],
-    [
-      'register',
-      'https://pico.mutx.dev/register?next=%2Facademy',
-      'https://pico.mutx.dev/pico/wip?next=%2Facademy',
-      'ja',
-    ],
-    [
-      'verify email',
-      'https://pico.mutx.dev/verify-email?token=test-token',
-      'https://pico.mutx.dev/pico/wip?token=test-token',
-      'ja',
-    ],
-    [
       'explicit app path',
       'https://pico.mutx.dev/pico/pricing',
       'https://pico.mutx.dev/pico/wip',
       'ja',
     ],
-  ])('rewrites pico host %s route to the WIP page', (_label, url, expectedRewrite, expectedLocale) => {
+  ])('rewrites pico host %s route to the expected internal route', (_label, url, expectedRewrite, expectedLocale) => {
     const response = proxy(mockRequest(url, { host: 'pico.mutx.dev', 'CF-IPCountry': 'JP' }))
 
     expect(response.status).toBe(200)
@@ -272,7 +254,22 @@ describe('host-aware UI routing proxy', () => {
     expect(response.headers.get('set-cookie')).toContain('NEXT_LOCALE=ja')
   })
 
-  it('maps pico geolocation headers to supported locales on first WIP visit', () => {
+  it.each([
+    ['login', 'https://pico.mutx.dev/login?next=%2Fonboarding'],
+    ['register', 'https://pico.mutx.dev/register?next=%2Facademy'],
+    ['verify email', 'https://pico.mutx.dev/verify-email?token=test-token'],
+    ['forgot password', 'https://pico.mutx.dev/forgot-password'],
+    ['reset password', 'https://pico.mutx.dev/reset-password?token=reset-token'],
+  ])('lets pico-hosted %s render instead of rewriting to WIP', (_label, url) => {
+    const response = proxy(mockRequest(url, { host: 'pico.mutx.dev', 'CF-IPCountry': 'JP' }))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull()
+    expect(response.headers.get('location')).toBeNull()
+    expect(response.headers.get('set-cookie')).toContain('NEXT_LOCALE=ja')
+  })
+
+  it('maps pico geolocation headers to supported locales on first pico visit', () => {
     const jpResponse = proxy(
       mockRequest(
         'https://pico.mutx.dev/',
@@ -299,10 +296,11 @@ describe('host-aware UI routing proxy', () => {
     )
 
     expect(jpResponse.headers.get('set-cookie')).toContain('NEXT_LOCALE=ja')
-    expect(jpResponse.headers.get('x-middleware-rewrite')).toBe('https://pico.mutx.dev/pico/wip')
+    expect(jpResponse.headers.get('x-middleware-rewrite')).toBe('https://pico.mutx.dev/pico')
     expect(krResponse.headers.get('set-cookie')).toContain('NEXT_LOCALE=ko')
-    expect(krResponse.headers.get('x-middleware-rewrite')).toBe('https://pico.mutx.dev/pico/wip')
+    expect(krResponse.headers.get('x-middleware-rewrite')).toBe('https://pico.mutx.dev/pico')
     expect(cnResponse.headers.get('set-cookie')).toContain('NEXT_LOCALE=zh')
+    expect(cnResponse.headers.get('x-middleware-rewrite')).toBe('https://pico.mutx.dev/pico')
   })
 
   it('keeps cookie precedence over pico geolocation', () => {
@@ -370,29 +368,45 @@ describe('host-aware UI routing proxy', () => {
     expect(response.headers.get('x-middleware-rewrite')).toBeNull()
   })
 
-  it('redirects pico-hosted OAuth starts to WIP instead of launching a provider flow', () => {
+  it('keeps the pico waitlist contact endpoint available on the pico host', () => {
+    const response = proxy(
+      mockRequest('https://pico.mutx.dev/api/contact', { host: 'pico.mutx.dev' }, 'POST'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull()
+  })
+
+  it.each(['google', 'github', 'discord', 'apple'])(
+    'lets pico-hosted %s OAuth starts reach the auth handler',
+    (provider) => {
+      const response = proxy(
+        mockRequest(
+          `https://pico.mutx.dev/api/auth/oauth/${provider}/start?intent=login&next=%2Fonboarding`,
+          { host: 'pico.mutx.dev' },
+        ),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('location')).toBeNull()
+      expect(response.headers.get('x-middleware-rewrite')).toBeNull()
+      expect(response.headers.get('cache-control')).toBe('no-store')
+    },
+  )
+
+  it('lets pico-hosted direct auth API calls reach handlers with auth rate limiting', () => {
     const response = proxy(
       mockRequest(
-        'https://pico.mutx.dev/api/auth/oauth/google/start?intent=login&next=%2Fonboarding',
+        'https://pico.mutx.dev/api/auth/register',
         { host: 'pico.mutx.dev' },
+        'POST',
       ),
     )
 
-    expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe(
-      'https://pico.mutx.dev/wip?intent=login&next=%2Fonboarding',
-    )
-  })
-
-  it('rejects pico-hosted direct auth API calls while beta is closed', async () => {
-    const response = proxy(
-      mockRequest('https://pico.mutx.dev/api/auth/register', { host: 'pico.mutx.dev' }, 'POST'),
-    )
-
-    expect(response.status).toBe(403)
-    expect(await response.json()).toEqual({
-      detail: 'Pico waitlist is closed; beta opens soon',
-    })
+    expect(response.status).toBe(200)
+    expect(response.headers.get('location')).toBeNull()
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull()
+    expect(response.headers.get('X-RateLimit-Limit')).toBe('8')
     expect(response.headers.get('cache-control')).toBe('no-store')
   })
 
@@ -425,6 +439,24 @@ describe('host-aware UI routing proxy', () => {
     expect(await response.json()).toEqual({
       detail: 'CSRF validation failed: origin is not allowed',
     })
+    expect(response.headers.get('cache-control')).toBe('no-store')
+  })
+
+  it('allows Apple OAuth form_post callbacks to pass CSRF origin checks', () => {
+    const response = proxy(
+      mockRequest(
+        'https://pico.mutx.dev/api/auth/oauth/apple/callback',
+        {
+          host: 'pico.mutx.dev',
+          origin: 'https://appleid.apple.com',
+        },
+        'POST',
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull()
+    expect(response.headers.get('location')).toBeNull()
     expect(response.headers.get('cache-control')).toBe('no-store')
   })
 


### PR DESCRIPTION
## Summary
- allow pico.mutx.dev auth pages and OAuth API routes to reach their handlers instead of the WIP guard
- allow Apple form_post callbacks through the CSRF guard and send transient OAuth cookies with SameSite=None
- generate Apple client_secret JWTs during exchange instead of requiring a static APPLE_CLIENT_SECRET

## Validation
- npx jest --runInBand tests/unit/middlewareRouting.test.ts tests/unit/authRoutes.test.ts
- npx eslint proxy.ts app/api/auth/oauth/[provider]/start/route.ts app/api/auth/oauth/[provider]/callback/route.ts tests/unit/middlewareRouting.test.ts tests/unit/authRoutes.test.ts --max-warnings=0
- ruff check src/api/services/social_auth.py tests/api/test_auth.py
- black --check src/api/services/social_auth.py tests/api/test_auth.py
- python -m compileall src/api/services/social_auth.py
- ./.venv/bin/python -m pytest tests/api/test_auth.py -q