### PR TITLE
Patch security audit findings

### DIFF
--- a/cli/faramesh_runtime.py
+++ b/cli/faramesh_runtime.py
@@ -5,15 +5,30 @@ import os
 import shutil
 import socket
 import subprocess
+import tempfile
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
 FAREMESH_PROVIDER_ID = "faramesh"
-FAREMESH_SOCKET_PATH = "/tmp/faramesh.sock"
 FAREMESH_DEFAULT_DAEMON_PORT = 7777
 FAREMESH_INSTALL_URL = "https://raw.githubusercontent.com/faramesh/faramesh-core/main/install.sh"
+
+
+def _default_faramesh_socket_path() -> str:
+    configured_path = os.environ.get("FAREMESH_SOCKET_PATH")
+    if configured_path:
+        return configured_path
+
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        return str(Path(runtime_dir).expanduser() / "faramesh.sock")
+
+    return str(Path.home() / ".mutx" / "run" / "faramesh.sock")
+
+
+FAREMESH_SOCKET_PATH = _default_faramesh_socket_path()
 
 
 @dataclass
@@ -217,28 +232,41 @@ def ensure_faramesh_installed(
         return False, None
 
     try:
-        install_script_path = Path("/tmp/faramesh_install.sh")
-        subprocess.run(
-            ["curl", "-fsSL", FAREMESH_INSTALL_URL, "-o", str(install_script_path)],
-            check=True,
-            timeout=30,
-        )
-        subprocess.run(
-            ["chmod", "+x", str(install_script_path)],
-            check=True,
-            timeout=5,
-        )
+        with tempfile.NamedTemporaryFile(
+            prefix="faramesh-install-",
+            suffix=".sh",
+            delete=False,
+        ) as install_script:
+            install_script_path = Path(install_script.name)
 
-        cmd = [str(install_script_path), "--install-dir", str(Path.home() / ".local" / "bin")]
-        if non_interactive:
-            cmd.append("--no-interactive")
+        try:
+            subprocess.run(
+                ["curl", "-fsSL", FAREMESH_INSTALL_URL, "-o", str(install_script_path)],
+                check=True,
+                timeout=30,
+            )
+            subprocess.run(
+                ["chmod", "+x", str(install_script_path)],
+                check=True,
+                timeout=5,
+            )
 
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
+            cmd = [
+                str(install_script_path),
+                "--install-dir",
+                str(Path.home() / ".local" / "bin"),
+            ]
+            if non_interactive:
+                cmd.append("--no-interactive")
+
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        finally:
+            install_script_path.unlink(missing_ok=True)
 
         if result.returncode == 0:
             bin_path = find_faramesh_bin()

--- a/cli/faramesh_runtime.py
+++ b/cli/faramesh_runtime.py
@@ -31,6 +31,12 @@ def _default_faramesh_socket_path() -> str:
 FAREMESH_SOCKET_PATH = _default_faramesh_socket_path()
 
 
+def _ensure_socket_parent(socket_path: str) -> None:
+    parent = Path(socket_path).expanduser().parent
+    if parent != Path("."):
+        parent.mkdir(parents=True, exist_ok=True)
+
+
 @dataclass
 class FarameshDaemonHealth:
     daemon_reachable: bool = False
@@ -406,6 +412,7 @@ def start_faramesh_daemon(
     cmd.extend(["--socket", socket_path])
 
     try:
+        _ensure_socket_parent(socket_path)
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,

--- a/cli/local_control_plane.py
+++ b/cli/local_control_plane.py
@@ -321,7 +321,7 @@ def _materialize_source_ref(source_ref: str, destination: Path) -> Path:
                 "GET",
                 source_ref,
                 timeout=30.0,
-                follow_redirects=False,
+                follow_redirects=True,
             ) as response:
                 response.raise_for_status()
                 with open(archive_path, "wb") as handle:

--- a/cli/local_control_plane.py
+++ b/cli/local_control_plane.py
@@ -8,7 +8,6 @@ import sys
 import tarfile
 import tempfile
 import time
-import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -317,8 +316,21 @@ def _materialize_source_ref(source_ref: str, destination: Path) -> Path:
 
     if source_ref.startswith(("http://", "https://")):
         archive_path = destination / "control-plane.tar.gz"
-        with urllib.request.urlopen(source_ref) as response, open(archive_path, "wb") as handle:
-            shutil.copyfileobj(response, handle)
+        try:
+            with httpx.stream(
+                "GET",
+                source_ref,
+                timeout=30.0,
+                follow_redirects=False,
+            ) as response:
+                response.raise_for_status()
+                with open(archive_path, "wb") as handle:
+                    for chunk in response.iter_bytes():
+                        handle.write(chunk)
+        except httpx.HTTPError as exc:
+            raise LocalControlPlaneError(
+                "MUTX could not download the local control plane source."
+            ) from exc
         _extract_archive(archive_path, destination)
         return destination
 
@@ -349,7 +361,27 @@ def _extract_archive(archive_path: Path, destination: Path) -> None:
                     "Archive contains unsafe paths."
                 )
 
-        archive.extractall(destination_root, members=members)
+        for member in members:
+            extraction_target = (destination_root / member.name).resolve()
+            if member.isdir():
+                extraction_target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                raise LocalControlPlaneError(
+                    "MUTX could not provision the local control plane source. "
+                    "Archive contains unsupported special file entries."
+                )
+
+            extraction_target.parent.mkdir(parents=True, exist_ok=True)
+            source = archive.extractfile(member)
+            if source is None:
+                raise LocalControlPlaneError(
+                    "MUTX could not provision the local control plane source. "
+                    "Archive contains unreadable file entries."
+                )
+            with source, open(extraction_target, "wb") as target:
+                shutil.copyfileobj(source, target)
+            extraction_target.chmod(member.mode & 0o777)
 
 
 def _resolve_checkout_root(path: Path) -> Path:

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -8,7 +8,7 @@ MUTX integrates [Faramesh](https://faramesh.dev) by [Faramesh Technologies](http
 
 ## Overview
 
-Faramesh runs as a daemon alongside MUTX, communicating via Unix socket at `/tmp/faramesh.sock`. When an agent attempts a tool call, Faramesh evaluates it against the active policy and returns PERMIT, DENY, or DEFER.
+Faramesh runs as a daemon alongside MUTX, communicating via Unix socket. The socket path is configured by `FAREMESH_SOCKET_PATH`; when it is unset, MUTX uses `$XDG_RUNTIME_DIR/faramesh.sock` or `~/.mutx/run/faramesh.sock`. When an agent attempts a tool call, Faramesh evaluates it against the active policy and returns PERMIT, DENY, or DEFER.
 
 ## CLI Commands
 
@@ -148,7 +148,7 @@ agent payment-bot {
 ┌─────────────────────────────────────────────────────────┐
 │                      MUTX CLI / TUI                      │
 └────────────────────────┬────────────────────────────────┘
-                         │ socket /tmp/faramesh.sock
+                         │ Unix socket
                          ▼
 ┌─────────────────────────────────────────────────────────┐
 │              Faramesh Governance Daemon                  │

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -1574,10 +1574,10 @@ When `faramesh run -- <command>` is used, it intercepts tool calls from these fr
 ### Unix Domain Socket Communication
 
 ```python
-FAREMESH_SOCKET_PATH = "/tmp/faramesh.sock"
+FAREMESH_SOCKET_PATH = _default_faramesh_socket_path()
 ```
 
-Faramesh communicates with supervised processes via Unix domain socket for low-latency governance checks.
+Faramesh communicates with supervised processes via Unix domain socket for low-latency governance checks. `_default_faramesh_socket_path()` honors `FAREMESH_SOCKET_PATH`, then `$XDG_RUNTIME_DIR/faramesh.sock`, then `~/.mutx/run/faramesh.sock`.
 
 ### SupervisionConfig
 
@@ -1751,10 +1751,10 @@ class AgentIdentity:
 @dataclass
 class SPIREConfig:
     server_address: str = "localhost:8081"
-    socket_path: str = "/tmp/spire-agent/public/api.sock"
+    socket_path: str = field(default_factory=_default_spire_socket_path)
     trust_bundle_path: Optional[str]
     agent_config_path: Optional[str]
-    workload_api_path: str = "/tmp/spire-agent/public/api.sock"
+    workload_api_path: str = field(default_factory=_default_spire_socket_path)
     spire_bin: Optional[str]
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
         "highlight.js": "^11.11.1",
         "lenis": "^1.1.9",
         "lucide-react": "^0.323.0",
-        "next": "16.2.3",
-        "next-intl": "^4.9.1",
+        "next": "16.2.7",
+        "next-intl": "^4.13.0",
         "pg": "^8.20.0",
         "postgres": "^3.4.8",
         "react": "^18.2.0",
@@ -47,7 +47,7 @@
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
-        "resend": "^6.9.3",
+        "resend": "^6.12.4",
         "satori": "^0.26.0",
         "sharp": "^0.34.5",
         "sonner": "^1.7.4",
@@ -76,7 +76,7 @@
         "jest": "^30.2.0",
         "openapi-typescript": "^7.13.0",
         "playwright": "^1.59.1",
-        "postcss": "^8.4.35",
+        "postcss": "^8.5.10",
         "remark-rehype": "^11.1.2",
         "sharp": "^0.34.5",
         "sonner": "^1.7.4",
@@ -681,29 +681,6 @@
         "node": ">=22.0.0"
       }
     },
-    "node_modules/@capacitor/cli/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@capacitor/cli/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@capacitor/cli/node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -1059,16 +1036,6 @@
         "node": ">=16.4"
       }
     },
-    "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@electron/universal/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -1122,7 +1089,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1182,29 +1148,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -1369,49 +1312,34 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
-    "node_modules/@formatjs/bigdecimal": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/bigdecimal/-/bigdecimal-0.2.0.tgz",
-      "integrity": "sha512-GeaxHZbUoYvHL9tC5eltHLs+1zU70aPw0s7LwqgktIzF5oMhNY4o4deEtusJMsq7WFJF3Ye2zQEzdG8beVk73w=="
-    },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.2.0.tgz",
-      "integrity": "sha512-dHnqHgBo6GXYGRsepaE1wmsC2etaivOWd5VaJstZd+HI2zR3DCUjbDVZRtoPGkkXZmyHvBwrdEUuqfvzhF/DtQ==",
-      "dependencies": {
-        "@formatjs/bigdecimal": "0.2.0",
-        "@formatjs/fast-memoize": "3.1.1",
-        "@formatjs/intl-localematcher": "0.8.2"
-      }
-    },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.1.tgz",
-      "integrity": "sha512-CbNbf+tlJn1baRnPkNePnBqTLxGliG6DDgNa/UtV66abwIjwsliPMOt0172tzxABYzSuxZBZfcp//qI8AvBWPg=="
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.5.tgz",
+      "integrity": "sha512-KLi3fan6WnCHmigd9pmEEN8Hid0v4wiFBW576M/d07KMWYecf1CvyMI3n34vCmHT4AoVqG2n702kiHbXjzZX2A==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.3.tgz",
-      "integrity": "sha512-HJWZ9S6JWey6iY5+YXE3Kd0ofWU1sC2KTTp56e1168g/xxWvVvr8k9G4fexIgwYV9wbtjY7kGYK5FjoWB3B2OQ==",
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.10.tgz",
+      "integrity": "sha512-XeJihYLy1lCe19xfK1KWKG/betBOK2rB0luL8lSkjfvJj0zP+LTJvkC+RKd0jsFI8mWxN71LrarHSrEXE8xxOQ==",
+      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.2.0",
-        "@formatjs/icu-skeleton-parser": "2.1.3"
+        "@formatjs/icu-skeleton-parser": "2.1.9"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.3.tgz",
-      "integrity": "sha512-9mFp8TJ166ZM2pcjKwsBWXrDnOJGT7vMEScVgLygUODPOsE8S6f/FHoacvrlHK1B4dYZk8vSCNruyPU64AfgJQ==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "3.2.0"
-      }
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.9.tgz",
+      "integrity": "sha512-rsxswgHMfU1zUgB2byc08fesf83wLGjFnzLCEtuf00mx2doiqc6pYrf67raI37XqdRcGUviQepk2UKGqpng74Q==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.2.tgz",
-      "integrity": "sha512-q05KMYGJLyqFNFtIb8NhWLF5X3aK/k0wYt7dnRFuy6aLQL+vUwQ1cg5cO4qawEiINybeCPXAWlprY2mSBjSXAQ==",
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.9.tgz",
+      "integrity": "sha512-GmB0F/gYh4Hdl4rLWjgDsgT+x4pB54fkJeRh8kAZ4XFzKeCK8dGs+SBJWXO42QZtOUni+IDWKNuCw6wiL4lTvw==",
+      "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "3.1.1"
+        "@formatjs/fast-memoize": "3.1.5"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1483,7 +1411,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1506,7 +1433,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1529,7 +1455,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1546,7 +1471,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1563,7 +1487,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1580,7 +1503,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1597,7 +1519,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1614,7 +1535,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1631,7 +1551,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1648,7 +1567,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1665,7 +1583,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1682,7 +1599,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1699,7 +1615,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1722,7 +1637,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1745,7 +1659,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1768,7 +1681,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1791,7 +1703,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1814,7 +1725,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1837,7 +1747,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1860,7 +1769,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1883,7 +1791,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1903,7 +1810,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1923,7 +1829,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1943,7 +1848,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2400,16 +2304,6 @@
         }
       }
     },
-    "node_modules/@jest/core/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@jest/core/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -2686,16 +2580,6 @@
         "node-notifier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@jest/reporters/node_modules/glob": {
@@ -2992,9 +2876,10 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
-      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA=="
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.7.tgz",
+      "integrity": "sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==",
+      "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "16.2.1",
@@ -3037,12 +2922,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
-      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.7.tgz",
+      "integrity": "sha512-vm1EDI/pVaBNNiychmxk3fft+OhQPVD9cIM/tReLZIQ3TfQ4kqI9DwKk00dzuS1ulC7icbrzCFrmRRlk9PfNdw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -3052,12 +2938,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
-      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.7.tgz",
+      "integrity": "sha512-O3IRSv1ZBL1zs0WrIgefTEcTKFVn+ryxBNe54erJ6KsD+2f/Mmt7g2jOYh8PSBdUwPtKQJuCsTMlZ7tIu2AcsQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -3067,12 +2954,16 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
-      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.7.tgz",
+      "integrity": "sha512-Re6PZtjBDd0aMU+VcZcC/PrIvj4WhrjDYtMhhCVQamWN4L90EVP0pcEOBQD25prSlw7OzNw5QpHLWMilRLsRNw==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3082,12 +2973,16 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
-      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.7.tgz",
+      "integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3097,12 +2992,16 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
-      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.7.tgz",
+      "integrity": "sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3112,12 +3011,16 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
-      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.7.tgz",
+      "integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3127,12 +3030,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
-      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.7.tgz",
+      "integrity": "sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -3142,12 +3046,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
-      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.7.tgz",
+      "integrity": "sha512-J4WlM72NMk076Qsg0jTdK3SNXatlSdnjW7L7oNGLst1tAGjHrJh/FYi+pw9wyIjEtGRKDNzD0zuiY16oWYWVaw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4507,16 +4412,6 @@
         "npm": ">=9.5.0"
       }
     },
-    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@redocly/openapi-core/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -4742,7 +4637,8 @@
     "node_modules/@schummar/icu-type-parser": {
       "version": "1.21.5",
       "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
-      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw=="
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
     },
     "node_modules/@shuding/opentype.js": {
       "version": "1.4.0-beta.0",
@@ -5581,29 +5477,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -5958,12 +5831,13 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/7zip-bin": {
@@ -6293,29 +6167,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/app-builder-lib/node_modules/ci-info": {
@@ -6864,11 +6715,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -6986,14 +6840,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -7180,16 +7036,6 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/cacache/node_modules/glob": {
@@ -7852,13 +7698,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -9365,29 +9204,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -9770,16 +9586,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -10745,15 +10551,16 @@
       }
     },
     "node_modules/icu-minify": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.9.1.tgz",
-      "integrity": "sha512-6NkfF9GHHFouqnz+wuiLjCWQiyxoEyJ5liUv4Jxxo/8wyhV7MY0L0iTEGDAVEa4aAD58WqTxFMa20S5nyMjwNw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.13.0.tgz",
+      "integrity": "sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/amannn"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@formatjs/icu-messageformat-parser": "^3.4.0"
       }
@@ -10894,19 +10701,19 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.0.tgz",
-      "integrity": "sha512-IhghAA8n4KSlXuWKzYsWyWb82JoYTzShfyvdSF85oJPnNOjvv4kAo7S7Jtkm3/vJ53C7dQNRO+Gpnj3iWgTjBQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.7.tgz",
+      "integrity": "sha512-+q6Ktg119nULZEpZ8YTuGOst9MyEzFtjD63FTGBlN1mLz0Z/MOUYDIvnpVKwq17eezIEh+cfJIebfJoCetpiNw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.2.0",
-        "@formatjs/fast-memoize": "3.1.1",
-        "@formatjs/icu-messageformat-parser": "3.5.3"
+        "@formatjs/fast-memoize": "3.1.5",
+        "@formatjs/icu-messageformat-parser": "3.5.10"
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11684,16 +11491,6 @@
         }
       }
     },
-    "node_modules/jest-cli/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/jest-cli/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -12128,16 +11925,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/jest-runtime/node_modules/glob": {
@@ -13883,9 +13670,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -13966,11 +13753,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
-      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.7.tgz",
+      "integrity": "sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.3",
+        "@next/env": "16.2.7",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -13984,14 +13772,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.3",
-        "@next/swc-darwin-x64": "16.2.3",
-        "@next/swc-linux-arm64-gnu": "16.2.3",
-        "@next/swc-linux-arm64-musl": "16.2.3",
-        "@next/swc-linux-x64-gnu": "16.2.3",
-        "@next/swc-linux-x64-musl": "16.2.3",
-        "@next/swc-win32-arm64-msvc": "16.2.3",
-        "@next/swc-win32-x64-msvc": "16.2.3",
+        "@next/swc-darwin-arm64": "16.2.7",
+        "@next/swc-darwin-x64": "16.2.7",
+        "@next/swc-linux-arm64-gnu": "16.2.7",
+        "@next/swc-linux-arm64-musl": "16.2.7",
+        "@next/swc-linux-x64-gnu": "16.2.7",
+        "@next/swc-linux-x64-musl": "16.2.7",
+        "@next/swc-win32-arm64-msvc": "16.2.7",
+        "@next/swc-win32-x64-msvc": "16.2.7",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -14018,24 +13806,25 @@
       }
     },
     "node_modules/next-intl": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.9.1.tgz",
-      "integrity": "sha512-N7ga0CjtYcdxNvaKNIi6eJ2mmatlHK5hp8rt0YO2Omoc1m0gean242/Ukdj6+gJNiReBVcYIjK0HZeNx7CV1ug==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.13.0.tgz",
+      "integrity": "sha512-OvNq2v5XLx4EkQOsAhVE9g+6zdb83XHusADCXXtIW4LILYnjEVaeINdr1lkVWKSjzwNUiMSlH5N4K0OQTRiv6A==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/amannn"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@formatjs/intl-localematcher": "^0.8.1",
         "@parcel/watcher": "^2.4.1",
         "@swc/core": "^1.15.2",
-        "icu-minify": "^4.9.1",
+        "icu-minify": "^4.13.0",
         "negotiator": "^1.0.0",
-        "next-intl-swc-plugin-extractor": "^4.9.1",
+        "next-intl-swc-plugin-extractor": "^4.13.0",
         "po-parser": "^2.1.1",
-        "use-intl": "^4.9.1"
+        "use-intl": "^4.13.0"
       },
       "peerDependencies": {
         "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -14048,9 +13837,10 @@
       }
     },
     "node_modules/next-intl-swc-plugin-extractor": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.9.1.tgz",
-      "integrity": "sha512-8whJJ6oxJz8JqkHarggmmuEDyXgC7nEnaPhZD91CJwEWW4xp0AST3Mw17YxvHyP2vAF3taWfFbs1maD+WWtz3w=="
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.13.0.tgz",
+      "integrity": "sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ==",
+      "license": "MIT"
     },
     "node_modules/next/node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -14058,34 +13848,6 @@
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "dependencies": {
         "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-abi": {
@@ -14947,7 +14709,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14999,16 +14760,15 @@
       }
     },
     "node_modules/postal-mime": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.3.tgz",
-      "integrity": "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
       "license": "MIT-0"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -15025,7 +14785,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -15878,13 +15638,13 @@
       }
     },
     "node_modules/resend": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.9.3.tgz",
-      "integrity": "sha512-GRXjH9XZBJA+daH7bBVDuTShr22iWCxXA8P7t495G4dM/RC+d+3gHBK/6bz9K6Vpcq11zRQKmD+B+jECwQlyGQ==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
+      "integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
       "license": "MIT",
       "dependencies": {
-        "postal-mime": "2.7.3",
-        "svix": "1.84.1"
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -17100,16 +16860,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svix": {
-      "version": "1.84.1",
-      "resolved": "https://registry.npmjs.org/svix/-/svix-1.84.1.tgz",
-      "integrity": "sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "standardwebhooks": "1.0.0",
-        "uuid": "^10.0.0"
-      }
-    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -17364,9 +17114,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17994,19 +17744,20 @@
       }
     },
     "node_modules/use-intl": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.9.1.tgz",
-      "integrity": "sha512-iGVV/xFYlhe3btafRlL8RPLD2Jsuet4yqn9DR6LWWbMhULsJnXgLonDkzDmsAIBIwFtk02oJuX/Ox2vwHKF+UQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.13.0.tgz",
+      "integrity": "sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/amannn"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@formatjs/fast-memoize": "^3.1.0",
         "@schummar/icu-type-parser": "1.21.5",
-        "icu-minify": "^4.9.1",
+        "icu-minify": "^4.13.0",
         "intl-messageformat": "^11.1.0"
       },
       "peerDependencies": {
@@ -18048,19 +17799,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
     "highlight.js": "^11.11.1",
     "lenis": "^1.1.9",
     "lucide-react": "^0.323.0",
-    "next": "16.2.3",
-    "next-intl": "^4.9.1",
+    "next": "16.2.7",
+    "next-intl": "^4.13.0",
     "pg": "^8.20.0",
     "postgres": "^3.4.8",
     "react": "^18.2.0",
@@ -131,7 +131,7 @@
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
-    "resend": "^6.9.3",
+    "resend": "^6.12.4",
     "satori": "^0.26.0",
     "sharp": "^0.34.5",
     "sonner": "^1.7.4",
@@ -160,7 +160,7 @@
     "jest": "^30.2.0",
     "openapi-typescript": "^7.13.0",
     "playwright": "^1.59.1",
-    "postcss": "^8.4.35",
+    "postcss": "^8.5.10",
     "remark-rehype": "^11.1.2",
     "sharp": "^0.34.5",
     "sonner": "^1.7.4",
@@ -172,7 +172,11 @@
     "zod": "^4.3.6"
   },
   "overrides": {
-    "@xmldom/xmldom": "^0.8.12",
-    "app-builder-bin": "5.0.0-alpha.13"
+    "@xmldom/xmldom": "^0.9.10",
+    "app-builder-bin": "5.0.0-alpha.13",
+    "brace-expansion": "^5.0.6",
+    "ip-address": "^10.2.0",
+    "postcss": "^8.5.10",
+    "tmp": "^0.2.7"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,18 +13,18 @@ greenlet==3.0.3
 alembic==1.13.1
 # Infrastructure
 python-digitalocean==1.17.0
-boto3==1.34.25
-botocore==1.34.25
+boto3>=1.43.20,<2
+botocore>=1.43.20,<2
 # Security
 python-jose[cryptography]==3.5.0
 passlib==1.7.4
-Authlib==1.6.9
-python-multipart==0.0.26
+Authlib==1.6.11
+python-multipart==0.0.27
 email-validator==2.1.0
 # Agent & AI
-openai>=1.68.2
-anthropic>=0.52.0,<1
-httpx==0.26.0
+openai==2.30.0
+anthropic==0.93.0
+httpx==0.28.1
 langchain>=0.3.26,<1.0.0
 langchain-openai>=0.3.0,<1.0.0
 langchain-anthropic>=0.3.0,<1.0.0
@@ -34,7 +34,7 @@ pgvector==0.2.3
 numpy==1.26.3
 # Configuration
 pyyaml==6.0.1
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 hvac==2.1.0
 prometheus-client==0.19.0
 # Utilities
@@ -47,7 +47,8 @@ aiosqlite==0.20.0
 langchain-core>=0.3.83,<0.4.0
 bcrypt>=4.0.0
 pillow>=11.1.0
-predict-rlm>=0.2.2,<1
+predict-rlm>=0.6.1,<1
+litellm==1.87.0
 # Updated Mon Mar 16 10:24:07 CET 2026
 
 

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("DATABASE_SSL_MODE", "DB_SSL_MODE"),
     )
-    api_host: str = "0.0.0.0"
+    api_host: str = "0.0.0.0"  # nosec B104 - server bind address; host validation is separate.
     api_port: int = Field(
         default=8000,
         validation_alias=AliasChoices("API_PORT", "PORT"),

--- a/src/api/services/assistant_control_plane.py
+++ b/src/api/services/assistant_control_plane.py
@@ -5,12 +5,12 @@ import logging
 import os
 import re
 import time
-import urllib.error
-import urllib.request
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+import httpx
 
 from src.api.models import Agent, AgentType
 from src.api.services.orchestra_research_catalog import (
@@ -846,22 +846,21 @@ def _request_gateway_json(paths: tuple[str, ...]) -> Any | None:
     if not base_url:
         return None
 
-    for path in paths:
-        request = urllib.request.Request(f"{base_url}{path}", headers=_gateway_headers())
-        try:
-            with urllib.request.urlopen(request, timeout=3) as response:
-                payload = response.read().decode("utf-8")
+    headers = _gateway_headers()
+    with httpx.Client(timeout=3.0, follow_redirects=False) as client:
+        for path in paths:
+            try:
+                response = client.get(f"{base_url}{path}", headers=headers)
+                if response.status_code == 404:
+                    continue
+                response.raise_for_status()
+                payload = response.text
                 if not payload:
                     return None
                 return json.loads(payload)
-        except urllib.error.HTTPError as exc:
-            if exc.code == 404:
-                continue
-            logger.debug("Gateway request failed for %s: %s", path, exc)
-            return None
-        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
-            logger.debug("Gateway request failed for %s: %s", path, exc)
-            return None
+            except (httpx.HTTPError, json.JSONDecodeError) as exc:
+                logger.debug("Gateway request failed for %s: %s", path, exc)
+                return None
     return None
 
 

--- a/src/api/services/audit_log.py
+++ b/src/api/services/audit_log.py
@@ -276,13 +276,19 @@ class AuditLog:
         if conditions:
             where_clause = "WHERE " + " AND ".join(conditions)
 
-        query_sql = f"""
-            SELECT event_id, agent_id, session_id, span_id, event_type, payload, timestamp, trace_id
-            FROM audit_events
-            {where_clause}
-            ORDER BY timestamp DESC
-            LIMIT ? OFFSET ?
-        """
+        query_parts = [
+            "SELECT event_id, agent_id, session_id, span_id, event_type, payload, timestamp, trace_id",
+            "FROM audit_events",
+        ]
+        if where_clause:
+            query_parts.append(where_clause)
+        query_parts.extend(
+            [
+                "ORDER BY timestamp DESC",
+                "LIMIT ? OFFSET ?",
+            ]
+        )
+        query_sql = "\n".join(query_parts)
         params.extend([filters.limit, filters.skip])
 
         async with self._lock:

--- a/src/api/services/faramesh_supervisor.py
+++ b/src/api/services/faramesh_supervisor.py
@@ -24,7 +24,20 @@ from src.api.config import get_settings
 
 logger = logging.getLogger(__name__)
 
-FAREMESH_SOCKET_PATH = "/tmp/faramesh.sock"
+
+def _default_faramesh_socket_path() -> str:
+    configured_path = os.environ.get("FAREMESH_SOCKET_PATH")
+    if configured_path:
+        return configured_path
+
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        return str(Path(runtime_dir).expanduser() / "faramesh.sock")
+
+    return str(Path.home() / ".mutx" / "run" / "faramesh.sock")
+
+
+FAREMESH_SOCKET_PATH = _default_faramesh_socket_path()
 
 
 class SupervisionState(str, Enum):

--- a/src/api/services/governance_webhook_service.py
+++ b/src/api/services/governance_webhook_service.py
@@ -10,6 +10,8 @@ Handles:
 import asyncio
 import json
 import logging
+import os
+from pathlib import Path
 import socket
 import threading
 from typing import Optional
@@ -24,7 +26,20 @@ from src.api.services.webhook_handler import (
 
 logger = logging.getLogger(__name__)
 
-FAREMESH_SOCKET_PATH = "/tmp/faramesh.sock"
+
+def _default_faramesh_socket_path() -> str:
+    configured_path = os.environ.get("FAREMESH_SOCKET_PATH")
+    if configured_path:
+        return configured_path
+
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        return str(Path(runtime_dir).expanduser() / "faramesh.sock")
+
+    return str(Path.home() / ".mutx" / "run" / "faramesh.sock")
+
+
+FAREMESH_SOCKET_PATH = _default_faramesh_socket_path()
 
 GOVERNANCE_EVENT_TYPES = {
     "governance.decision.permit",

--- a/src/api/services/social_auth.py
+++ b/src/api/services/social_auth.py
@@ -6,12 +6,16 @@ from typing import Any
 from urllib.parse import urlencode
 
 import httpx
-from jose import jwt
+from jose import JWTError, jwt
 from pydantic import BaseModel
 
 from src.api.config import get_settings
 
 settings = get_settings()
+
+APPLE_ID_TOKEN_ISSUER = "https://appleid.apple.com"
+APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
+APPLE_ID_TOKEN_ALGORITHMS = ["RS256"]
 
 
 class OAuthProvider(str, Enum):
@@ -409,13 +413,7 @@ async def _exchange_apple_code(
     if not isinstance(id_token_raw, str) or not id_token_raw:
         raise SocialAuthError("Apple did not return an id_token.")
 
-    # Decode the id_token without strict verification — Apple's id_token
-    # is a standard JWT signed by Apple's own keys.  We trust it because
-    # it arrived over the TLS-protected token exchange.
-    try:
-        claims = jwt.decode(id_token_raw, options={"verify_signature": False})
-    except Exception as exc:
-        raise SocialAuthError("Could not decode Apple id_token.") from exc
+    claims = await _decode_apple_id_token(client, id_token_raw, client_id)
 
     apple_user_id = claims.get("sub")
     if not isinstance(apple_user_id, str) or not apple_user_id:
@@ -444,6 +442,46 @@ async def _exchange_apple_code(
             "id_token_claims": claims,
         },
     )
+
+
+async def _decode_apple_id_token(
+    client: httpx.AsyncClient,
+    id_token_raw: str,
+    client_id: str,
+) -> dict[str, Any]:
+    try:
+        header = jwt.get_unverified_header(id_token_raw)
+    except JWTError as exc:
+        raise SocialAuthError("Could not read Apple id_token header.") from exc
+
+    kid = header.get("kid")
+    if not isinstance(kid, str) or not kid:
+        raise SocialAuthError("Apple id_token did not include a key identifier.")
+
+    jwks_response = await client.get(APPLE_JWKS_URL)
+    _raise_for_provider_error(jwks_response, "Apple key lookup failed")
+
+    jwks_payload = jwks_response.json()
+    keys = jwks_payload.get("keys") if isinstance(jwks_payload, dict) else None
+    if not isinstance(keys, list) or not keys:
+        raise SocialAuthError("Apple key lookup did not return signing keys.", status_code=502)
+
+    signing_key = next(
+        (key for key in keys if isinstance(key, dict) and key.get("kid") == kid), None
+    )
+    if signing_key is None:
+        raise SocialAuthError("Apple id_token signing key was not found.", status_code=401)
+
+    try:
+        return jwt.decode(
+            id_token_raw,
+            signing_key,
+            algorithms=APPLE_ID_TOKEN_ALGORITHMS,
+            audience=client_id,
+            issuer=APPLE_ID_TOKEN_ISSUER,
+        )
+    except JWTError as exc:
+        raise SocialAuthError("Apple id_token verification failed.", status_code=401) from exc
 
 
 def _pick_github_email(items: Any) -> dict[str, Any] | None:

--- a/src/api/services/spiffe_identity.py
+++ b/src/api/services/spiffe_identity.py
@@ -14,13 +14,31 @@ import asyncio
 import logging
 import os
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_socket_path(value: str) -> str:
+    return value.removeprefix("unix://")
+
+
+def _default_spire_socket_path() -> str:
+    configured_path = os.environ.get("SPIRE_AGENT_SOCKET_PATH") or os.environ.get(
+        "SPIFFE_ENDPOINT_SOCKET"
+    )
+    if configured_path:
+        return _normalize_socket_path(configured_path)
+
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        return str(Path(runtime_dir).expanduser() / "spire-agent" / "api.sock")
+
+    return str(Path.home() / ".mutx" / "run" / "spire-agent-api.sock")
 
 
 class IdentitySource(str, Enum):
@@ -44,10 +62,10 @@ class AgentIdentity:
 @dataclass
 class SPIREConfig:
     server_address: str = "localhost:8081"
-    socket_path: str = "/tmp/spire-agent/public/api.sock"
+    socket_path: str = field(default_factory=_default_spire_socket_path)
     trust_bundle_path: Optional[str] = None
     agent_config_path: Optional[str] = None
-    workload_api_path: str = "/tmp/spire-agent/public/api.sock"
+    workload_api_path: str = field(default_factory=_default_spire_socket_path)
     spire_bin: Optional[str] = None
 
 

--- a/src/runtime/gateways/faramesh.py
+++ b/src/runtime/gateways/faramesh.py
@@ -19,6 +19,8 @@ https://github.com/faramesh/faramesh-core/blob/main/LICENSE
 
 import json
 import logging
+import os
+from pathlib import Path
 import socket
 import time
 from dataclasses import dataclass, field
@@ -29,9 +31,23 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 
-FAREMESH_SOCKET_PATH = "/tmp/faramesh.sock"
 FAREMESH_DEFAULT_DAEMON_PORT = 7777
 FAREMESH_INSTALL_URL = "https://raw.githubusercontent.com/faramesh/faramesh-core/main/install.sh"
+
+
+def _default_faramesh_socket_path() -> str:
+    configured_path = os.environ.get("FAREMESH_SOCKET_PATH")
+    if configured_path:
+        return configured_path
+
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        return str(Path(runtime_dir).expanduser() / "faramesh.sock")
+
+    return str(Path.home() / ".mutx" / "run" / "faramesh.sock")
+
+
+FAREMESH_SOCKET_PATH = _default_faramesh_socket_path()
 
 
 class FarameshDecision(str, Enum):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,6 @@ pytest-asyncio>=0.23.0
 pytest-cov>=4.0.0
 
 # Explicitly pin overlap-prone runtime deps used heavily in tests.
-httpx==0.26.0
+httpx==0.28.1
 aiosqlite==0.20.0
 sqlalchemy==2.0.25

--- a/tests/api/test_social_auth.py
+++ b/tests/api/test_social_auth.py
@@ -1,0 +1,77 @@
+import httpx
+import pytest
+
+from src.api.services import social_auth
+
+
+class FakeAppleJwksClient:
+    def __init__(self, keys: list[dict[str, str]]):
+        self.keys = keys
+        self.requested_urls: list[str] = []
+
+    async def get(self, url: str) -> httpx.Response:
+        self.requested_urls.append(url)
+        return httpx.Response(200, json={"keys": self.keys}, request=httpx.Request("GET", url))
+
+
+@pytest.mark.asyncio
+async def test_decode_apple_id_token_verifies_against_matching_jwks_key(monkeypatch):
+    client = FakeAppleJwksClient(keys=[{"kid": "apple-key", "kty": "RSA"}])
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        social_auth.jwt,
+        "get_unverified_header",
+        lambda _token: {"kid": "apple-key", "alg": "RS256"},
+    )
+
+    def fake_decode(token, key, *, algorithms, audience, issuer):
+        captured.update(
+            {
+                "token": token,
+                "key": key,
+                "algorithms": algorithms,
+                "audience": audience,
+                "issuer": issuer,
+            }
+        )
+        return {
+            "sub": "apple-user-id",
+            "email": "apple@example.com",
+            "email_verified": "true",
+        }
+
+    monkeypatch.setattr(social_auth.jwt, "decode", fake_decode)
+
+    claims = await social_auth._decode_apple_id_token(
+        client,
+        "raw-id-token",
+        "mutx-apple-client-id",
+    )
+
+    assert client.requested_urls == [social_auth.APPLE_JWKS_URL]
+    assert claims["sub"] == "apple-user-id"
+    assert captured == {
+        "token": "raw-id-token",
+        "key": {"kid": "apple-key", "kty": "RSA"},
+        "algorithms": social_auth.APPLE_ID_TOKEN_ALGORITHMS,
+        "audience": "mutx-apple-client-id",
+        "issuer": social_auth.APPLE_ID_TOKEN_ISSUER,
+    }
+
+
+@pytest.mark.asyncio
+async def test_decode_apple_id_token_rejects_unknown_signing_key(monkeypatch):
+    client = FakeAppleJwksClient(keys=[{"kid": "other-key", "kty": "RSA"}])
+
+    monkeypatch.setattr(
+        social_auth.jwt,
+        "get_unverified_header",
+        lambda _token: {"kid": "apple-key", "alg": "RS256"},
+    )
+
+    with pytest.raises(social_auth.SocialAuthError) as exc_info:
+        await social_auth._decode_apple_id_token(client, "raw-id-token", "mutx-apple-client-id")
+
+    assert exc_info.value.status_code == 401
+    assert "signing key was not found" in exc_info.value.message

--- a/tests/test_faramesh_runtime.py
+++ b/tests/test_faramesh_runtime.py
@@ -11,6 +11,7 @@ from cli.faramesh_runtime import (
     get_pending_defers,
     get_recent_decisions,
     is_socket_reachable,
+    start_faramesh_daemon,
     _count_decisions_by_effect,
 )
 
@@ -209,6 +210,31 @@ class TestGetFarameshHealth:
 
         assert health.version == "faramesh v1.0.0"
         assert "not running" in health.doctor_summary.lower()
+
+
+class TestStartFarameshDaemon:
+    @patch("cli.faramesh_runtime.time.sleep")
+    @patch("cli.faramesh_runtime.subprocess.Popen")
+    @patch("cli.faramesh_runtime.find_faramesh_bin")
+    def test_creates_socket_parent_directory(self, mock_bin, mock_popen, mock_sleep, tmp_path):
+        socket_path = tmp_path / "run" / "faramesh.sock"
+        proc = MagicMock()
+        proc.poll.return_value = None
+        mock_bin.return_value = "/usr/local/bin/faramesh"
+        mock_popen.return_value = proc
+
+        result = start_faramesh_daemon(socket_path=str(socket_path))
+
+        assert result is proc
+        assert socket_path.parent.exists()
+        mock_popen.assert_called_once()
+        command = mock_popen.call_args.args[0]
+        assert command == [
+            "/usr/local/bin/faramesh",
+            "serve",
+            "--socket",
+            str(socket_path),
+        ]
 
 
 class TestCollectFarameshSnapshot:


### PR DESCRIPTION
## Summary
- patch JavaScript and Python dependency audit findings where compatible
- verify Apple OAuth id_tokens against Apple JWKS instead of decoding without signature verification
- harden local source archive extraction, gateway HTTP calls, audit query construction, and runtime socket defaults
- sanitize Faramesh/SPIRE docs to avoid world-writable `/tmp` socket defaults

## Validation
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `./.venv/bin/python -m pip_audit -r requirements.txt` (residual: LangChain 1.x migration advisories; diskcache no fixed release)
- `./.venv/bin/python -m bandit -r src/api cli sdk -x tests -f json -q` (0 medium/high findings)
- `./.venv/bin/python -m black --check ... && ./.venv/bin/python -m ruff check ...`
- `./.venv/bin/python -m pytest tests/api/test_social_auth.py tests/test_local_control_plane.py tests/api/test_auth.py -q` (53 passed)
- `./.venv/bin/python -m pytest tests/api/test_audit.py -q` (25 passed)
- `./.venv/bin/python -m compileall src/api cli sdk/mutx`
- `npm run typecheck`
- `npm run build`

## Residual Risk
- `langchain-openai` and `langchain-text-splitters` fixes require a LangChain 1.x migration; current code imports 0.3-era APIs, so this should be a separate compatibility migration.
- `diskcache` CVE-2025-69872 has no fixed release available from pip-audit.
