### PR TITLE
Polish dashboard and Pico launch QA surfaces

### DIFF
--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -12,7 +12,7 @@ export default function DashboardAnalyticsPage() {
         <div className="space-y-4">
           <RouteHeader
             title="Analytics"
-            description="Usage trends, latency posture, and operator activity summaries from the live analytics contracts."
+            description="Usage trends, latency posture, and activity summaries from the live analytics contracts."
             icon={BarChart3}
             iconTone="text-fuchsia-300 bg-fuchsia-400/10"
             badge="analytics surface"

--- a/app/dashboard/api-keys/page.tsx
+++ b/app/dashboard/api-keys/page.tsx
@@ -12,7 +12,7 @@ export default function DashboardApiKeysPage() {
         <div className="space-y-4">
           <RouteHeader
             title="API Keys"
-            description="Create, rotate, revoke, and inspect operator keys without leaving the dashboard shell."
+            description="Create, rotate, revoke, and inspect API keys without leaving the dashboard."
             icon={Key}
             iconTone="text-amber-300 bg-amber-400/10"
             badge="credential surface"

--- a/app/dashboard/autonomy/page.tsx
+++ b/app/dashboard/autonomy/page.tsx
@@ -12,7 +12,7 @@ export default function DashboardAutonomyPage() {
         <div className="space-y-4">
           <RouteHeader
             title="Autonomy"
-            description="Local-only operator view for the live autonomy daemon, lane state, queue depth, active runners, and recent reports."
+            description="Local view for the live autonomy daemon, queue depth, active runners, and recent reports."
             icon={Bot}
             iconTone="text-fuchsia-300 bg-fuchsia-400/10"
             badge="local autonomy surface"

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
   metadataBase: new URL(getAppUrl()),
   ...buildPageMetadata({
     title: "Dashboard - MUTX",
-    description: "Operator dashboard for agents, deployments, runs, budgets, webhooks, and governance.",
+    description: "Dashboard for agents, deployments, runs, budgets, webhooks, and governance.",
     path: "/",
     host: getAppUrl(),
     siteName: "MUTX App",
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
     nocache: true,
   },
   title: "Dashboard - MUTX",
-  description: "Operator dashboard for agents, deployments, runs, budgets, webhooks, and governance.",
+  description: "Dashboard for agents, deployments, runs, budgets, webhooks, and governance.",
   keywords: [
     "agent control plane",
     "agent deployments",

--- a/app/dashboard/memory/page.tsx
+++ b/app/dashboard/memory/page.tsx
@@ -10,11 +10,11 @@ export default function DashboardMemoryPage() {
       browserView={
         <DemoRoutePage
           title="Memory"
-          description="Memory and context-management need real retention and retrieval contracts before they deserve operator controls."
+          description="Memory and context management need real retention and retrieval contracts before controls belong here."
           badge="demo memory"
           notes={[
             "Do not ship pretend vector-store or retention controls before the product semantics exist.",
-            "This surface should become the place operators inspect memory pressure, retention windows, and context ownership.",
+            "This page should become the place to inspect memory pressure, retention windows, and context ownership.",
             "Until then, keep the route compact, honest, and visually aligned with the rest of the control plane.",
           ]}
         />

--- a/app/dashboard/notifications/page.tsx
+++ b/app/dashboard/notifications/page.tsx
@@ -8,10 +8,10 @@ export default function DashboardNotificationsPage() {
     <div className="space-y-4">
       <RouteHeader
         title="Notifications"
-        description="Operator inbox composed from live alerts, pending approvals, webhook failures, and runtime incident summaries."
+        description="A focused inbox for live alerts, pending approvals, webhook failures, and runtime incident summaries."
         icon={BellRing}
         iconTone="text-amber-300 bg-amber-400/10"
-        badge="operator inbox"
+        badge="signal inbox"
         stats={[
           { label: "Scope", value: "Signals only" },
           { label: "Data", value: "Live API", tone: "success" },

--- a/app/dashboard/orchestration/page.tsx
+++ b/app/dashboard/orchestration/page.tsx
@@ -13,7 +13,7 @@ export default function DashboardOrchestrationPage() {
           description="Workflow and handoff control will land here once the backend owns orchestration entities end to end."
           badge="demo orchestration"
           notes={[
-            "Show truthful workflow topology once orchestration endpoints ship instead of inventing queue theater.",
+            "Show truthful workflow topology once orchestration endpoints ship.",
             "Keep pause, resume, and concurrency controls hidden until they map to auditable backend actions.",
             "Use the same shell and density rules as the live routes so this page is ready for backend wiring, not another redesign.",
           ]}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -14,12 +14,12 @@ export default function DashboardPage() {
         <div className="space-y-4">
           <RouteHeader
             title="Overview"
-            description="Fleet posture, recent execution, alert pressure, delivery health, and operator budget state in one surface."
+            description="Fleet posture, recent execution, alerts, delivery health, and budget state in one surface."
             icon={Activity}
             iconTone="text-cyan-300 bg-cyan-400/10"
-            badge="operator overview"
+            badge="workspace overview"
             stats={[
-              { label: "Shell", value: "Canonical /dashboard" },
+              { label: "Route", value: "/dashboard" },
               { label: "Data", value: "Live API", tone: "success" },
             ]}
           />

--- a/app/dashboard/runs/page.tsx
+++ b/app/dashboard/runs/page.tsx
@@ -12,7 +12,7 @@ export default function DashboardRunsPage() {
         <div className="space-y-4">
           <RouteHeader
             title="Runs"
-            description="Recent execution history, terminal state, and operator recovery context from the live runs contract."
+            description="Recent execution history, terminal state, and recovery context from the live runs contract."
             icon={History}
             iconTone="text-cyan-300 bg-cyan-400/10"
             badge="execution surface"

--- a/app/dashboard/security/page.tsx
+++ b/app/dashboard/security/page.tsx
@@ -12,7 +12,7 @@ export default function DashboardSecurityPage() {
         <div className="space-y-4">
           <RouteHeader
             title="Security"
-            description="Credential inventory, auth posture, and operator trust boundaries in the same surface as deployment and recovery."
+            description="Credential inventory, auth posture, and trust boundaries in the same surface as deployment and recovery."
             icon={ShieldCheck}
             iconTone="text-amber-300 bg-amber-400/10"
             badge="security surface"

--- a/app/dashboard/standup/page.tsx
+++ b/app/dashboard/standup/page.tsx
@@ -8,7 +8,7 @@ export default function DashboardStandupPage() {
     <div className="space-y-4">
       <RouteHeader
         title="Standup"
-        description="Derived operator brief synthesized from current alerts, approvals, runs, webhook failures, and optional local autonomy backlog."
+        description="Read-only brief synthesized from current alerts, approvals, runs, webhook failures, and optional local autonomy backlog."
         icon={Activity}
         iconTone="text-cyan-300 bg-cyan-400/10"
         badge="derived brief"

--- a/components/AuthNav.tsx
+++ b/components/AuthNav.tsx
@@ -30,13 +30,13 @@ export function AuthNav({ hostVariant = "default" }: AuthNavProps) {
                 {isPicoPreview ? "Pico" : "MUTX"}
               </span>
               <span className="font-[family:var(--font-mono)] text-[10px] uppercase tracking-[0.22em] text-[rgba(232,221,203,0.56)]">
-                {isPicoPreview ? "preview access" : "auth lane"}
+                {isPicoPreview ? "preview access" : "account access"}
               </span>
             </span>
           </Link>
 
         <span className="hidden rounded-full border border-[rgba(255,240,214,0.1)] bg-[rgba(255,248,236,0.03)] px-3 py-1.5 font-[family:var(--font-mono)] text-[10px] uppercase tracking-[0.18em] text-[rgba(232,221,203,0.6)] lg:inline-flex">
-          {isPicoPreview ? "preview account boundary" : "hosted operator identity"}
+          {isPicoPreview ? "preview account" : "hosted workspace identity"}
         </span>
       </div>
     </nav>

--- a/components/app/AppDomainDemoIntro.tsx
+++ b/components/app/AppDomainDemoIntro.tsx
@@ -56,7 +56,7 @@ export function AppDomainDemoIntro() {
   const pathname = usePathname();
   const prefersReducedMotion = useReducedMotion();
   const [mounted, setMounted] = useState(false);
-  const [introVisible, setIntroVisible] = useState(true);
+  const [introVisible, setIntroVisible] = useState(false);
   const [introArmed, setIntroArmed] = useState(false);
   const completedRef = useRef(false);
 

--- a/components/dashboard/DashboardContentRouter.tsx
+++ b/components/dashboard/DashboardContentRouter.tsx
@@ -176,7 +176,7 @@ function UpgradeNudge({
       description={`The ${panel} panel is gated in essential mode so the shell stays focused on the core workflow.`}
       badge='essential mode'
       checks={[
-        'Switch the interface mode to full once you need the broader Mission Control surface.',
+        'Switch the interface mode to full once you need the broader dashboard surface.',
         `Current subscription: ${subscription || 'free'}.`,
         'Essential mode keeps overview, agents, tasks, chat, activity, logs, and settings available.',
       ]}
@@ -211,12 +211,12 @@ function renderPanel(panel: DashboardPanelId) {
       return (
         <ShellRoute
           title='Overview'
-          description='Fleet posture, recent execution, alert pressure, delivery health, and operator budget state in one surface.'
+          description='Fleet posture, recent execution, alerts, delivery health, and budget state in one surface.'
           icon={Activity}
           iconTone='text-cyan-300 bg-cyan-400/10'
-          badge='operator overview'
+          badge='workspace overview'
           stats={[
-            { label: 'Shell', value: 'Mission Control' },
+            { label: 'Route', value: '/dashboard' },
             { label: 'Data', value: 'Live API', tone: 'success' },
           ]}
         >
@@ -291,7 +291,7 @@ function renderPanel(panel: DashboardPanelId) {
       return (
         <ShellRoute
           title='Runs'
-          description='Recent execution history, terminal state, and operator recovery context from the live runs contract.'
+          description='Recent execution history, terminal state, and recovery context from the live runs contract.'
           icon={History}
           iconTone='text-cyan-300 bg-cyan-400/10'
           badge='execution surface'
@@ -387,7 +387,7 @@ function renderPanel(panel: DashboardPanelId) {
       return (
         <ShellRoute
           title='API Keys'
-          description='Create, rotate, revoke, and inspect operator keys without leaving the dashboard shell.'
+          description='Create, rotate, revoke, and inspect API keys without leaving the dashboard.'
           icon={Key}
           iconTone='text-amber-300 bg-amber-400/10'
           badge='credential surface'
@@ -435,7 +435,7 @@ function renderPanel(panel: DashboardPanelId) {
       return (
         <ShellRoute
           title='Security'
-          description='Credential inventory, auth posture, and operator trust boundaries in the same surface as deployment and recovery.'
+          description='Credential inventory, auth posture, and trust boundaries in the same surface as deployment and recovery.'
           icon={ShieldCheck}
           iconTone='text-amber-300 bg-amber-400/10'
           badge='security surface'
@@ -454,7 +454,7 @@ function renderPanel(panel: DashboardPanelId) {
           description='Workflow and handoff control will land here once the backend owns orchestration entities end to end.'
           badge='demo orchestration'
           notes={[
-            'Show truthful workflow topology once orchestration endpoints ship instead of inventing queue theater.',
+            'Show truthful workflow topology once orchestration endpoints ship.',
             'Keep pause, resume, and concurrency controls hidden until they map to auditable backend actions.',
             'Use the same shell and density rules as the live routes so this page is ready for backend wiring, not another redesign.',
           ]}
@@ -464,11 +464,11 @@ function renderPanel(panel: DashboardPanelId) {
       return (
         <DemoRoutePage
           title='Memory'
-          description='Memory and context-management need real retention and retrieval contracts before they deserve operator controls.'
+          description='Memory and context management need real retention and retrieval contracts before controls belong here.'
           badge='demo memory'
           notes={[
             'Do not ship pretend vector-store or retention controls before the product semantics exist.',
-            'This surface should become the place operators inspect memory pressure, retention windows, and context ownership.',
+            'This page should become the place to inspect memory pressure, retention windows, and context ownership.',
             'Until then, keep the route compact, honest, and visually aligned with the rest of the control plane.',
           ]}
         />
@@ -477,7 +477,7 @@ function renderPanel(panel: DashboardPanelId) {
       return (
         <ShellRoute
           title='Analytics'
-          description='Usage trends, latency posture, and operator activity summaries from the live analytics contracts.'
+          description='Usage trends, latency posture, and activity summaries from the live analytics contracts.'
           icon={BarChart3}
           iconTone='text-fuchsia-300 bg-fuchsia-400/10'
           badge='analytics surface'
@@ -538,7 +538,7 @@ function renderPanel(panel: DashboardPanelId) {
       return (
         <ShellRoute
           title='Settings'
-          description='Bridge diagnostics, runtime repair, and setup flow for this operator seat.'
+          description='Bridge diagnostics, runtime repair, and setup flow for this workspace.'
           icon={Network}
           iconTone='text-cyan-300 bg-cyan-400/10'
           badge='advanced diagnostics'
@@ -554,7 +554,7 @@ function renderPanel(panel: DashboardPanelId) {
       return (
         <ShellRoute
           title='Autonomy'
-          description='Local operator view for the live autonomy daemon, lane state, queue depth, active runners, and recent reports.'
+          description='Local view for the live autonomy daemon, queue depth, active runners, and recent reports.'
           icon={Bot}
           iconTone='text-fuchsia-300 bg-fuchsia-400/10'
           badge='local autonomy surface'
@@ -609,7 +609,7 @@ function renderPanel(panel: DashboardPanelId) {
       return (
         <MissingPanel
           title='Standup'
-          description='Mission Control expects a standup panel, but MUTX does not have a real standup workflow in this checkout yet.'
+          description='MUTX does not have a real standup workflow in this checkout yet, so this panel stays reserved.'
         />
       )
   }

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -172,24 +172,24 @@ export function DashboardShell({ children, spaShellEnabled }: DashboardShellProp
   const shellCopy = useMemo(() => {
     if (!platformReady) {
       return {
-        eyebrow: "shell bootstrap",
-        title: "Resolving native operator context",
+        eyebrow: "starting up",
+        title: "Opening your workspace",
         detail: "Checking whether this session is running inside MUTX.app and syncing the latest desktop state.",
       };
     }
 
     if (!isDesktop) {
       return {
-        eyebrow: "web shell",
-        title: "Canonical MUTX dashboard",
-        detail: "Desktop-only actions stay gated until this session is running inside MUTX.app.",
+        eyebrow: "web access",
+        title: "MUTX dashboard",
+        detail: "Review agents, runs, keys, alerts, and setup state from one workspace.",
       };
     }
 
     if (!status.authenticated) {
       return {
-        eyebrow: "mission control",
-        title: "The home surface is now the setup surface",
+        eyebrow: "setup",
+        title: "Finish setup from the dashboard",
         detail: "Use /dashboard to sync identity, runtime, and the local desktop contract from one native shell.",
       };
     }
@@ -197,7 +197,7 @@ export function DashboardShell({ children, spaShellEnabled }: DashboardShellProp
     if (!status.assistant?.found) {
       return {
         eyebrow: status.mode === "local" ? "local workspace" : "hosted workspace",
-        title: "Bind the first assistant from mission control",
+        title: "Connect the first assistant",
         detail: "Stay on /dashboard to drive runtime choice and assistant setup, then move into advanced control only when needed.",
       };
     }
@@ -206,12 +206,12 @@ export function DashboardShell({ children, spaShellEnabled }: DashboardShellProp
       return {
         eyebrow: "local runtime",
         title: `${status.assistant.name} is ready, but the local stack is offline`,
-        detail: "Bring the control plane online to turn this machine into an active operator seat.",
+        detail: "Start the local stack before running desktop-only actions from this machine.",
       };
     }
 
     return {
-      eyebrow: status.mode === "local" ? "desktop operator" : "hosted operator",
+      eyebrow: status.mode === "local" ? "desktop workspace" : "hosted workspace",
       title: `${status.assistant.name || "Assistant"} is wired into the control plane`,
       detail:
         status.openclaw?.gatewayUrl ||
@@ -355,7 +355,7 @@ export function DashboardShell({ children, spaShellEnabled }: DashboardShellProp
             MUTX
           </p>
         </div>
-        <p className="text-[10px] uppercase tracking-[0.28em] text-[#93c5fd]">Operator Console</p>
+        <p className="text-[10px] uppercase tracking-[0.28em] text-[#93c5fd]">Workspace</p>
       </div>
     </div>
   );
@@ -365,7 +365,7 @@ export function DashboardShell({ children, spaShellEnabled }: DashboardShellProp
       <div className="rounded-[24px] border border-[rgba(191,219,254,0.1)] bg-[linear-gradient(180deg,#121a29_0%,#0a0f18_100%)] px-3.5 py-4">
         <div className="flex items-center justify-between gap-2">
           <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-[#93c5fd]">
-            Operator memo
+            Workspace memo
           </p>
           <span className="rounded-full border border-[rgba(191,219,254,0.12)] bg-[#0f1728] px-2.5 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[#dbeafe]">
             {isDesktop ? "desktop" : "web"}
@@ -373,7 +373,7 @@ export function DashboardShell({ children, spaShellEnabled }: DashboardShellProp
         </div>
         <p className="mt-3 text-sm leading-6 text-[#dbe7f8]">
           {isDesktop
-            ? status.user?.name || "Connect this machine to an operator account"
+            ? status.user?.name || "Connect this machine to a workspace account"
             : "Desktop identity and machine-local actions appear here inside MUTX.app."}
         </p>
         <p className="mt-1 text-[12px] leading-5 text-[#9bb4d6]">
@@ -483,7 +483,7 @@ export function DashboardShell({ children, spaShellEnabled }: DashboardShellProp
                     {activeItem?.title || "Dashboard"}
                   </p>
                   <p className="truncate text-[10px] uppercase tracking-[0.22em] text-[#93c5fd]">
-                    {activeItem?.group === "home" ? "Mission Control" : activeItem?.group || "Operator"}
+                    {activeItem?.group === "home" ? "Workspace" : activeItem?.group || "Dashboard"}
                   </p>
                 </div>
               </div>
@@ -520,7 +520,7 @@ export function DashboardShell({ children, spaShellEnabled }: DashboardShellProp
                         <Sparkles className="h-3.5 w-3.5" />
                         {shellCopy.eyebrow}
                       </span>
-                      <span>{activeItem?.group === "home" ? "Mission Control" : activeItem?.group || "Operator"}</span>
+                      <span>{activeItem?.group === "home" ? "Workspace" : activeItem?.group || "Dashboard"}</span>
                     </div>
 
                     <div className="max-w-4xl">
@@ -534,7 +534,7 @@ export function DashboardShell({ children, spaShellEnabled }: DashboardShellProp
 
                     <div className="flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.14em]">
                       <span className="rounded-full border border-[rgba(191,219,254,0.12)] bg-[#101722] px-2.5 py-1 text-[#c8daf4]">
-                        {status.user?.email || "operator session"}
+                        {status.user?.email || "session needed"}
                       </span>
                       <span className="rounded-full border border-[rgba(191,219,254,0.12)] bg-[#101722] px-2.5 py-1 text-[#c8daf4]">
                         {activeItem?.title || "Dashboard"}

--- a/components/dashboard/DashboardSpaPanelHost.tsx
+++ b/components/dashboard/DashboardSpaPanelHost.tsx
@@ -514,7 +514,7 @@ export function DashboardSpaPanelHost() {
             </div>
             <div>
               <h2 className='font-[family:var(--font-site-display)] text-[1.7rem] leading-[0.98] tracking-[-0.06em] text-white'>
-                Mission Control shell is routing this dashboard from one surface
+                The dashboard shell is routing everything from one surface
               </h2>
               <p className='mt-2 max-w-4xl text-sm leading-6 text-slate-300'>
                 The panel switchboard now owns boot, routing, gating, and failure isolation. Legacy
@@ -573,7 +573,7 @@ export function DashboardSpaPanelHost() {
 
         <div className='mt-4 flex flex-wrap items-center gap-2 text-[11px] text-slate-300'>
           <span className='rounded-full border border-white/10 bg-[#0f1728] px-2.5 py-1'>
-            {currentUser?.display_name || 'Operator pending'}
+            {currentUser?.display_name || 'Sign-in pending'}
           </span>
           <span className='rounded-full border border-white/10 bg-[#0f1728] px-2.5 py-1'>
             {subscription || 'free'} subscription
@@ -603,7 +603,7 @@ export function DashboardSpaPanelHost() {
                   Live feed
                 </p>
                 <p className='mt-2 text-sm text-slate-300'>
-                  Shell posture, boot state, and operator mode in one side rail.
+                  Shell posture, boot state, and interface mode in one side rail.
                 </p>
               </div>
               <span className='rounded-full border border-white/10 bg-[#0f1728] px-2.5 py-1 text-[10px] uppercase tracking-[0.14em] text-slate-200'>
@@ -627,7 +627,7 @@ export function DashboardSpaPanelHost() {
                     <span className='text-slate-400'>{desktopRuntimeActive ? 'local' : 'gateway'}</span>
                   </div>
                   <div className='flex items-center justify-between gap-3'>
-                    <span>Operator</span>
+                    <span>Account</span>
                     <span className='truncate text-slate-400'>{currentUser?.display_name || 'pending'}</span>
                   </div>
                 </div>
@@ -691,7 +691,7 @@ export function DashboardSpaPanelHost() {
           <div className='space-y-4 px-5 py-5'>
             <p className='text-sm leading-6 text-slate-300'>
               The shell keeps chat as a first-class panel. Open the session surface to work the live
-              session list without leaving Mission Control.
+              session list without leaving the dashboard.
             </p>
 
             <div className='grid gap-3 sm:grid-cols-2'>
@@ -737,7 +737,7 @@ export function DashboardSpaPanelHost() {
                 </div>
                 <div>
                   <h2 className='font-[family:var(--font-site-display)] text-[1.95rem] tracking-[-0.06em] text-white'>
-                    Bringing Mission Control online
+                    Bringing the dashboard online
                   </h2>
                   <p className='mt-2 max-w-2xl text-sm leading-6 text-slate-300'>
                     The shell is walking auth, capabilities, config, and the initial data preload before

--- a/components/dashboard/DemoRoutePage.tsx
+++ b/components/dashboard/DemoRoutePage.tsx
@@ -25,7 +25,7 @@ export function DemoRoutePage({
         hint={{
           tone: "comingSoon",
           detail:
-            "This route is intentionally staged. The layout is real, but operator actions stay hidden until the backend contract ships end to end.",
+            "This route is intentionally staged. The layout is real, but actions stay hidden until the backend contract ships end to end.",
         }}
         stats={[
           { label: "State", value: "Integration pending", tone: "warning" },

--- a/components/dashboard/FeatureHint.tsx
+++ b/components/dashboard/FeatureHint.tsx
@@ -62,7 +62,7 @@ export function FeatureHint({
 
       <div
         className={cn(
-          "absolute top-[calc(100%+0.5rem)] z-30 w-[min(20rem,calc(100vw-2rem))] rounded-[18px] border p-4 shadow-[0_20px_50px_rgba(2,2,5,0.34)]",
+          "absolute top-[calc(100%+0.5rem)] z-30 hidden w-[min(20rem,calc(100vw-2rem))] rounded-[18px] border p-4 shadow-[0_20px_50px_rgba(2,2,5,0.34)] group-open:block",
           align === "left" ? "left-0" : "right-0",
           copy.detailClassName,
         )}

--- a/components/dashboard/NotificationsPageClient.tsx
+++ b/components/dashboard/NotificationsPageClient.tsx
@@ -125,13 +125,13 @@ export function NotificationsPageClient() {
         <LiveStatCard
           label="Alerts"
           value={String(payload.summary.alerts)}
-          detail="Open monitoring alerts sampled into the operator inbox."
+          detail="Open monitoring alerts sampled into the signal inbox."
           status={payload.summary.alerts > 0 ? "error" : "success"}
         />
         <LiveStatCard
           label="Approvals"
           value={String(payload.summary.approvals)}
-          detail="Pending approval requests still waiting on an operator decision."
+          detail="Pending approval requests still waiting on review."
           status={payload.summary.approvals > 0 ? "warning" : "success"}
         />
         <LiveStatCard

--- a/components/dashboard/RouteHeader.tsx
+++ b/components/dashboard/RouteHeader.tsx
@@ -126,7 +126,7 @@ export function RouteHeader({
             </div>
           ) : (
             <p className="mt-3 text-sm leading-6" style={{ color: dashboardTokens.textSubtle }}>
-              This route is mounted inside the unified operator shell and ready for live data.
+              This route is mounted inside the unified dashboard shell and ready for live data.
             </p>
           )}
         </div>

--- a/components/dashboard/SecurityPageClient.tsx
+++ b/components/dashboard/SecurityPageClient.tsx
@@ -129,7 +129,7 @@ export function SecurityPageClient() {
           </div>
         </LivePanel>
 
-        <LivePanel title="Security posture" meta="operator trust">
+        <LivePanel title="Security posture" meta="workspace trust">
           <div className="space-y-3">
             <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
               <div className="flex items-center gap-2 text-slate-300">
@@ -137,7 +137,7 @@ export function SecurityPageClient() {
                 <span className="text-sm font-medium">Owned credentials</span>
               </div>
               <p className="mt-3 text-sm leading-6 text-slate-400">
-                MUTX keeps operator keys and deployment actions in the same governance surface so rotation, ownership, and actionability stay connected.
+                MUTX keeps API keys and deployment actions in the same governance surface so rotation, ownership, and actionability stay connected.
               </p>
             </div>
             <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">

--- a/components/dashboard/livePrimitives.tsx
+++ b/components/dashboard/livePrimitives.tsx
@@ -252,8 +252,10 @@ export function LiveAuthRequired({
   title: string;
   message: string;
 }) {
+  const displayTitle = title.replace(/^Operator session/i, "Sign-in");
+
   return (
-    <LivePanel title={title} meta="auth required">
+    <LivePanel title={displayTitle} meta="auth required">
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1.08fr)_minmax(260px,0.92fr)]">
         <div
           className="rounded-[24px] border p-5"
@@ -284,7 +286,7 @@ export function LiveAuthRequired({
                 className="mt-2 font-[family:var(--font-site-display)] text-lg font-semibold"
                 style={{ color: dashboardTokens.textPrimary }}
               >
-                {title}
+                {displayTitle}
               </p>
               <p className="mt-2 text-sm leading-6" style={{ color: dashboardTokens.textSubtle }}>
                 {message}
@@ -295,8 +297,8 @@ export function LiveAuthRequired({
 
         <div className="grid gap-3">
           {[
-            "Run the MUTX setup lane or sign back in with the active operator account.",
-            "Once authenticated, this route swaps the gate state for the real control-plane payload.",
+            "Open setup or sign back in with the account for this workspace.",
+            "After sign-in, this page loads live data from the control plane.",
           ].map((note) => (
             <div
               key={note}

--- a/components/pico/AgentSlider.tsx
+++ b/components/pico/AgentSlider.tsx
@@ -210,10 +210,6 @@ export function AgentSlider({
           background: linear-gradient(270deg, rgba(5, 8, 13, 0.98), transparent);
         }
 
-        .agent-slider[data-interactive='false'] {
-          pointer-events: none;
-        }
-
         .agent-viewport {
           overflow: hidden;
           padding: 0.82rem 0;
@@ -280,6 +276,10 @@ export function AgentSlider({
         button.agent-card {
           cursor: pointer;
           touch-action: manipulation;
+        }
+
+        .agent-slider[data-interactive='false'] .agent-card {
+          touch-action: pan-x pan-y;
         }
 
         .agent-slider[data-interactive='true']:is(:hover, :focus-within) .agent-card {

--- a/components/pico/AgentSlider.tsx
+++ b/components/pico/AgentSlider.tsx
@@ -106,16 +106,9 @@ export function AgentSlider({
         {agents.map((agent, index) => {
           const kind = agent.kind ?? DEFAULT_AGENTS[index % DEFAULT_AGENTS.length]?.kind ?? 'dev'
           const Icon = ICONS[kind]
-
-          return (
-            <button
-              key={`${isDuplicate ? 'duplicate' : 'primary'}-${agent.name}-${index}`}
-              type="button"
-              className="agent-card"
-              tabIndex={isDuplicate ? -1 : undefined}
-              aria-label={`${agent.name}: ${agent.description}`}
-              onClick={() => onAgentClick?.(agent, index)}
-            >
+          const label = `${agent.name}: ${agent.description}`
+          const content = (
+            <>
               <span className="agent-icon" aria-hidden="true">
                 <Icon />
               </span>
@@ -123,6 +116,33 @@ export function AgentSlider({
                 <span className="agent-name">{agent.name}</span>
                 <span className="agent-description">{agent.description}</span>
               </span>
+            </>
+          )
+
+          if (!onAgentClick) {
+            return (
+              <article
+                key={`${isDuplicate ? 'duplicate' : 'primary'}-${agent.name}-${index}`}
+                className="agent-card"
+                data-agent-slider-card={isDuplicate ? 'duplicate' : 'primary'}
+                aria-label={label}
+              >
+                {content}
+              </article>
+            )
+          }
+
+          return (
+            <button
+              key={`${isDuplicate ? 'duplicate' : 'primary'}-${agent.name}-${index}`}
+              type="button"
+              className="agent-card"
+              data-agent-slider-card={isDuplicate ? 'duplicate' : 'primary'}
+              tabIndex={isDuplicate ? -1 : undefined}
+              aria-label={label}
+              onClick={() => onAgentClick?.(agent, index)}
+            >
+              {content}
             </button>
           )
         })}
@@ -136,6 +156,7 @@ export function AgentSlider({
       style={style}
       aria-label={ariaLabel}
       data-direction={direction}
+      data-interactive={onAgentClick ? 'true' : 'false'}
       data-pause={pauseOnHover ? 'true' : 'false'}
     >
       <div className="agent-viewport">
@@ -187,6 +208,10 @@ export function AgentSlider({
         .agent-slider::after {
           right: 0;
           background: linear-gradient(270deg, rgba(5, 8, 13, 0.98), transparent);
+        }
+
+        .agent-slider[data-interactive='false'] {
+          pointer-events: none;
         }
 
         .agent-viewport {
@@ -247,16 +272,23 @@ export function AgentSlider({
             border-color 170ms ease,
             background 170ms ease,
             box-shadow 170ms ease;
+          cursor: default;
+          touch-action: pan-y;
+          user-select: none;
+        }
+
+        button.agent-card {
+          cursor: pointer;
           touch-action: manipulation;
         }
 
-        .agent-slider:is(:hover, :focus-within) .agent-card {
+        .agent-slider[data-interactive='true']:is(:hover, :focus-within) .agent-card {
           opacity: 0.58;
         }
 
-        .agent-card:hover,
-        .agent-card:focus,
-        .agent-card:active {
+        .agent-slider[data-interactive='true'] .agent-card:hover,
+        .agent-slider[data-interactive='true'] .agent-card:focus,
+        .agent-slider[data-interactive='true'] .agent-card:active {
           z-index: 3;
           opacity: 1;
           transform: scale(1.065);
@@ -275,7 +307,7 @@ export function AgentSlider({
             inset 0 1px 0 rgba(255, 255, 255, 0.08);
         }
 
-        .agent-card:focus-visible {
+        .agent-slider[data-interactive='true'] .agent-card:focus-visible {
           outline: none;
           box-shadow:
             0 0 0 3px rgba(var(--pico-accent-rgb, 164, 255, 92), 0.24),
@@ -347,16 +379,18 @@ export function AgentSlider({
             transform 160ms ease;
         }
 
-        .agent-card:hover .agent-name,
-        .agent-card:focus .agent-name,
-        .agent-card:active .agent-name {
+        .agent-slider[data-interactive='true'] .agent-card:hover .agent-name,
+        .agent-slider[data-interactive='true'] .agent-card:focus .agent-name,
+        .agent-slider[data-interactive='true'] .agent-card:active .agent-name,
+        .agent-slider[data-interactive='false'] .agent-name {
           color: var(--pico-accent-bright, #ebffbf);
           transform: translateY(0);
         }
 
-        .agent-card:hover .agent-description,
-        .agent-card:focus .agent-description,
-        .agent-card:active .agent-description {
+        .agent-slider[data-interactive='true'] .agent-card:hover .agent-description,
+        .agent-slider[data-interactive='true'] .agent-card:focus .agent-description,
+        .agent-slider[data-interactive='true'] .agent-card:active .agent-description,
+        .agent-slider[data-interactive='false'] .agent-description {
           opacity: 1;
           transform: translateY(0);
         }

--- a/components/pico/PicoLandingPoster.tsx
+++ b/components/pico/PicoLandingPoster.tsx
@@ -215,7 +215,7 @@ export function PicoLandingPoster() {
           className={s.agentSliderBand}
           ariaLabel={t('agentSlider.ariaLabel')}
           agents={agentSliderAgents}
-          onAgentClick={() => openForm('build')}
+          pauseOnHover={false}
           speed={46}
         />
 

--- a/components/pico/PicoLessonDetail.tsx
+++ b/components/pico/PicoLessonDetail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 
 import { PicoShell } from '@/components/pico/PicoShell'
@@ -58,8 +58,9 @@ function formatDifficulty(difficulty: PicoLesson['difficulty']) {
 
 export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
   const session = usePicoSession()
-  const { progress, derived, actions } = usePicoProgress()
+  const { ready: progressReady, progress, derived, actions } = usePicoProgress()
   const toHref = usePicoHref()
+  const [interactiveReady, setInteractiveReady] = useState(false)
 
   const started = progress.startedLessons.includes(lesson.slug)
   const completed = progress.completedLessons.includes(lesson.slug)
@@ -79,6 +80,7 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
   const previousLesson = lessonIndex > 0 ? trackLessons[lessonIndex - 1] ?? null : null
 
   const {
+    ready: workspaceReady,
     workspace,
     completedStepCount,
     progressPercent,
@@ -92,6 +94,7 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
   const activeStepIndex = workspace.activeStepIndex >= 0 ? workspace.activeStepIndex : 0
   const activeWorkspaceStep = lesson.steps[activeStepIndex] ?? lesson.steps[0] ?? null
   const evidenceReady = workspace.evidence.trim().length > 0
+  const lessonControlsReady = interactiveReady && progressReady && workspaceReady
   const hostedStamp =
     session.status === 'authenticated'
       ? session.user.isEmailVerified === false
@@ -135,6 +138,10 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
       value: `${lesson.estimatedMinutes}m • ${lesson.xp} xp • ${formatDifficulty(lesson.difficulty)}`,
     },
   ]
+
+  useEffect(() => {
+    setInteractiveReady(true)
+  }, [])
 
   useEffect(() => {
     if (!missingPrerequisiteLesson && !started && !completed) {
@@ -191,7 +198,11 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
           <button
             type="button"
             onClick={() => actions.completeLesson(lesson.slug)}
-            className={picoClasses.secondaryButton}
+            disabled={!lessonControlsReady}
+            className={cn(
+              picoClasses.secondaryButton,
+              !lessonControlsReady && 'disabled:cursor-not-allowed disabled:opacity-60',
+            )}
           >
             {getCompleteLabel(lesson.slug)}
           </button>
@@ -203,7 +214,11 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
       <button
         type="button"
         onClick={() => actions.completeLesson(lesson.slug)}
-        className={buttonClassName}
+        disabled={!lessonControlsReady}
+        className={cn(
+          buttonClassName,
+          !lessonControlsReady && 'disabled:cursor-not-allowed disabled:opacity-60',
+        )}
       >
         {getCompleteLabel(lesson.slug)}
       </button>
@@ -397,11 +412,13 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
                   key={step.title}
                   type="button"
                   onClick={() => workspaceActions.setActiveStep(index)}
+                  disabled={!lessonControlsReady}
                   className={cn(
                     'grid min-w-[13rem] gap-2 rounded-[24px] border px-4 py-4 text-left transition',
                     active
                       ? 'border-[color:var(--pico-accent)] bg-[linear-gradient(180deg,rgba(var(--pico-accent-rgb),0.22),rgba(8,16,10,0.32))] text-[color:var(--pico-text)]'
                       : 'border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] text-[color:var(--pico-text-secondary)]',
+                    !lessonControlsReady && 'disabled:cursor-not-allowed disabled:opacity-60',
                   )}
                 >
                   <div className="flex flex-wrap items-center gap-2">
@@ -447,11 +464,13 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
                       key={step.title}
                       type="button"
                       onClick={() => workspaceActions.setActiveStep(index)}
+                      disabled={!lessonControlsReady}
                       className={cn(
                         'grid gap-2 border-l pl-4 text-left transition',
                         active
                           ? 'border-[color:var(--pico-accent)] text-[color:var(--pico-text)]'
                           : 'border-[color:var(--pico-border)] text-[color:var(--pico-text-secondary)] hover:border-[color:var(--pico-border-hover)] hover:text-[color:var(--pico-text)]',
+                        !lessonControlsReady && 'disabled:cursor-not-allowed disabled:opacity-60',
                       )}
                     >
                       <div className="flex flex-wrap items-center gap-2">
@@ -482,17 +501,25 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
               <button
                 type="button"
                 onClick={() => workspaceActions.reset()}
-                className={picoClasses.tertiaryButton}
+                disabled={!lessonControlsReady}
+                className={cn(
+                  picoClasses.tertiaryButton,
+                  !lessonControlsReady && 'disabled:cursor-not-allowed disabled:opacity-60',
+                )}
               >
                 Reset workspace
               </button>
               <button
                 type="button"
                 onClick={() => workspaceActions.toggleStep(activeStepIndex)}
+                disabled={!lessonControlsReady}
                 className={
-                  workspace.completedStepIndexes.includes(activeStepIndex)
-                    ? picoClasses.secondaryButton
-                    : picoClasses.primaryButton
+                  cn(
+                    workspace.completedStepIndexes.includes(activeStepIndex)
+                      ? picoClasses.secondaryButton
+                      : picoClasses.primaryButton,
+                    !lessonControlsReady && 'disabled:cursor-not-allowed disabled:opacity-60',
+                  )
                 }
                 data-testid={activeStepIndex === 0 ? 'pico-step-toggle-first' : undefined}
               >
@@ -528,8 +555,9 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
                 <textarea
                   value={workspace.evidence}
                   onChange={(event) => workspaceActions.setEvidence(event.target.value)}
+                  disabled={!lessonControlsReady}
                   placeholder="Paste the output, transcript note, or file path from this step."
-                  className="min-h-40 rounded-[18px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-input)] px-4 py-3 text-sm text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
+                  className="min-h-40 rounded-[18px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-input)] px-4 py-3 text-sm text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)] disabled:cursor-not-allowed disabled:opacity-60"
                   data-testid="pico-lesson-proof"
                 />
               </label>
@@ -539,8 +567,9 @@ export function PicoLessonDetail({ lesson }: PicoLessonDetailProps) {
                 <textarea
                   value={workspace.notes}
                   onChange={(event) => workspaceActions.setNotes(event.target.value)}
+                  disabled={!lessonControlsReady}
                   placeholder="Capture the blocker, file path, or command variation that mattered."
-                  className="min-h-40 rounded-[18px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-input)] px-4 py-3 text-sm text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
+                  className="min-h-40 rounded-[18px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-input)] px-4 py-3 text-sm text-[color:var(--pico-text)] outline-none placeholder:text-[color:var(--pico-text-muted)] disabled:cursor-not-allowed disabled:opacity-60"
                 />
               </label>
             </div>

--- a/components/pico/PicoShell.tsx
+++ b/components/pico/PicoShell.tsx
@@ -193,6 +193,7 @@ export function PicoShell({
 }: PicoShellProps) {
   const pathname = usePathname()
   const [tourOpen, setTourOpen] = useState(false)
+  const [interactiveReady, setInteractiveReady] = useState(false)
   const academyMode = mode === 'academy'
   const currentItem = navItems.find((item) => routeIsActive(pathname, item.href)) ?? navItems[0]
   const routeRobot = getPicoRouteRobot(pathname, academyMode)
@@ -200,6 +201,10 @@ export function PicoShell({
   const previousItem = currentIndex > 0 ? navItems[currentIndex - 1] : null
   const nextItem = currentIndex < navItems.length - 1 ? navItems[currentIndex + 1] : null
   const isAcademyLessonRoute = pathname.startsWith('/pico/academy/')
+
+  useEffect(() => {
+    setInteractiveReady(true)
+  }, [])
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -236,6 +241,7 @@ export function PicoShell({
                   <button
                     type="button"
                     onClick={() => setTourOpen(true)}
+                    disabled={!interactiveReady}
                     className={picoClasses.tertiaryButton}
                     data-testid="pico-open-tour"
                   >
@@ -245,6 +251,7 @@ export function PicoShell({
                     <button
                       type="button"
                       onClick={onToggleRail}
+                      disabled={!interactiveReady}
                       aria-pressed={!railCollapsed}
                       className={cn(
                         picoClasses.tertiaryButton,
@@ -259,6 +266,7 @@ export function PicoShell({
                     <button
                       type="button"
                       onClick={onToggleHelpLane}
+                      disabled={!interactiveReady}
                       aria-pressed={helpLaneOpen}
                       className={cn(
                         picoClasses.tertiaryButton,
@@ -279,6 +287,7 @@ export function PicoShell({
                   <button
                     type="button"
                     onClick={() => setTourOpen(true)}
+                    disabled={!interactiveReady}
                     className={picoClasses.tertiaryButton}
                     data-testid="pico-open-tour-mobile"
                   >
@@ -365,6 +374,7 @@ export function PicoShell({
                   <button
                     type="button"
                     onClick={onToggleRail}
+                    disabled={!interactiveReady}
                     className="inline-flex min-h-9 items-center justify-center rounded-[11px] border border-[color:var(--pico-border)] px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--pico-text-secondary)]"
                   >
                     Map
@@ -469,6 +479,7 @@ export function PicoShell({
                     <button
                       type="button"
                       onClick={() => setTourOpen(true)}
+                      disabled={!interactiveReady}
                       className={picoClasses.tertiaryButton}
                       data-testid="pico-open-tour"
                     >
@@ -493,7 +504,12 @@ export function PicoShell({
                       </Link>
                     ) : null}
                     {onToggleHelpLane ? (
-                      <button type="button" onClick={onToggleHelpLane} className={picoClasses.tertiaryButton}>
+                      <button
+                        type="button"
+                        onClick={onToggleHelpLane}
+                        disabled={!interactiveReady}
+                        className={picoClasses.tertiaryButton}
+                      >
                         {helpLaneOpen ? 'Hide recovery' : 'Show recovery'}
                       </button>
                     ) : null}
@@ -507,6 +523,7 @@ export function PicoShell({
                     <button
                       type="button"
                       onClick={() => setTourOpen(true)}
+                      disabled={!interactiveReady}
                       className={picoClasses.tertiaryButton}
                       data-testid="pico-open-tour-mobile"
                     >

--- a/components/pico/PicoShell.tsx
+++ b/components/pico/PicoShell.tsx
@@ -330,7 +330,7 @@ export function PicoShell({
 
         <PicoFooter />
 
-        <div className="hidden">
+        <div className="fixed inset-x-3 bottom-3 z-40 lg:hidden" data-testid="pico-mobile-academy-nav">
           <div className={picoCodexFrame('px-2 py-2 shadow-[0_18px_44px_rgba(0,0,0,0.38)]')}>
             <div className="grid grid-cols-3 gap-2">
               {isAcademyLessonRoute ? (
@@ -369,13 +369,13 @@ export function PicoShell({
                   >
                     Map
                   </button>
-                  <button
-                    type="button"
-                    onClick={onToggleHelpLane}
+                  <Link
+                    href={picoHref(pathname, '/support')}
+                    aria-label="Open Pico support"
                     className="inline-flex min-h-9 items-center justify-center rounded-[11px] border border-[color:var(--pico-border)] px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--pico-text-secondary)]"
                   >
                     Help
-                  </button>
+                  </Link>
                 </>
               )}
             </div>
@@ -441,8 +441,20 @@ export function PicoShell({
           </aside>
 
           <div className="min-w-0 space-y-5">
+            <div className="lg:hidden" data-testid="pico-mobile-product-masthead">
+              <div className={picoPanel('px-4 py-4')}>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <PicoWordmark pathname={pathname} />
+                  <span className={picoCodex.stamp}>Chapter {currentItem.chapter}</span>
+                </div>
+                <p className="mt-3 text-xs leading-5 text-[color:var(--pico-text-secondary)]">
+                  {currentItem.note}
+                </p>
+              </div>
+            </div>
+
             <header className={picoPanel('overflow-hidden')}>
-              <div className="border-b border-[color:var(--pico-border)] px-4 py-3 sm:px-5">
+              <div className="hidden border-b border-[color:var(--pico-border)] px-4 py-3 sm:block sm:px-5">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div className="flex flex-wrap items-center gap-3">
                     <span className="inline-flex rounded-[9px] border border-[color:var(--pico-border)] bg-[rgba(255,255,255,0.02)] px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.13em] text-[color:var(--pico-accent-bright)]">
@@ -564,15 +576,24 @@ export function PicoShell({
 
       <PicoFooter />
 
-      <div className="hidden">
+      <div className="fixed inset-x-3 bottom-3 z-40 lg:hidden" data-testid="pico-mobile-product-nav">
         <div className="grid grid-cols-[auto,1fr,auto,auto] items-center gap-1.5 rounded-[16px] border border-[color:var(--pico-border)] bg-[rgba(6,12,8,0.9)] p-1.5 shadow-[0_18px_44px_rgba(0,0,0,0.36)] backdrop-blur">
-          <Link
-            href={picoHref(pathname, previousItem?.href ?? '/onboarding')}
-            aria-label={previousItem ? `Go to previous chapter: ${previousItem.label}` : 'Go to onboarding'}
-            className="inline-flex min-h-9 items-center justify-center rounded-[11px] border border-[color:var(--pico-border)] px-2 text-[10px] font-medium uppercase tracking-[0.1em] text-[color:var(--pico-text-secondary)]"
-          >
-            Prev
-          </Link>
+          {previousItem ? (
+            <Link
+              href={picoHref(pathname, previousItem.href)}
+              aria-label={`Go to previous chapter: ${previousItem.label}`}
+              className="inline-flex min-h-9 items-center justify-center rounded-[11px] border border-[color:var(--pico-border)] px-2 text-[10px] font-medium uppercase tracking-[0.1em] text-[color:var(--pico-text-secondary)]"
+            >
+              Prev
+            </Link>
+          ) : (
+            <span
+              aria-disabled="true"
+              className="inline-flex min-h-9 items-center justify-center rounded-[11px] border border-[color:rgba(255,255,255,0.035)] px-2 text-[10px] font-medium uppercase tracking-[0.1em] text-[color:var(--pico-text-muted)]"
+            >
+              Start
+            </span>
+          )}
 
           <div className="min-w-0 px-1">
             <p className="truncate text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--pico-text-muted)]">
@@ -583,13 +604,22 @@ export function PicoShell({
             </p>
           </div>
 
-          <Link
-            href={picoHref(pathname, nextItem?.href ?? '/support')}
-            aria-label={nextItem ? `Go to next chapter: ${nextItem.label}` : 'Go to support'}
-            className="inline-flex min-h-9 items-center justify-center rounded-[11px] border border-[color:var(--pico-border)] px-2 text-[10px] font-medium uppercase tracking-[0.1em] text-[color:var(--pico-text-secondary)]"
-          >
-            Next
-          </Link>
+          {nextItem ? (
+            <Link
+              href={picoHref(pathname, nextItem.href)}
+              aria-label={`Go to next chapter: ${nextItem.label}`}
+              className="inline-flex min-h-9 items-center justify-center rounded-[11px] border border-[color:var(--pico-border)] px-2 text-[10px] font-medium uppercase tracking-[0.1em] text-[color:var(--pico-text-secondary)]"
+            >
+              Next
+            </Link>
+          ) : (
+            <span
+              aria-disabled="true"
+              className="inline-flex min-h-9 items-center justify-center rounded-[11px] border border-[color:rgba(255,255,255,0.035)] px-2 text-[10px] font-medium uppercase tracking-[0.1em] text-[color:var(--pico-text-muted)]"
+            >
+              End
+            </span>
+          )}
 
           <Link
             href={picoHref(pathname, currentItem.href === '/support' ? '/academy' : '/support')}

--- a/components/pico/PicoSupportPageClient.tsx
+++ b/components/pico/PicoSupportPageClient.tsx
@@ -82,8 +82,9 @@ export function PicoSupportPageClient() {
   const pathname = usePathname()
   const session = usePicoSession()
   const setup = usePicoSetupState(session.status === 'authenticated')
-  const { actions, progress, derived } = usePicoProgress(session.status === 'authenticated')
+  const { ready: progressReady, actions, progress, derived } = usePicoProgress(session.status === 'authenticated')
   const toHref = usePicoHref()
+  const [interactiveReady, setInteractiveReady] = useState(false)
   const [formOpen, setFormOpen] = useState(false)
   const [interest, setInterest] = useState<string | undefined>()
   const [copied, setCopied] = useState(false)
@@ -119,6 +120,14 @@ export function PicoSupportPageClient() {
     `Return ${returnRouteLabel}`,
     `Packet ${packetState}`,
   ].join('\n')
+  const supportControlsReady = interactiveReady && progressReady && recoveryWorkspace.ready
+  const disabledControlClassName = !supportControlsReady
+    ? 'disabled:cursor-not-allowed disabled:opacity-60'
+    : undefined
+
+  useEffect(() => {
+    setInteractiveReady(true)
+  }, [])
 
   useEffect(() => {
     if (progress.platform.activeSurface !== 'support') {
@@ -182,11 +191,19 @@ export function PicoSupportPageClient() {
   const defaultSupportMessage = `${diagnosticPacket}\n\nProblem:\n`
 
   function openEscalation(defaultInterest: string) {
+    if (!supportControlsReady) {
+      return
+    }
+
     setInterest(defaultInterest)
     setFormOpen(true)
   }
 
   async function copyDiagnosticPacket() {
+    if (!supportControlsReady) {
+      return
+    }
+
     try {
       await navigator.clipboard.writeText(diagnosticPacket)
       setCopied(true)
@@ -329,21 +346,24 @@ export function PicoSupportPageClient() {
             <button
               type="button"
               onClick={() => openEscalation('fixing-existing')}
-              className={picoClasses.primaryButton}
+              disabled={!supportControlsReady}
+              className={cn(picoClasses.primaryButton, disabledControlClassName)}
             >
               Get 1-on-1 help
             </button>
             <button
               type="button"
               onClick={() => void copyDiagnosticPacket()}
-              className={picoClasses.secondaryButton}
+              disabled={!supportControlsReady}
+              className={cn(picoClasses.secondaryButton, disabledControlClassName)}
             >
               {copied ? 'Copied packet' : 'Copy packet'}
             </button>
             <button
               type="button"
               onClick={() => openEscalation('other')}
-              className={picoClasses.tertiaryButton}
+              disabled={!supportControlsReady}
+              className={cn(picoClasses.tertiaryButton, disabledControlClassName)}
             >
               Book guidance
             </button>
@@ -476,7 +496,11 @@ export function PicoSupportPageClient() {
                       <button
                         type="button"
                         onClick={() => openEscalation(option.id)}
-                        className={option.id === 'fixing-existing' ? picoClasses.primaryButton : picoClasses.secondaryButton}
+                        disabled={!supportControlsReady}
+                        className={cn(
+                          option.id === 'fixing-existing' ? picoClasses.primaryButton : picoClasses.secondaryButton,
+                          disabledControlClassName,
+                        )}
                       >
                         {option.id === 'fixing-existing' ? 'Start support request' : 'Book guidance'}
                       </button>
@@ -560,14 +584,16 @@ export function PicoSupportPageClient() {
                 <button
                   type="button"
                   onClick={() => void copyDiagnosticPacket()}
-                  className={picoClasses.secondaryButton}
+                  disabled={!supportControlsReady}
+                  className={cn(picoClasses.secondaryButton, disabledControlClassName)}
                 >
                   {copied ? 'Copied packet' : 'Copy packet'}
                 </button>
                 <button
                   type="button"
                   onClick={() => openEscalation('fixing-existing')}
-                  className={picoClasses.primaryButton}
+                  disabled={!supportControlsReady}
+                  className={cn(picoClasses.primaryButton, disabledControlClassName)}
                 >
                   Open form with packet
                 </button>

--- a/components/pico/PicoTutorPageClient.tsx
+++ b/components/pico/PicoTutorPageClient.tsx
@@ -143,6 +143,7 @@ export function PicoTutorPageClient() {
   const [error, setError] = useState<string | null>(null)
   const [reply, setReply] = useState<PicoTutorReply | null>(null)
   const [recentQuestions, setRecentQuestions] = useState<string[]>([])
+  const [formReady, setFormReady] = useState(false)
   const [openAIConnection, setOpenAIConnection] = useState<TutorOpenAIConnection | null>(null)
   const [openAIConnectionLoading, setOpenAIConnectionLoading] = useState(false)
   const [openAIConnectionSaving, setOpenAIConnectionSaving] = useState(false)
@@ -235,6 +236,7 @@ export function PicoTutorPageClient() {
 
   useEffect(() => {
     setRecentQuestions(readRecentQuestions())
+    setFormReady(true)
   }, [])
 
   useEffect(() => {
@@ -778,6 +780,7 @@ export function PicoTutorPageClient() {
               <textarea
                 value={question}
                 onChange={(event) => setQuestion(event.target.value)}
+                disabled={!formReady || loading}
                 placeholder="Describe the blocker, the exact step, and what you expected to happen."
                 className="mt-6 min-h-[240px] w-full rounded-[28px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-5 py-5 text-sm leading-7 text-[color:var(--pico-text-secondary)] outline-none placeholder:text-[color:var(--pico-text-muted)]"
               />
@@ -788,6 +791,7 @@ export function PicoTutorPageClient() {
                   <select
                     value={lessonSlug}
                     onChange={(event) => setLessonSlug(event.target.value)}
+                    disabled={!formReady || loading}
                     className="mt-3 w-full rounded-[22px] border border-[color:var(--pico-border)] bg-[color:var(--pico-bg-surface)] px-4 py-3 text-sm text-[color:var(--pico-text-secondary)] outline-none"
                   >
                     <option value="">No lesson selected</option>
@@ -798,7 +802,7 @@ export function PicoTutorPageClient() {
                     ))}
                   </select>
                 </label>
-                <button type="submit" disabled={loading} className={picoClasses.primaryButton}>
+                <button type="submit" disabled={!formReady || loading} className={picoClasses.primaryButton}>
                   {loading ? 'Finding the next step...' : 'Get next step'}
                 </button>
               </div>
@@ -810,6 +814,7 @@ export function PicoTutorPageClient() {
                       key={prompt}
                       type="button"
                       onClick={() => setQuestion(prompt)}
+                      disabled={!formReady || loading}
                       className={picoClasses.tertiaryButton}
                     >
                       {prompt}

--- a/components/pico/usePicoLessonWorkspace.ts
+++ b/components/pico/usePicoLessonWorkspace.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   createDefaultLessonWorkspace,
@@ -58,16 +58,17 @@ function hasMeaningfulWorkspaceState(workspace: PicoLessonWorkspaceState) {
   )
 }
 
+function getWorkspaceTimestamp(workspace: PicoLessonWorkspaceState) {
+  const timestamp = workspace.updatedAt ? Date.parse(workspace.updatedAt) : 0
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
 export function usePicoLessonWorkspace(
   lessonSlug: string,
   stepCount: number,
   options?: PicoLessonWorkspaceOptions,
 ) {
   const persistedWorkspace = options?.progress?.lessonWorkspaces[lessonSlug]
-  const [workspace, setWorkspace] = useState<PicoLessonWorkspaceState>(() =>
-    createDefaultLessonWorkspace(stepCount),
-  )
-
   const resolvedWorkspace = useMemo(() => {
     if (persistedWorkspace) {
       return normalizeLessonWorkspace(persistedWorkspace, stepCount)
@@ -75,10 +76,39 @@ export function usePicoLessonWorkspace(
 
     return readLessonWorkspace(lessonSlug, stepCount)
   }, [lessonSlug, persistedWorkspace, stepCount])
+  const [workspace, setWorkspace] = useState<PicoLessonWorkspaceState>(() =>
+    createDefaultLessonWorkspace(stepCount),
+  )
+  const [ready, setReady] = useState(false)
+  const workspaceRef = useRef<PicoLessonWorkspaceState>(createDefaultLessonWorkspace(stepCount))
+  const workspaceLessonRef = useRef(lessonSlug)
 
   useEffect(() => {
+    const lessonChanged = workspaceLessonRef.current !== lessonSlug
+    const currentTimestamp = getWorkspaceTimestamp(workspaceRef.current)
+    const resolvedTimestamp = getWorkspaceTimestamp(resolvedWorkspace)
+
+    if (!lessonChanged && currentTimestamp > resolvedTimestamp) {
+      setReady(true)
+      return
+    }
+
+    workspaceLessonRef.current = lessonSlug
+    workspaceRef.current = resolvedWorkspace
     setWorkspace(resolvedWorkspace)
-  }, [resolvedWorkspace])
+    setReady(true)
+  }, [lessonSlug, resolvedWorkspace])
+
+  const writePersistedWorkspace = useCallback(
+    (nextWorkspace: PicoLessonWorkspaceState) => {
+      const workspaceMap = readWorkspaceMap()
+      workspaceMap[lessonSlug] = nextWorkspace
+      writeWorkspaceMap(workspaceMap)
+
+      options?.persistRemote?.(lessonSlug, nextWorkspace)
+    },
+    [lessonSlug, options],
+  )
 
   useEffect(() => {
     if (!options?.persistRemote || persistedWorkspace) {
@@ -99,37 +129,32 @@ export function usePicoLessonWorkspace(
   const persist = useCallback(
     (nextWorkspace: PicoLessonWorkspaceState) => {
       const normalized = normalizeLessonWorkspace(nextWorkspace, stepCount)
+      workspaceLessonRef.current = lessonSlug
+      workspaceRef.current = normalized
       setWorkspace(normalized)
-
-      const workspaceMap = readWorkspaceMap()
-      workspaceMap[lessonSlug] = normalized
-      writeWorkspaceMap(workspaceMap)
-
-      options?.persistRemote?.(lessonSlug, normalized)
+      setReady(true)
+      writePersistedWorkspace(normalized)
     },
-    [lessonSlug, options, stepCount],
+    [lessonSlug, stepCount, writePersistedWorkspace],
   )
 
   const touch = useCallback(
     (updater: (current: PicoLessonWorkspaceState) => PicoLessonWorkspaceState) => {
-      setWorkspace((current) => {
-        const normalized = normalizeLessonWorkspace(
-          {
-            ...updater(current),
-            updatedAt: new Date().toISOString(),
-          },
-          stepCount,
-        )
+      const normalized = normalizeLessonWorkspace(
+        {
+          ...updater(workspaceRef.current),
+          updatedAt: new Date().toISOString(),
+        },
+        stepCount,
+      )
 
-        const workspaceMap = readWorkspaceMap()
-        workspaceMap[lessonSlug] = normalized
-        writeWorkspaceMap(workspaceMap)
-
-        options?.persistRemote?.(lessonSlug, normalized)
-        return normalized
-      })
+      workspaceLessonRef.current = lessonSlug
+      workspaceRef.current = normalized
+      setWorkspace(normalized)
+      setReady(true)
+      writePersistedWorkspace(normalized)
     },
-    [lessonSlug, options, stepCount],
+    [lessonSlug, stepCount, writePersistedWorkspace],
   )
 
   const completedStepCount = workspace.completedStepIndexes.length
@@ -137,6 +162,7 @@ export function usePicoLessonWorkspace(
     stepCount > 0 ? Math.round((completedStepCount / stepCount) * 100) : 0
 
   return {
+    ready: ready && workspaceLessonRef.current === lessonSlug,
     workspace,
     completedStepCount,
     progressPercent,

--- a/components/pico/usePicoLessonWorkspace.ts
+++ b/components/pico/usePicoLessonWorkspace.ts
@@ -112,12 +112,24 @@ export function usePicoLessonWorkspace(
 
   const touch = useCallback(
     (updater: (current: PicoLessonWorkspaceState) => PicoLessonWorkspaceState) => {
-      persist({
-        ...updater(workspace),
-        updatedAt: new Date().toISOString(),
+      setWorkspace((current) => {
+        const normalized = normalizeLessonWorkspace(
+          {
+            ...updater(current),
+            updatedAt: new Date().toISOString(),
+          },
+          stepCount,
+        )
+
+        const workspaceMap = readWorkspaceMap()
+        workspaceMap[lessonSlug] = normalized
+        writeWorkspaceMap(workspaceMap)
+
+        options?.persistRemote?.(lessonSlug, normalized)
+        return normalized
       })
     },
-    [persist, workspace],
+    [lessonSlug, options, stepCount],
   )
 
   const completedStepCount = workspace.completedStepIndexes.length

--- a/components/pico/usePicoProgress.ts
+++ b/components/pico/usePicoProgress.ts
@@ -89,8 +89,9 @@ export function usePicoProgress(remoteSyncEnabled = true) {
         }
 
         const payload = normalizePicoProgress(await response.json())
-        writeLocalProgress(payload)
-        setProgress(payload)
+        const merged = resolveHydratedPicoProgress(payload, readLocalProgress())
+        writeLocalProgress(merged)
+        setProgress(merged)
         setSyncState('synced')
       } catch {
         setSyncState('offline')

--- a/components/site/AuthSurface.tsx
+++ b/components/site/AuthSurface.tsx
@@ -130,7 +130,7 @@ export function AuthSurface({
 
               <div className="rounded-[32px] border border-[rgba(73,46,26,0.12)] bg-[linear-gradient(180deg,rgba(244,233,214,0.96),rgba(229,212,187,0.9))] p-5 text-[#392416] shadow-[0_24px_64px_rgba(10,8,10,0.18)] sm:p-6">
                 <p className="font-[family:var(--font-mono)] text-[11px] font-semibold uppercase tracking-[0.22em] text-[#8b633b]">
-                  {isRecovery ? "Recovery checklist" : isPicoPreview ? "Preview notes" : "Operator checklist"}
+                  {isRecovery ? "Recovery checklist" : isPicoPreview ? "Preview notes" : "Account checklist"}
                 </p>
                 <div className="mt-4 grid gap-3">
                   {highlights.map((item) => (

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,7 @@ const withNextIntl = withNextIntlPlugin('./i18n/request.ts')
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  allowedDevOrigins: ['127.0.0.1'],
   images: {
     unoptimized: false,
     formats: ['image/avif', 'image/webp'],

--- a/tests/website.spec.ts
+++ b/tests/website.spec.ts
@@ -945,6 +945,16 @@ test.describe('mutx.dev QA', () => {
     await expect(agentGallery).toHaveAttribute('data-interactive', 'false');
     await expect(agentGallery).toHaveAttribute('data-pause', 'false');
     await expect(agentGallery.getByRole('button')).toHaveCount(0);
+    const agentGalleryInteraction = await agentGallery.evaluate((node) => {
+      const primaryCard = node.querySelector('[data-agent-slider-card="primary"]');
+
+      return {
+        pointerEvents: getComputedStyle(node).pointerEvents,
+        cardTouchAction: primaryCard ? getComputedStyle(primaryCard).touchAction : null,
+      };
+    });
+    expect(agentGalleryInteraction.pointerEvents).toBe('auto');
+    expect(agentGalleryInteraction.cardTouchAction).toContain('pan-x');
     const agentGalleryBox = await agentGallery.boundingBox();
     expect(agentGalleryBox).not.toBeNull();
     await page.mouse.click(
@@ -1263,6 +1273,11 @@ test.describe('mutx.dev QA', () => {
   });
 
   test('pico lesson workspace persists execution context back into the academy', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => {
+      pageErrors.push(error.message);
+    });
+
     await stubPicoProductApis(page);
 
     await page.goto('/pico/academy/install-hermes-locally', { waitUntil: 'domcontentloaded' });
@@ -1283,6 +1298,9 @@ test.describe('mutx.dev QA', () => {
     await expect(page.getByTestId('pico-autopilot-academy-context')).toBeVisible();
     await expect(page.getByTestId('pico-autopilot-academy-context').getByText(/1\/3/i)).toBeVisible();
     await expect(page.getByTestId('pico-autopilot-academy-context').getByText(/^saved$/i)).toBeVisible();
+    expect(
+      pageErrors.filter((error) => /hydration failed|server rendered text didn't match/i.test(error))
+    ).toHaveLength(0);
   });
 
   test('pico product routes expose hosted provider auth when no session is attached', async ({ page }) => {

--- a/tests/website.spec.ts
+++ b/tests/website.spec.ts
@@ -941,6 +941,18 @@ test.describe('mutx.dev QA', () => {
     await expect(page.locator('main')).toContainText(/founding access|waitlist-first|request access/i);
     await expect(page.locator('main')).not.toContainText(/pre-register/i);
 
+    const agentGallery = page.getByRole('region', { name: /autonomous agent types/i });
+    await expect(agentGallery).toHaveAttribute('data-interactive', 'false');
+    await expect(agentGallery).toHaveAttribute('data-pause', 'false');
+    await expect(agentGallery.getByRole('button')).toHaveCount(0);
+    const agentGalleryBox = await agentGallery.boundingBox();
+    expect(agentGalleryBox).not.toBeNull();
+    await page.mouse.click(
+      agentGalleryBox!.x + agentGalleryBox!.width / 2,
+      agentGalleryBox!.y + agentGalleryBox!.height / 2,
+    );
+    await expect(page.getByRole('dialog', { name: /contact form/i })).toHaveCount(0);
+
     await page.getByRole('button', { name: /request access/i }).first().click();
     const dialog = page.getByRole('dialog', { name: /contact form/i });
     await expect(dialog).toBeVisible();

--- a/tests/website.spec.ts
+++ b/tests/website.spec.ts
@@ -919,6 +919,7 @@ test.describe('mutx.dev QA', () => {
 
     await page.goto('/pico', { waitUntil: 'domcontentloaded' });
 
+    await expect(page.getByRole('dialog', { name: /mutx demo intro/i })).toHaveCount(0);
     await expect(page.getByTestId('pico-landing')).toBeVisible();
     await expect(page.locator('main h1').first()).toBeVisible();
     await expect(page.locator('main')).toContainText(/PicoMUTX/i);
@@ -1103,10 +1104,16 @@ test.describe('mutx.dev QA', () => {
     await page.setViewportSize({ width: 390, height: 844 });
 
     await page.goto('/pico/onboarding', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('pico-mobile-product-masthead')).toBeVisible();
+    await expect(page.getByTestId('pico-mobile-product-nav')).toBeVisible();
     await expect(page.getByRole('heading', { name: /get to your first working agent fast/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /go to next chapter: lessons/i }).first()).toBeVisible();
 
     await page.getByRole('link', { name: /go to next chapter: lessons/i }).first().click();
+    await expect(page.getByTestId('pico-mobile-academy-nav')).toBeVisible();
+    await expect(
+      page.getByTestId('pico-mobile-academy-nav').getByRole('link', { name: /open pico support/i }),
+    ).toBeVisible();
     await expect(page.getByRole('heading', { name: /install hermes locally/i })).toBeVisible();
     await expect(page.getByTestId('pico-academy-mission-billboard')).toBeVisible();
     await expect(page.getByTestId('pico-academy-progress-strip')).toBeVisible();


### PR DESCRIPTION
## Summary
- Simplify logged-in dashboard/auth language and remove remaining loaded operator/mission-control wording from audited surfaces.
- Expose the Pico mobile product masthead and bottom chapter docks so product routes keep brand, navigation, and recovery actions visible on small screens.
- Make the Pico landing agent gallery ambient instead of clickable, so clicking/looking around the moving gallery no longer opens the contact dialog or interrupts the view.
- Keep the app-domain demo intro from rendering an invisible dialog on Pico/non-app hosts.
- Guard Pico shell/tutor controls until hydration and merge overlapping progress saves so route toggles, tutor submits, and lesson workspace state do not lose early user actions.
- Allow `127.0.0.1` as a Next dev origin so local Playwright/dev QA hydrates CTA interactions correctly.
- Add Playwright coverage for the Pico landing guard, mobile shell controls, and non-interactive gallery behavior.

## Validation
- `npm run qa:pico-i18n`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `PLAYWRIGHT_REUSE_EXISTING_SERVER=1 BASE_URL=http://127.0.0.1:3000 npx playwright test tests/website.spec.ts -g "pico root stays" --project=chromium`
- `PLAYWRIGHT_REUSE_EXISTING_SERVER=1 BASE_URL=http://127.0.0.1:3000 npx playwright test tests/website.spec.ts -g "pico academy shell toggles|pico tutor renders structured|pico lesson workspace persists" --project=chromium --workers=1`
- `PLAYWRIGHT_REUSE_EXISTING_SERVER=1 BASE_URL=http://127.0.0.1:3000 npx playwright test tests/website.spec.ts --project=chromium --workers=1`

## Notes
- Browser plugin navigation/DOM inspection was attempted first; screenshot capture timed out after hot reload, so final screenshot evidence came from repo Playwright at `/tmp/pico-gallery-fixed.png`.
- Existing untracked Pico screenshot artifacts in the worktree were left untouched.